### PR TITLE
Fix Gmail transform overwrite and improve setup replay

### DIFF
--- a/lib/public/js/components/google/gmail-setup-wizard.js
+++ b/lib/public/js/components/google/gmail-setup-wizard.js
@@ -47,14 +47,14 @@ const copyText = async (value) => {
   }
 };
 
-const kStepTitles = [
+const kSetupStepTitles = [
   "Install + Authenticate gcloud",
   "Enable APIs",
   "Create Topic + IAM",
   "Create Push Subscription",
   "Build with your Agent",
 ];
-const kTotalSteps = kStepTitles.length;
+const kTutorialStepTitles = kSetupStepTitles.slice(0, 3);
 const kNoSessionSelectedValue = kNoDestinationSessionValue;
 
 const renderCommandBlock = (command = "", onCopy = () => {}) => html`
@@ -136,6 +136,8 @@ export const GmailSetupWizard = ({
     String(clientConfig?.projectId || "").trim() ||
     "<project-id>";
   const hasExistingWebhookSetup = Boolean(clientConfig?.webhookExists);
+  const stepTitles = hasExistingWebhookSetup ? kTutorialStepTitles : kSetupStepTitles;
+  const totalSteps = stepTitles.length;
   const client =
     String(account?.client || clientConfig?.client || "default").trim() ||
     "default";
@@ -172,7 +174,7 @@ export const GmailSetupWizard = ({
         destination: selectedDestination,
       });
       setWatchEnabled(true);
-      setStep((prev) => Math.min(prev + 1, kTotalSteps - 1));
+      setStep((prev) => Math.min(prev + 1, totalSteps - 1));
     } catch (err) {
       setLocalError(err.message || "Could not finish setup");
     }
@@ -196,7 +198,7 @@ export const GmailSetupWizard = ({
       }
       return;
     }
-    setStep((prev) => Math.min(prev + 1, kTotalSteps - 1));
+    setStep((prev) => Math.min(prev + 1, totalSteps - 1));
   };
 
   const handleSendToAgent = async () => {
@@ -240,7 +242,7 @@ export const GmailSetupWizard = ({
       </button>
       <div class="text-xs text-gray-500">Gmail Pub / Sub Setup</div>
       <div class="flex items-center gap-1">
-        ${kStepTitles.map(
+        ${stepTitles.map(
           (title, idx) => html`
             <div
               class=${`h-1 flex-1 rounded-full transition-colors ${idx <= step ? "bg-accent" : "bg-border"}`}
@@ -251,7 +253,7 @@ export const GmailSetupWizard = ({
         )}
       </div>
       <${PageHeader}
-        title=${`Step ${step + 1} of ${kTotalSteps}: ${kStepTitles[step]}`}
+        title=${`Step ${step + 1} of ${totalSteps}: ${stepTitles[step]}`}
         actions=${null}
       />
       ${localError ? html`<div class="text-xs text-red-400">${localError}</div>` : null}
@@ -341,7 +343,7 @@ export const GmailSetupWizard = ({
           : null
       }
       ${
-        !needsProjectId && step === 3
+        !hasExistingWebhookSetup && !needsProjectId && step === 3
           ? html`
               ${renderCommandBlock(commands?.createSubscription || "", () =>
                 handleCopy(commands?.createSubscription || ""),
@@ -376,7 +378,7 @@ export const GmailSetupWizard = ({
           : null
       }
       ${
-        step === 4
+        !hasExistingWebhookSetup && step === 4
           ? html`
               <div
                 class="rounded-lg border border-border bg-black/20 p-3 space-y-3"
@@ -469,7 +471,18 @@ export const GmailSetupWizard = ({
               />`
         }
         ${
-          step < kTotalSteps - 2
+          !hasExistingWebhookSetup && step === totalSteps - 2
+            ? html`<${ActionButton}
+                onClick=${handleFinish}
+                disabled=${false}
+                loading=${saving}
+                idleLabel="Enable watch"
+                loadingLabel="Enabling..."
+                tone="primary"
+                size="md"
+                className="w-full justify-center"
+              />`
+            : step < totalSteps - 1
             ? html`<${ActionButton}
                 onClick=${handleNext}
                 disabled=${saving || (needsProjectId && !canAdvance)}
@@ -478,27 +491,14 @@ export const GmailSetupWizard = ({
                 size="md"
                 className="w-full justify-center"
               />`
-            : step === kTotalSteps - 2
-              ? html`<${ActionButton}
-                  onClick=${hasExistingWebhookSetup ? handleNext : handleFinish}
-                  disabled=${false}
-                  loading=${saving}
-                  idleLabel=${hasExistingWebhookSetup ? "Next" : "Enable watch"}
-                  loadingLabel=${hasExistingWebhookSetup
-                    ? "Loading..."
-                    : "Enabling..."}
-                  tone="primary"
-                  size="md"
-                  className="w-full justify-center"
-                />`
-              : html`<${ActionButton}
-                  onClick=${onClose}
-                  disabled=${saving || sendingToAgent}
-                  idleLabel="Done"
-                  tone="secondary"
-                  size="md"
-                  className="w-full justify-center"
-                />`
+            : html`<${ActionButton}
+                onClick=${onClose}
+                disabled=${saving || sendingToAgent}
+                idleLabel="Done"
+                tone="secondary"
+                size="md"
+                className="w-full justify-center"
+              />`
         }
       </div>
     </${ModalShell}>

--- a/lib/public/js/components/google/index.js
+++ b/lib/public/js/components/google/index.js
@@ -373,7 +373,7 @@ export const Google = ({
     if (!account) return;
     const client = String(account.client || "default").trim() || "default";
     const clientConfig = clientConfigByClient.get(client);
-    if (!clientConfig?.configured) {
+    if (!clientConfig?.configured || !clientConfig?.webhookExists) {
       openGmailSetupWizard(accountId);
       return;
     }

--- a/lib/server/gmail-watch.js
+++ b/lib/server/gmail-watch.js
@@ -316,7 +316,6 @@ const createGmailWatchService = ({
         transform: { module: gmailTransformModulePath },
       },
       transformSource: buildGmailTransformSource(destination),
-      overwriteTransform: true,
     });
     const webhookAfter = fs.readFileSync(configPath, "utf8");
     if (webhookBefore !== webhookAfter) {

--- a/tests/server/gmail-watch.test.js
+++ b/tests/server/gmail-watch.test.js
@@ -186,4 +186,73 @@ describe("server/gmail-watch", () => {
       }),
     ]);
   });
+
+  it("preserves an existing custom Gmail transform while ensuring hook wiring", () => {
+    const statePath = "/tmp/gogcli/state.json";
+    const configDir = "/tmp/gogcli";
+    const openclawDir = "/tmp/.openclaw";
+    const configPath = `${openclawDir}/openclaw.json`;
+    const transformPath = `${openclawDir}/hooks/transforms/gmail/gmail-transform.mjs`;
+    const customTransformSource =
+      "export default async function transform(payload) {\n" +
+      "  return { message: payload?.custom || \"custom\" };\n" +
+      "}\n";
+    const fs = createMemoryFs({
+      [statePath]: JSON.stringify({
+        version: 2,
+        accounts: [],
+        gmailPush: {
+          token: "push-token",
+          topics: {},
+        },
+      }),
+      [configPath]: JSON.stringify({
+        agents: {
+          list: [{ id: "main", default: true }],
+        },
+        hooks: {
+          enabled: true,
+          token: "${WEBHOOK_TOKEN}",
+          presets: ["gmail"],
+          mappings: [
+            {
+              match: { path: "gmail" },
+              action: "agent",
+              name: "Gmail",
+              wakeMode: "now",
+              transform: { module: "gmail/gmail-transform.mjs" },
+            },
+          ],
+        },
+      }),
+      [transformPath]: customTransformSource,
+    });
+    const service = createGmailWatchService({
+      fs,
+      constants: {
+        GOG_STATE_PATH: statePath,
+        GOG_CONFIG_DIR: configDir,
+        OPENCLAW_DIR: openclawDir,
+      },
+      gogCmd: async () => ({ ok: true, stdout: "", stderr: "" }),
+      getBaseUrl: () => "https://alphaclaw.example",
+      readGoogleCredentials: () => ({
+        projectId: "my-project",
+      }),
+      readEnvFile: () => [{ key: "WEBHOOK_TOKEN", value: "existing-token" }],
+      writeEnvFile: () => {},
+      reloadEnv: () => {},
+      restartRequiredState: null,
+    });
+
+    service.ensureHookWiring({
+      destination: {
+        channel: "telegram",
+        to: "-100123",
+        agentId: "main",
+      },
+    });
+
+    expect(fs.readFileSync(transformPath, "utf8")).toBe(customTransformSource);
+  });
 });


### PR DESCRIPTION
## Summary
- stop forcing Gmail transform rewrites during hook wiring so existing custom `hooks/transforms/gmail/gmail-transform.mjs` is preserved
- keep Gmail enable flow routed through the wizard when webhook wiring is missing so initial creation captures the selected destination
- make Gmail Configure reusable as a tutorial replay after setup by showing only the first three instructional steps once webhook setup already exists
- add a server regression test proving `ensureHookWiring` does not overwrite an existing custom Gmail transform

## Test plan
- [x] Run `npm test -- tests/server/gmail-watch.test.js`
- [ ] In UI, with existing Gmail webhook setup, click **Configure** and verify only tutorial steps are shown (no destination/enable watch/agent handoff)
- [ ] In UI, on an account with configured client but no Gmail webhook mapping, toggle Gmail watch and verify wizard opens before first watch start
- [ ] In a real OpenClaw workspace with a customized `hooks/transforms/gmail/gmail-transform.mjs`, renew/start watch and verify file contents are unchanged

Closes #13