### PR TITLE
Add CSS variable theming for Tailwind colors

### DIFF
--- a/lib/public/css/theme.css
+++ b/lib/public/css/theme.css
@@ -1,4 +1,5 @@
 :root {
+  /* ── App theme tokens ──────────────────────────── */
   --bg: #0d121b;
   --bg-sidebar: #0f141f;
   --bg-content: #0f1521;
@@ -22,6 +23,73 @@
   --panel-border-contrast: rgba(255, 255, 255, 0.11);
   --field-bg-contrast: rgba(0, 0, 0, 0.3);
   --field-border-contrast: rgba(255, 255, 255, 0.13);
+
+  /* ── Tailwind color palette (remappable) ───────── */
+  /* Gray */
+  --tw-gray-100: #f3f4f6;
+  --tw-gray-200: #e5e7eb;
+  --tw-gray-300: #d1d5db;
+  --tw-gray-400: #9ca3af;
+  --tw-gray-500: #6b7280;
+  --tw-gray-600: #4b5563;
+
+  /* Red */
+  --tw-red-200: #fecaca;
+  --tw-red-300: #fca5a5;
+  --tw-red-400: #f87171;
+  --tw-red-500: #ef4444;
+  --tw-red-700: #b91c1c;
+  --tw-red-800: #991b1b;
+  --tw-red-900: #7f1d1d;
+  --tw-red-950: #450a0a;
+
+  /* Yellow */
+  --tw-yellow-100: #fef9c3;
+  --tw-yellow-200: #fef08a;
+  --tw-yellow-300: #fde047;
+  --tw-yellow-400: #facc15;
+  --tw-yellow-500: #eab308;
+  --tw-yellow-700: #a16207;
+  --tw-yellow-800: #854d0e;
+  --tw-yellow-900: #713f12;
+  --tw-yellow-950: #422006;
+
+  /* Green */
+  --tw-green-200: #bbf7d0;
+  --tw-green-300: #86efac;
+  --tw-green-400: #4ade80;
+  --tw-green-500: #22c55e;
+  --tw-green-700: #15803d;
+  --tw-green-900: #14532d;
+  --tw-green-950: #052e16;
+
+  /* Cyan */
+  --tw-cyan-100: #cffafe;
+  --tw-cyan-200: #a5f3fc;
+  --tw-cyan-300: #67e8f9;
+  --tw-cyan-400: #22d3ee;
+  --tw-cyan-500: #06b6d4;
+  --tw-cyan-700: #0e7490;
+  --tw-cyan-800: #155e75;
+  --tw-cyan-900: #164e63;
+  --tw-cyan-950: #083344;
+
+  /* Blue */
+  --tw-blue-300: #93c5fd;
+  --tw-blue-400: #60a5fa;
+  --tw-blue-500: #3b82f6;
+
+  /* Purple */
+  --tw-purple-300: #d8b4fe;
+  --tw-purple-400: #c084fc;
+  --tw-purple-500: #a855f7;
+
+  /* Indigo */
+  --tw-indigo-300: #a5b4fc;
+  --tw-indigo-500: #6366f1;
+
+  /* Amber */
+  --tw-amber-300: #fcd34d;
 }
 
 html, body { height: 100%; }

