### PR TITLE
Add space before channel name in onboarding confirmation

### DIFF
--- a/lib/public/js/components/onboarding/welcome-pairing-step.js
+++ b/lib/public/js/components/onboarding/welcome-pairing-step.js
@@ -116,8 +116,8 @@ export const WelcomePairingStep = ({
               🎉 Setup complete
             </p>
             <p class="text-xs text-gray-300">
-              Your ${channelMeta.label} channel is connected. You can switch to
-              ${channelMeta.label} and start using your agent now.
+              Your ${channelMeta.label} channel is connected. You can switch
+              to ${channelMeta.label} and start using your agent now.
             </p>
             <p class="text-xs text-gray-500 font-normal opacity-85">
               Continue to the dashboard to explore extras like Google Workspace


### PR DESCRIPTION
This adds a space before the channel name in the onboarding confirmation message. For example, it currently says "Your Discord Channel is connected. You can switch toDiscord and start using your agent now."