### PR TITLE
fix: add skip option on onboarding pairing step

### DIFF
--- a/lib/public/js/components/onboarding/welcome-pairing-step.js
+++ b/lib/public/js/components/onboarding/welcome-pairing-step.js
@@ -80,6 +80,7 @@ export const WelcomePairingStep = ({
   onReject,
   canFinish,
   onContinue,
+  onSkip,
 }) => {
   const channelMeta = kChannelMeta[channel] || {
     label: channel ? channel.charAt(0).toUpperCase() + channel.slice(1) : "Channel",
@@ -168,6 +169,15 @@ export const WelcomePairingStep = ({
             ${error}
           </div>`
         : null}
+      <div class="pt-3 border-t border-border text-center">
+        <button
+          type="button"
+          onclick=${onSkip}
+          class="ac-tip-link text-xs font-medium"
+        >
+          Skip pairing for now
+        </button>
+      </div>
     </div>
   `;
 };

--- a/lib/public/js/components/welcome/index.js
+++ b/lib/public/js/components/welcome/index.js
@@ -73,6 +73,7 @@ export const Welcome = ({ onComplete, acVersion }) => {
                       onReject=${actions.handlePairingReject}
                       canFinish=${state.pairingComplete || state.canFinishPairing}
                       onContinue=${actions.finishOnboarding}
+                      onSkip=${actions.finishOnboarding}
                     />`
                   : html`
                       <${WelcomeFormStep}


### PR DESCRIPTION
## Summary
- add a low-emphasis `Skip pairing for now` action at the bottom of the onboarding pairing step
- allow users to continue to the dashboard even when pairing is deferred or blocked
- wire skip to the existing onboarding completion path to avoid getting stuck in setup

Fixes #3

## Test plan
- [x] Run `npx vitest run tests/frontend/api.test.js`
- [x] Verify pairing step still supports approve/reject flow
- [x] Verify skip action exits onboarding to dashboard