### PR TITLE
Update route handling to use splat syntax

### DIFF
--- a/lib/server/routes/proxy.js
+++ b/lib/server/routes/proxy.js
@@ -9,16 +9,16 @@ const registerProxyRoutes = ({
     req.url = "/";
     proxy.web(req, res);
   });
-  app.all("/openclaw/*", requireAuth, (req, res) => {
+  app.all("/openclaw/*splat", requireAuth, (req, res) => {
     req.url = req.url.replace(/^\/openclaw/, "");
     proxy.web(req, res);
   });
-  app.all("/assets/*", requireAuth, (req, res) => proxy.web(req, res));
+  app.all("/assets/*splat", requireAuth, (req, res) => proxy.web(req, res));
 
-  app.all("/hooks/*", webhookMiddleware);
-  app.all("/webhook/*", webhookMiddleware);
+  app.all("/hooks/*splat", webhookMiddleware);
+  app.all("/webhook/*splat", webhookMiddleware);
 
-  app.all("/api/*", (req, res) => {
+  app.all("/api/*splat", (req, res) => {
     if (SETUP_API_PREFIXES.some((p) => req.path.startsWith(p))) return;
     proxy.web(req, res);
   });


### PR DESCRIPTION
This changes proxy route patterns from `"/path/*"` to `"/path/*splat"` (and similarly for `/openclaw`, `/assets`, `/hooks`, `/webhook`, `/api`).

On newer routing stacks that use path-to-regexp (e.g., Express 5 / the standalone router package), a bare * wildcard is no longer a valid token and throws at route registration time:

> PathError: Missing parameter name ... /openclaw/*

Naming the wildcard (*splat) preserves the intended “match everything under this prefix” behavior while providing a parameter name for the matcher. This prevents the server from crash-looping on startup in deployments that resolve to the newer path-to-regexp parser (I hit this on Railway with Node 22).

No behavior change intended beyond restoring compatibility; handlers continue to rewrite req.url as before and do not rely on the captured splat.