### PR TITLE
fix: allow org-owned workspace repos during onboarding

### DIFF
--- a/lib/server/onboarding/github.js
+++ b/lib/server/onboarding/github.js
@@ -66,20 +66,7 @@ const verifyGithubRepoForOnboarding = async ({
         };
       }
     }
-    const authedUser = await userRes.json().catch(() => ({}));
-    const authedLogin = String(authedUser?.login || "").trim();
-    if (
-      !isExisting &&
-      repoOwner &&
-      authedLogin &&
-      repoOwner.toLowerCase() !== authedLogin.toLowerCase()
-    ) {
-      return {
-        ok: false,
-        status: 400,
-        error: `New workspace repo owner must match your token user "${authedLogin}"`,
-      };
-    }
+    await userRes.json().catch(() => ({}));
 
     const checkRes = await fetch(`https://api.github.com/repos/${repoUrl}`, {
       headers: ghHeaders,

--- a/tests/server/onboarding-github.test.js
+++ b/tests/server/onboarding-github.test.js
@@ -1,8 +1,15 @@
 const fs = require("fs");
 
-const { cloneRepoToTemp } = require("../../lib/server/onboarding/github");
+const {
+  cloneRepoToTemp,
+  verifyGithubRepoForOnboarding,
+} = require("../../lib/server/onboarding/github");
 
 describe("server/onboarding/github", () => {
+  beforeEach(() => {
+    global.fetch = vi.fn();
+  });
+
   it("clones without embedding the github token in the command line", async () => {
     const shellCmd = vi.fn(async (cmd, opts = {}) => {
       expect(cmd).toContain('git clone --depth=1 "https://github.com/my-org/source-repo.git"');
@@ -23,5 +30,32 @@ describe("server/onboarding/github", () => {
     expect(shellCmd).toHaveBeenCalledTimes(1);
     const [, opts] = shellCmd.mock.calls[0];
     expect(fs.existsSync(opts.env.GIT_ASKPASS)).toBe(false);
+  });
+
+  it("allows org-owned new repos when github token verification succeeds", async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "repo" },
+        json: async () => ({ login: "tokudu" }),
+      })
+      .mockResolvedValueOnce({
+        status: 404,
+        ok: false,
+        statusText: "Not Found",
+        json: async () => ({ message: "Not Found" }),
+      });
+
+    const result = await verifyGithubRepoForOnboarding({
+      repoUrl: "make-stories/new-workspace",
+      githubToken: "ghp_secret_token_value",
+      mode: "new",
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      repoExists: false,
+      repoIsEmpty: false,
+    });
   });
 });

--- a/tests/server/routes-onboarding.test.js
+++ b/tests/server/routes-onboarding.test.js
@@ -266,25 +266,34 @@ describe("server/routes/onboarding", () => {
     });
   });
 
-  it("rejects new workspace repos whose owner differs from the token user", async () => {
+  it("allows new workspace repos owned by organizations when github verification passes", async () => {
     const deps = createBaseDeps();
     const app = createApp(deps);
-    global.fetch.mockResolvedValueOnce({
-      ok: true,
-      headers: { get: () => "repo" },
-      json: async () => ({ login: "owner" }),
-    });
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "repo" },
+        json: async () => ({ login: "tokudu" }),
+      })
+      .mockResolvedValueOnce({
+        status: 404,
+        ok: false,
+        statusText: "Not Found",
+        json: async () => ({ message: "Not Found" }),
+      });
 
     const res = await request(app).post("/api/onboard/github/verify").send({
-      repo: "my-org/new-repo",
+      repo: "make-stories/new-repo",
       token: "ghp_test_123456789",
       mode: "new",
     });
 
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
     expect(res.body).toEqual({
-      ok: false,
-      error: 'New workspace repo owner must match your token user "owner"',
+      ok: true,
+      repoExists: false,
+      repoIsEmpty: false,
+      tempDir: null,
     });
   });
 


### PR DESCRIPTION
## Summary
- remove the onboarding check that rejects new workspace repos when the owner differs from the token user
- allow org-owned repos to proceed to the existing GitHub API permission checks instead
- add unit and route coverage for org-owned new repo verification

## Test Plan
- pnpm test tests/server/onboarding-github.test.js tests/server/routes-onboarding.test.js