### PR TITLE
Fix onboarding validation for non-recommended models

### DIFF
--- a/lib/public/js/components/welcome/use-welcome.js
+++ b/lib/public/js/components/welcome/use-welcome.js
@@ -8,8 +8,10 @@ import {
 } from "../../lib/api.js";
 import {
   getModelProvider,
+  getAuthProviderFromModelProvider,
   getFeaturedModels,
   getVisibleAiFieldKeys,
+  kProviderAuthFields,
 } from "../../lib/model-config.js";
 import {
   kWelcomeGroups,
@@ -162,16 +164,14 @@ export const useWelcome = ({ onComplete }) => {
   const canToggleFullCatalog =
     featuredModels.length > 0 && models.length > featuredModels.length;
   const visibleAiFieldKeys = getVisibleAiFieldKeys(selectedProvider);
+  const selectedAuthProvider = getAuthProviderFromModelProvider(selectedProvider);
+  const selectedProviderAuthFields = kProviderAuthFields[selectedAuthProvider] || [];
   const hasAi =
-    selectedProvider === "anthropic"
-      ? !!(vals.ANTHROPIC_API_KEY || vals.ANTHROPIC_TOKEN)
-      : selectedProvider === "openai"
-        ? !!vals.OPENAI_API_KEY
-        : selectedProvider === "google"
-          ? !!vals.GEMINI_API_KEY
-          : selectedProvider === "openai-codex"
-            ? !!codexStatus.connected
-            : false;
+    selectedProvider === "openai-codex"
+      ? !!codexStatus.connected
+      : selectedProviderAuthFields.some(
+          (field) => !!String(vals[field.key] || "").trim(),
+        );
 
   const allValid = kWelcomeGroups.every((group) => group.validate(vals, { hasAi }));
   const isPreStep = step === -1;


### PR DESCRIPTION
## Summary
- fix onboarding AI-step validation to derive required credentials from provider metadata instead of a hardcoded provider list
- allow full-catalog (non-recommended) model selections to satisfy the required state when that provider key/token is entered
- keep `openai-codex` OAuth-based validation behavior unchanged

Closes #22

## Test plan
- [x] Select a non-recommended model from "Show full model catalog"
- [x] Enter that provider's credential field and verify the AI step clears `Required`
- [x] Confirm the `Next` button becomes interactable on step 2
- [ ] Run full UI regression pass