### PR TITLE
Prevent AlphaClaw from starting on port 18789

### DIFF
--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -131,13 +131,13 @@ const resolveGithubRepoPath = (value) =>
 // ---------------------------------------------------------------------------
 
 const rootDir =
-  flagValue(globalArgs, "--root-dir") ||
+  flagValue(args, "--root-dir") ||
   process.env.ALPHACLAW_ROOT_DIR ||
   path.join(os.homedir(), ".alphaclaw");
 
 process.env.ALPHACLAW_ROOT_DIR = rootDir;
 
-const portFlag = flagValue(globalArgs, "--port");
+const portFlag = flagValue(args, "--port");
 if (portFlag) {
   process.env.PORT = portFlag;
 }
@@ -464,6 +464,17 @@ if (
   commandAction === "add"
 ) {
   process.exit(runTelegramTopicAdd());
+}
+
+const kPort = String(process.env.PORT || "3000").trim();
+if (kPort === "18789") {
+  console.error(
+    [
+      "[alphaclaw] Fatal config error: AlphaClaw cannot be started on port 18789.",
+      "[alphaclaw] Port 18789 is reserved for the OpenClaw gateway.",
+    ].join("\n"),
+  );
+  process.exit(1);
 }
 
 const kSetupPassword = String(process.env.SETUP_PASSWORD || "").trim();

--- a/tests/bin/alphaclaw.test.js
+++ b/tests/bin/alphaclaw.test.js
@@ -1,0 +1,80 @@
+const { execSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+const os = require("os");
+
+describe("bin/alphaclaw port check", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-test-"));
+  });
+
+  afterEach(() => {
+    try {
+      if (fs.existsSync(tmpDir)) {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    } catch {}
+  });
+
+  const binPath = path.resolve(__dirname, "../../bin/alphaclaw.js");
+
+  it("exits with error if PORT env var is 18789", () => {
+    let output = "";
+    let status = 0;
+    try {
+      execSync(`ALPHACLAW_ROOT_DIR="${tmpDir}" node "${binPath}" start`, {
+        stdio: "pipe",
+        encoding: "utf8",
+        env: { ...process.env, PORT: "18789", ALPHACLAW_ROOT_DIR: tmpDir }
+      });
+    } catch (e) {
+      status = e.status;
+      output = e.stdout + e.stderr;
+    }
+
+    expect(status).toBe(1);
+    expect(output).toContain("AlphaClaw cannot be started on port 18789");
+    expect(output).toContain("reserved for the OpenClaw gateway");
+  });
+
+  it("exits with error if --port flag is 18789", () => {
+    let output = "";
+    let status = 0;
+    try {
+      execSync(`ALPHACLAW_ROOT_DIR="${tmpDir}" node "${binPath}" start --port 18789`, {
+        stdio: "pipe",
+        encoding: "utf8",
+        env: { ...process.env, PORT: "3000", ALPHACLAW_ROOT_DIR: tmpDir }
+      });
+    } catch (e) {
+      status = e.status;
+      output = e.stdout + e.stderr;
+    }
+
+    expect(status).toBe(1);
+    expect(output).toContain("AlphaClaw cannot be started on port 18789");
+    expect(output).toContain("reserved for the OpenClaw gateway");
+  });
+
+  it("does not exit if PORT is not 18789 (fails on SETUP_PASSWORD)", () => {
+    let output = "";
+    let status = 0;
+    try {
+      // We expect it to fail on SETUP_PASSWORD missing, which is AFTER the port check
+      execSync(`ALPHACLAW_ROOT_DIR="${tmpDir}" node "${binPath}" start`, {
+        stdio: "pipe",
+        encoding: "utf8",
+        env: { ...process.env, PORT: "3001", ALPHACLAW_ROOT_DIR: tmpDir, SETUP_PASSWORD: "" }
+      });
+    } catch (e) {
+      status = e.status;
+      output = e.stdout + e.stderr;
+    }
+
+    expect(status).toBe(1);
+    expect(output).not.toContain("AlphaClaw cannot be started on port 18789");
+    expect(output).toContain("SETUP_PASSWORD is missing or empty");
+  });
+});


### PR DESCRIPTION
This resolves #26, by preventing AlphaClaw from starting on port 18789. An alternative approach would be to change the port used for OpenClaw when AlphaClaw uses this port.

Changes Made:
1.  Updated bin/alphaclaw.js:
    *   Improved flag parsing to correctly recognise `--port` and `--root-dir` even when placed after the command (e.g., `alphaclaw start --port 18789`).
    *   Added a fatal error check that prevents AlphaClaw from starting if the resolved port is 18789 (the port reserved for the OpenClaw gateway).
2.  Added unit tests:
    *   Created tests/bin/alphaclaw.test.js to verify the port check behavior.
    *   Verified that `PORT=18789` environment variable triggers the error.
    *   Verified that `--port 18789` CLI flag triggers the error.
    *   Verified that other ports allow the process to continue (until the next check, such as `SETUP_PASSWORD`).