### PR TITLE
fix: isolate onboarding auth from stale env vars

### DIFF
--- a/lib/server/onboarding/index.js
+++ b/lib/server/onboarding/index.js
@@ -43,6 +43,40 @@ const upsertEnvVar = (items, key, value) => {
   return items;
 };
 
+const removeEnvVar = (items, key) => {
+  const normalizedKey = String(key || "").trim();
+  if (!normalizedKey) return items;
+  const idx = items.findIndex((entry) => entry.key === normalizedKey);
+  if (idx !== -1) items.splice(idx, 1);
+  return items;
+};
+
+const applySubmittedEnvVars = (items, vars = []) => {
+  for (const entry of vars || []) {
+    const key = String(entry?.key || "").trim();
+    if (!key || key === "GITHUB_WORKSPACE_REPO") continue;
+    const value = String(entry?.value || "");
+    if (value) {
+      upsertEnvVar(items, key, value);
+    } else {
+      removeEnvVar(items, key);
+    }
+  }
+  return items;
+};
+
+const pruneConflictingProviderAuthVars = (items, { selectedProvider, varMap }) => {
+  if (selectedProvider !== "anthropic") return items;
+  const hasAnthropicToken = !!String(varMap.ANTHROPIC_TOKEN || "").trim();
+  const hasAnthropicApiKey = !!String(varMap.ANTHROPIC_API_KEY || "").trim();
+  if (hasAnthropicToken && !hasAnthropicApiKey) {
+    removeEnvVar(items, "ANTHROPIC_API_KEY");
+  } else if (hasAnthropicApiKey && !hasAnthropicToken) {
+    removeEnvVar(items, "ANTHROPIC_TOKEN");
+  }
+  return items;
+};
+
 const clearImportedChannelPairingState = (channelsRoot) => {
   if (!channelsRoot || typeof channelsRoot !== "object") return false;
   let changed = false;
@@ -363,12 +397,12 @@ const createOnboardingService = ({
     const existingEnvVars =
       typeof readEnvFile === "function" ? readEnvFile() : [];
     const varsToSave = [...existingEnvVars];
-    for (const entry of vars.filter(
-      (item) => item.value && item.key !== "GITHUB_WORKSPACE_REPO",
-    )) {
-      upsertEnvVar(varsToSave, entry.key, entry.value);
-    }
+    applySubmittedEnvVars(varsToSave, vars);
     upsertEnvVar(varsToSave, "GITHUB_WORKSPACE_REPO", repoUrl);
+    pruneConflictingProviderAuthVars(varsToSave, {
+      selectedProvider,
+      varMap,
+    });
     if (importMode && existingConfigPresent) {
       const systemVars =
         constants.kSystemVars instanceof Set

--- a/lib/server/onboarding/openclaw.js
+++ b/lib/server/onboarding/openclaw.js
@@ -20,6 +20,12 @@ const buildOnboardArgs = ({
   hasCodexOauth,
   workspaceDir,
 }) => {
+  const openclawGatewayToken =
+    varMap.OPENCLAW_GATEWAY_TOKEN || process.env.OPENCLAW_GATEWAY_TOKEN || "";
+  const anthropicToken = varMap.ANTHROPIC_TOKEN || "";
+  const anthropicApiKey = varMap.ANTHROPIC_API_KEY || "";
+  const openaiApiKey = varMap.OPENAI_API_KEY || "";
+  const geminiApiKey = varMap.GEMINI_API_KEY || "";
   const onboardArgs = [
     "--non-interactive",
     "--accept-risk",
@@ -32,7 +38,7 @@ const buildOnboardArgs = ({
     "--gateway-auth",
     "token",
     "--gateway-token",
-    varMap.OPENCLAW_GATEWAY_TOKEN || process.env.OPENCLAW_GATEWAY_TOKEN || "",
+    openclawGatewayToken,
     "--no-install-daemon",
     "--skip-health",
     "--workspace",
@@ -41,19 +47,19 @@ const buildOnboardArgs = ({
 
   if (
     selectedProvider === "openai-codex" &&
-    (varMap.OPENAI_API_KEY || process.env.OPENAI_API_KEY)
+    openaiApiKey
   ) {
     onboardArgs.push(
       "--auth-choice",
       "openai-api-key",
       "--openai-api-key",
-      varMap.OPENAI_API_KEY || process.env.OPENAI_API_KEY,
+      openaiApiKey,
     );
   } else if (selectedProvider === "openai-codex" && hasCodexOauth) {
     onboardArgs.push("--auth-choice", "skip");
   } else if (
     (selectedProvider === "anthropic" || !selectedProvider) &&
-    (varMap.ANTHROPIC_TOKEN || process.env.ANTHROPIC_TOKEN)
+    anthropicToken
   ) {
     onboardArgs.push(
       "--auth-choice",
@@ -61,67 +67,67 @@ const buildOnboardArgs = ({
       "--token-provider",
       "anthropic",
       "--token",
-      varMap.ANTHROPIC_TOKEN || process.env.ANTHROPIC_TOKEN,
+      anthropicToken,
     );
   } else if (
     (selectedProvider === "anthropic" || !selectedProvider) &&
-    (varMap.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY)
+    anthropicApiKey
   ) {
     onboardArgs.push(
       "--auth-choice",
       "apiKey",
       "--anthropic-api-key",
-      varMap.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY,
+      anthropicApiKey,
     );
   } else if (
     (selectedProvider === "openai" || !selectedProvider) &&
-    (varMap.OPENAI_API_KEY || process.env.OPENAI_API_KEY)
+    openaiApiKey
   ) {
     onboardArgs.push(
       "--auth-choice",
       "openai-api-key",
       "--openai-api-key",
-      varMap.OPENAI_API_KEY || process.env.OPENAI_API_KEY,
+      openaiApiKey,
     );
   } else if (
     (selectedProvider === "google" || !selectedProvider) &&
-    (varMap.GEMINI_API_KEY || process.env.GEMINI_API_KEY)
+    geminiApiKey
   ) {
     onboardArgs.push(
       "--auth-choice",
       "gemini-api-key",
       "--gemini-api-key",
-      varMap.GEMINI_API_KEY || process.env.GEMINI_API_KEY,
+      geminiApiKey,
     );
-  } else if (varMap.ANTHROPIC_TOKEN || process.env.ANTHROPIC_TOKEN) {
+  } else if (anthropicToken) {
     onboardArgs.push(
       "--auth-choice",
       "token",
       "--token-provider",
       "anthropic",
       "--token",
-      varMap.ANTHROPIC_TOKEN || process.env.ANTHROPIC_TOKEN,
+      anthropicToken,
     );
-  } else if (varMap.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY) {
+  } else if (anthropicApiKey) {
     onboardArgs.push(
       "--auth-choice",
       "apiKey",
       "--anthropic-api-key",
-      varMap.ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY,
+      anthropicApiKey,
     );
-  } else if (varMap.OPENAI_API_KEY || process.env.OPENAI_API_KEY) {
+  } else if (openaiApiKey) {
     onboardArgs.push(
       "--auth-choice",
       "openai-api-key",
       "--openai-api-key",
-      varMap.OPENAI_API_KEY || process.env.OPENAI_API_KEY,
+      openaiApiKey,
     );
-  } else if (varMap.GEMINI_API_KEY || process.env.GEMINI_API_KEY) {
+  } else if (geminiApiKey) {
     onboardArgs.push(
       "--auth-choice",
       "gemini-api-key",
       "--gemini-api-key",
-      varMap.GEMINI_API_KEY || process.env.GEMINI_API_KEY,
+      geminiApiKey,
     );
   } else if (hasCodexOauth) {
     onboardArgs.push("--auth-choice", "skip");

--- a/lib/server/onboarding/validation.js
+++ b/lib/server/onboarding/validation.js
@@ -1,3 +1,29 @@
+const kAnthropicSetupTokenPrefix = "sk-ant-oat01-";
+const kAnthropicApiKeyPrefix = "sk-ant-api";
+
+const validateAnthropicCredentialShape = (varMap) => {
+  const anthropicToken = String(varMap.ANTHROPIC_TOKEN || "").trim();
+  const anthropicApiKey = String(varMap.ANTHROPIC_API_KEY || "").trim();
+  if (
+    anthropicToken &&
+    !anthropicToken.startsWith(kAnthropicSetupTokenPrefix)
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      error: `ANTHROPIC_TOKEN must start with ${kAnthropicSetupTokenPrefix}`,
+    };
+  }
+  if (anthropicApiKey && !anthropicApiKey.startsWith(kAnthropicApiKeyPrefix)) {
+    return {
+      ok: false,
+      status: 400,
+      error: `ANTHROPIC_API_KEY must start with ${kAnthropicApiKeyPrefix}`,
+    };
+  }
+  return { ok: true };
+};
+
 const validateOnboardingInput = ({ vars, modelKey, resolveModelProvider, hasCodexOauthProfile }) => {
   const kMaxOnboardingVars = 64;
   const kMaxEnvKeyLength = 128;
@@ -39,6 +65,8 @@ const validateOnboardingInput = ({ vars, modelKey, resolveModelProvider, hasCode
   }
 
   const varMap = Object.fromEntries(vars.map((v) => [v.key, v.value]));
+  const anthropicValidation = validateAnthropicCredentialShape(varMap);
+  if (!anthropicValidation.ok) return anthropicValidation;
   const githubToken = String(varMap.GITHUB_TOKEN || "");
   const githubRepoInput = String(varMap.GITHUB_WORKSPACE_REPO || "").trim();
   const selectedProvider = resolveModelProvider(modelKey);

--- a/tests/server/onboarding-openclaw.test.js
+++ b/tests/server/onboarding-openclaw.test.js
@@ -3,6 +3,7 @@ const os = require("os");
 const path = require("path");
 
 const {
+  buildOnboardArgs,
   writeManagedImportOpenclawConfig,
   writeSanitizedOpenclawConfig,
 } = require("../../lib/server/onboarding/openclaw");
@@ -11,6 +12,27 @@ const createTempOpenclawDir = () =>
   fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-onboarding-openclaw-test-"));
 
 describe("server/onboarding/openclaw", () => {
+  it("builds onboarding args from submitted vars instead of stale process env auth", () => {
+    process.env.ANTHROPIC_TOKEN = "sk-ant-oat01-stale-token";
+
+    const args = buildOnboardArgs({
+      varMap: {
+        ANTHROPIC_API_KEY: "sk-ant-api-fresh-key",
+        OPENCLAW_GATEWAY_TOKEN: "gw-token",
+      },
+      selectedProvider: "anthropic",
+      hasCodexOauth: false,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(args).toContain("--anthropic-api-key");
+    expect(args).toContain("sk-ant-api-fresh-key");
+    expect(args).not.toContain("--token");
+    expect(args).not.toContain("sk-ant-oat01-stale-token");
+
+    delete process.env.ANTHROPIC_TOKEN;
+  });
+
   it("only scrubs exact secret string values in JSON", () => {
     const openclawDir = createTempOpenclawDir();
     const configPath = path.join(openclawDir, "openclaw.json");

--- a/tests/server/routes-onboarding.test.js
+++ b/tests/server/routes-onboarding.test.js
@@ -196,6 +196,28 @@ describe("server/routes/onboarding", () => {
     });
   });
 
+  it("rejects anthropic setup tokens with the wrong prefix", async () => {
+    const deps = createBaseDeps();
+    const app = createApp(deps);
+
+    const res = await request(app).post("/api/onboard").send({
+      modelKey: "anthropic/claude-opus-4-6",
+      vars: [
+        { key: "ANTHROPIC_TOKEN", value: "sk-ant-api03-not-a-setup-token" },
+        { key: "GITHUB_TOKEN", value: "ghp_test_123456789" },
+        { key: "GITHUB_WORKSPACE_REPO", value: "owner/repo" },
+        { key: "TELEGRAM_BOT_TOKEN", value: "telegram_123456789" },
+      ],
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: "ANTHROPIC_TOKEN must start with sk-ant-oat01-",
+    });
+    expect(deps.shellCmd).not.toHaveBeenCalled();
+  });
+
   it("returns github error when repository check fails", async () => {
     const deps = createBaseDeps();
     const app = createApp(deps);
@@ -401,7 +423,7 @@ describe("server/routes/onboarding", () => {
     const res = await request(app).post("/api/onboard").send({
       modelKey: "anthropic/claude-opus-4-6",
       vars: [
-        { key: "ANTHROPIC_API_KEY", value: "sk-ant-test-123456789" },
+        { key: "ANTHROPIC_API_KEY", value: "sk-ant-api03-123456789" },
         { key: "GITHUB_TOKEN", value: "ghp_test_123456789" },
         { key: "GITHUB_WORKSPACE_REPO", value: "owner/repo" },
         { key: "TELEGRAM_BOT_TOKEN", value: "telegram_123456789" },
@@ -411,9 +433,48 @@ describe("server/routes/onboarding", () => {
     expect(res.status).toBe(200);
     expect(deps.authProfiles.upsertApiKeyProfileForEnvVar).toHaveBeenCalledWith(
       "anthropic",
-      "sk-ant-test-123456789",
+      "sk-ant-api03-123456789",
     );
     expect(deps.authProfiles.syncConfigAuthReferencesForAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes stale anthropic token env state when onboarding with an api key", async () => {
+    const deps = createBaseDeps();
+    deps.readEnvFile.mockReturnValue([
+      { key: "ANTHROPIC_TOKEN", value: "sk-ant-oat01-stale-token" },
+      { key: "GITHUB_TOKEN", value: "ghp_old" },
+    ]);
+    deps.fs.readFileSync.mockImplementation((p) => {
+      if (p === "/tmp/openclaw/openclaw.json") return "{}";
+      if (p === path.join(kSetupDir, "core-prompts", "TOOLS.md")) return "Setup: {{SETUP_UI_URL}}";
+      if (p === path.join(kSetupDir, "hourly-git-sync.sh")) return "echo Auto-commit hourly sync";
+      return "{}";
+    });
+    const app = createApp(deps);
+    mockGithubVerifyAndCreate();
+
+    const res = await request(app).post("/api/onboard").send({
+      modelKey: "anthropic/claude-opus-4-6",
+      vars: [
+        { key: "ANTHROPIC_API_KEY", value: "sk-ant-api-fresh-123456789" },
+        { key: "GITHUB_TOKEN", value: "ghp_test_123456789" },
+        { key: "GITHUB_WORKSPACE_REPO", value: "owner/repo" },
+        { key: "TELEGRAM_BOT_TOKEN", value: "telegram_123456789" },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    expect(deps.writeEnvFile).toHaveBeenCalled();
+    const savedVars = deps.writeEnvFile.mock.calls.at(-1)[0];
+    expect(savedVars.some((entry) => entry.key === "ANTHROPIC_TOKEN")).toBe(false);
+
+    const onboardCall = deps.shellCmd.mock.calls.find(([cmd]) =>
+      cmd.startsWith("openclaw onboard "),
+    );
+    expect(onboardCall).toBeTruthy();
+    expect(onboardCall[0]).toContain("--anthropic-api-key");
+    expect(onboardCall[0]).not.toContain("--token-provider");
+    expect(onboardCall[0]).not.toContain("sk-ant-oat01-stale-token");
   });
 
   it("sanitizes onboarding command failures to avoid leaking secrets", async () => {


### PR DESCRIPTION
## Summary

This fixes a setup rerun bug where AlphaClaw could reuse stale provider credentials from `.env` during onboarding.

In particular, Anthropic onboarding could fail if an old `ANTHROPIC_TOKEN` or `ANTHROPIC_API_KEY` was already persisted, because the onboarding command builder fell back to `process.env` after `.env` was reloaded. That made reruns non-deterministic and could send the wrong auth mode to `openclaw onboard`.

## Changes

- make onboarding auth selection use the current submitted vars instead of falling back to stale `process.env` provider credentials
- allow submitted onboarding vars to remove existing `.env` entries instead of only appending/updating
- prune conflicting Anthropic auth vars during onboarding
  - submitting `ANTHROPIC_API_KEY` clears stale `ANTHROPIC_TOKEN`
  - submitting `ANTHROPIC_TOKEN` clears stale `ANTHROPIC_API_KEY`
- add validation for Anthropic credential shape
  - `ANTHROPIC_TOKEN` must start with `sk-ant-oat01-`
  - `ANTHROPIC_API_KEY` must start with `sk-ant-api`

## Regression covered

- stale `ANTHROPIC_TOKEN` in env no longer leaks into API-key onboarding runs
- invalid Anthropic setup-token prefixes are rejected before invoking `openclaw onboard`

## Tests

```bash
npx vitest run tests/server/onboarding-openclaw.test.js tests/server/routes-onboarding.test.js
```