--- a/lib/public/js/tailwind-config.js
+++ b/lib/public/js/tailwind-config.js
@@ -1,0 +1,81 @@
+// Shared Tailwind config — remaps color palette to CSS variables
+// so themes can override colors without touching component files.
+tailwind.config = {
+  theme: {
+    extend: {
+      colors: {
+        surface: "var(--bg-sidebar)",
+        border: "var(--border)",
+        gray: {
+          100: "var(--tw-gray-100)",
+          200: "var(--tw-gray-200)",
+          300: "var(--tw-gray-300)",
+          400: "var(--tw-gray-400)",
+          500: "var(--tw-gray-500)",
+          600: "var(--tw-gray-600)",
+        },
+        red: {
+          200: "var(--tw-red-200)",
+          300: "var(--tw-red-300)",
+          400: "var(--tw-red-400)",
+          500: "var(--tw-red-500)",
+          700: "var(--tw-red-700)",
+          800: "var(--tw-red-800)",
+          900: "var(--tw-red-900)",
+          950: "var(--tw-red-950)",
+        },
+        yellow: {
+          100: "var(--tw-yellow-100)",
+          200: "var(--tw-yellow-200)",
+          300: "var(--tw-yellow-300)",
+          400: "var(--tw-yellow-400)",
+          500: "var(--tw-yellow-500)",
+          700: "var(--tw-yellow-700)",
+          800: "var(--tw-yellow-800)",
+          900: "var(--tw-yellow-900)",
+          950: "var(--tw-yellow-950)",
+        },
+        green: {
+          200: "var(--tw-green-200)",
+          300: "var(--tw-green-300)",
+          400: "var(--tw-green-400)",
+          500: "var(--tw-green-500)",
+          700: "var(--tw-green-700)",
+          900: "var(--tw-green-900)",
+          950: "var(--tw-green-950)",
+        },
+        cyan: {
+          100: "var(--tw-cyan-100)",
+          200: "var(--tw-cyan-200)",
+          300: "var(--tw-cyan-300)",
+          400: "var(--tw-cyan-400)",
+          500: "var(--tw-cyan-500)",
+          700: "var(--tw-cyan-700)",
+          800: "var(--tw-cyan-800)",
+          900: "var(--tw-cyan-900)",
+          950: "var(--tw-cyan-950)",
+        },
+        blue: {
+          300: "var(--tw-blue-300)",
+          400: "var(--tw-blue-400)",
+          500: "var(--tw-blue-500)",
+        },
+        purple: {
+          300: "var(--tw-purple-300)",
+          400: "var(--tw-purple-400)",
+          500: "var(--tw-purple-500)",
+        },
+        indigo: {
+          300: "var(--tw-indigo-300)",
+          500: "var(--tw-indigo-500)",
+        },
+        amber: {
+          300: "var(--tw-amber-300)",
+        },
+      },
+      fontFamily: {
+        mono: ["'JetBrains Mono'", "monospace"],
+      },
+    },
+  },
+};

--- a/lib/public/login.html
+++ b/lib/public/login.html
@@ -11,21 +11,7 @@
     <link rel="icon" type="image/svg+xml" href="./img/logo.svg" />
     <link rel="stylesheet" href="./css/theme.css" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            colors: {
-              surface: "var(--bg-sidebar)",
-              border: "var(--border)",
-            },
-            fontFamily: {
-              mono: ["'JetBrains Mono'", "monospace"],
-            },
-          },
-        },
-      };
-    </script>
+    <script src="./js/tailwind-config.js"></script>
   </head>
   <body class="min-h-screen flex items-center justify-center p-4">
     <div class="max-w-sm w-full relative z-10">

--- a/lib/public/setup.html
+++ b/lib/public/setup.html
@@ -16,21 +16,7 @@
     <link rel="stylesheet" href="./css/cron.css" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            colors: {
-              surface: "var(--bg-sidebar)",
-              border: "var(--border)",
-            },
-            fontFamily: {
-              mono: ["'JetBrains Mono'", "monospace"],
-            },
-          },
-        },
-      };
-    </script>
+    <script src="./js/tailwind-config.js"></script>
   </head>
   <body>
     <div id="app"></div>


### PR DESCRIPTION
## What this does

Remaps Tailwind's color palette to CSS custom properties, so the entire UI can be themed by overriding a single set of variables and without touching any component files.

Currently, colours like `text-gray-300` resolve to hardcoded hex values baked into Tailwind's defaults. With this change, they resolve through CSS variables (`var(--tw-gray-300)`) whose default values are identical to Tailwind's originals. This makes theming possible. 

## What changed

- **`lib/public/css/theme.css`** — added `--tw-{color}-{shade}` variable definitions for every Tailwind color actually used in the codebase (48 variables). Defaults match Tailwind's originals exactly.
- **`lib/public/js/tailwind-config.js`** — new shared file that configures Tailwind to resolve colors through the CSS variables. Also deduplicates the config that was previously inlined in both HTML files.
- **`lib/public/login.html`** and **`lib/public/setup.html`** — replaced inline Tailwind config blocks with a `<script src>` reference to the shared config.

## What didn't change

- No component files touched
- No branding, logos, fonts, or naming changes
- No new dependencies
- Black/white opacity variants (`bg-black/30`, `bg-white/5`, etc.) are left as-is since they're structural transparency effects, not themeable colors

## Test plan

- [ ] All existing tests pass (confirmed locally — the single pre-existing failure in `doctor-helpers.test.js` is unrelated)
- [ ] UI looks identical before and after (default variable values match Tailwind defaults)
- [ ] Theming works: overriding a `--tw-*` variable in a downstream CSS file changes the corresponding Tailwind utility across the whole UI