### PR TITLE
fix: use HTTP /health endpoint instead of WS CLI (fixes #21)

### DIFF
--- a/fix-issue-21.patch
+++ b/fix-issue-21.patch
@@ -1,0 +1,172 @@
+diff --git a/lib/server/watchdog.js b/lib/server/watchdog.js
+index old..new 100644
+--- a/lib/server/watchdog.js
++++ b/lib/server/watchdog.js
+@@ -1,3 +1,5 @@
++const http = require("http");
++
+ const {
+   kWatchdogCheckIntervalMs,
+   kWatchdogDegradedCheckIntervalMs,
+@@ -45,6 +47,39 @@ const parseHealthResult = (result) => {
+   return { ok: true };
+ };
+ 
++const httpHealthCheck = async ({ gatewayPort = 18789, gatewayToken = "", timeoutMs = 5000 }) => {
++  return new Promise((resolve) => {
++    const timeout = setTimeout(() => {
++      req.destroy();
++      resolve({ ok: false, reason: "HTTP health check timeout" });
++    }, timeoutMs);
++
++    const req = http.get(
++      {
++        hostname: "127.0.0.1",
++        port: gatewayPort,
++        path: "/health",
++        headers: gatewayToken ? { Authorization: `Bearer ${gatewayToken}` } : {},
++        timeout: timeoutMs,
++      },
++      (res) => {
++        clearTimeout(timeout);
++        let body = "";
++        res.on("data", (chunk) => (body += chunk));
++        res.on("end", () => {
++          if (res.statusCode === 200) {
++            resolve({ ok: true, details: { statusCode: res.statusCode, body } });
++          } else {
++            resolve({ ok: false, reason: `HTTP ${res.statusCode}` });
++          }
++        });
++      }
++    );
++
++    req.on("error", (err) => {
++      clearTimeout(timeout);
++      resolve({ ok: false, reason: err.message || "HTTP request failed" });
++    });
++  });
++};
++
+ const isDuplicateGatewayLaunchExit = ({ code, stderrTail = [] } = {}) => {
+   if (code !== 1) return false;
+   const stderrText = (Array.isArray(stderrTail) ? stderrTail : [])
+@@ -59,10 +94,12 @@ const isDuplicateGatewayLaunchExit = ({ code, stderrTail = [] } = {}) => {
+ 
+ const createWatchdog = ({
+   clawCmd,
++  gatewayPort = 18789,
++  gatewayToken = "",
+   launchGatewayProcess,
+   insertWatchdogEvent,
+@@ -413,7 +450,12 @@ const createWatchdog = ({
+     const gatewayStartedAtAtStart = state.gatewayStartedAt;
+     const correlationId = createCorrelationId();
+     state.lastHealthCheckAt = new Date().toISOString();
+-    const result = await clawCmd("health --json", { quiet: true });
++    
++    // Use HTTP /health endpoint instead of WS CLI to avoid Tailscale Serve issues (fixes #21)
++    const result = await httpHealthCheck({ 
++      gatewayPort, 
++      gatewayToken,
++      timeoutMs: 5000 
++    });
+     const parsed = parseHealthResult(result);
+     const staleAfterRestart =
+       gatewayStartedAtAtStart != null &&
+diff --git a/lib/server/routes/nodes.js b/lib/server/routes/nodes.js
+index old..new 100644
+--- a/lib/server/routes/nodes.js
++++ b/lib/server/routes/nodes.js
+@@ -1,4 +1,5 @@
+ const path = require("path");
++const http = require("http");
+ const crypto = require("crypto");
+ const { parseJsonObjectFromNoisyOutput } = require("../utils/json");
+ const { quoteShellArg } = require("../utils/shell");
+@@ -164,6 +165,62 @@ const parseBaseUrlParts = (baseUrl) => {
+   }
+ };
+ 
++const httpGatewayRequest = async ({ 
++  path, 
++  gatewayPort = 18789, 
++  gatewayToken = "", 
++  timeoutMs = 5000 
++}) => {
++  return new Promise((resolve) => {
++    const timeout = setTimeout(() => {
++      req.destroy();
++      resolve({ ok: false, error: "Gateway HTTP request timeout" });
++    }, timeoutMs);
++
++    const req = http.get(
++      {
++        hostname: "127.0.0.1",
++        port: gatewayPort,
++        path,
++        headers: gatewayToken ? { Authorization: `Bearer ${gatewayToken}` } : {},
++        timeout: timeoutMs,
++      },
++      (res) => {
++        clearTimeout(timeout);
++        let body = "";
++        res.on("data", (chunk) => (body += chunk));
++        res.on("end", () => {
++          if (res.statusCode === 200) {
++            try {
++              const parsed = JSON.parse(body);
++              resolve({ ok: true, stdout: JSON.stringify(parsed) });
++            } catch {
++              resolve({ ok: true, stdout: body });
++            }
++          } else {
++            resolve({ ok: false, error: `HTTP ${res.statusCode}: ${body}` });
++          }
++        });
++      }
++    );
++
++    req.on("error", (err) => {
++      clearTimeout(timeout);
++      resolve({ ok: false, error: err.message || "Gateway HTTP request failed" });
++    });
++  });
++};
++
+ const registerNodeRoutes = ({
+   app,
+   clawCmd,
++  gatewayPort = 18789,
++  gatewayToken = "",
+   openclawDir,
+@@ -179,12 +236,20 @@ const registerNodeRoutes = ({
+   });
+ 
+   app.get("/api/nodes", async (_req, res) => {
+-    const statusResult = await clawCmd("nodes status --json", { quiet: true });
++    // Use HTTP gateway endpoints instead of WS CLI to avoid Tailscale Serve issues (fixes #21)
++    const statusResult = await httpGatewayRequest({ 
++      path: "/nodes/status",
++      gatewayPort,
++      gatewayToken,
++      timeoutMs: kNodeRouteCliTimeoutMs 
++    });
+     if (!statusResult.ok) {
+       return res.status(500).json({
+         ok: false,
+-        error: statusResult.stderr || "Could not load nodes status",
++        error: statusResult.error || "Could not load nodes status",
+       });
+     }
+     const status = parseNodesStatus(statusResult.stdout);
+-    const pendingResult = await clawCmd("nodes pending --json", { quiet: true });
++    const pendingResult = await httpGatewayRequest({ 
++      path: "/nodes/pending",
++      gatewayPort,
++      gatewayToken,
++      timeoutMs: kNodeRouteCliTimeoutMs 
++    });
+     const pending = pendingResult.ok
+       ? parseNodesPending(pendingResult.stdout)
+       : status.pending;

--- a/lib/server.js
+++ b/lib/server.js
@@ -219,6 +219,8 @@ const slackApi = createSlackApi(() => process.env.SLACK_BOT_TOKEN);
 const watchdogNotifier = createWatchdogNotifier({ telegramApi, discordApi, slackApi });
 const watchdog = createWatchdog({
   clawCmd,
+  gatewayPort: constants.kDefaultGatewayPort,
+  gatewayToken: gatewayEnv.OPENCLAW_GATEWAY_TOKEN || "",
   launchGatewayProcess,
   insertWatchdogEvent,
   notifier: watchdogNotifier,

--- a/lib/server/routes/nodes.js
+++ b/lib/server/routes/nodes.js
@@ -172,7 +172,11 @@ const registerNodeRoutes = ({
   fsModule,
 }) => {
   app.get("/api/nodes", async (_req, res) => {
-    const statusResult = await clawCmd("nodes status --json", { quiet: true });
+    // Add timeout to prevent zombie processes when gateway.tailscale.mode=serve (fixes #21)
+    const statusResult = await clawCmd("nodes status --json", { 
+      quiet: true,
+      timeoutMs: kNodeRouteCliTimeoutMs 
+    });
     if (!statusResult.ok) {
       return res.status(500).json({
         ok: false,
@@ -180,7 +184,10 @@ const registerNodeRoutes = ({
       });
     }
     const status = parseNodesStatus(statusResult.stdout);
-    const pendingResult = await clawCmd("nodes pending --json", { quiet: true });
+    const pendingResult = await clawCmd("nodes pending --json", { 
+      quiet: true,
+      timeoutMs: kNodeRouteCliTimeoutMs 
+    });
     const pending = pendingResult.ok
       ? parseNodesPending(pendingResult.stdout)
       : status.pending;

--- a/lib/server/watchdog.js
+++ b/lib/server/watchdog.js
@@ -1,3 +1,5 @@
+const http = require("http");
+
 const {
   kWatchdogCheckIntervalMs,
   kWatchdogDegradedCheckIntervalMs,
@@ -10,6 +12,7 @@ const {
 const kHealthStartupGraceMs = 30 * 1000;
 const kBootstrapHealthCheckMs = 5 * 1000;
 const kExpectedRestartWindowMs = 15 * 1000;
+const kHttpHealthCheckTimeoutMs = 5 * 1000;
 
 const isTruthy = (value) =>
   ["1", "true", "yes", "on"].includes(
@@ -44,6 +47,56 @@ const parseHealthResult = (result) => {
   }
   return { ok: true };
 };
+
+/**
+ * HTTP-based health check using /health endpoint.
+ * Avoids WebSocket CLI issues when gateway.tailscale.mode=serve (fixes #21).
+ */
+const httpHealthCheck = async ({ gatewayPort = 18789, gatewayToken = "" }) => {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      req.destroy();
+      resolve({ ok: false, reason: "HTTP health check timeout" });
+    }, kHttpHealthCheckTimeoutMs);
+
+    const req = http.get(
+      {
+        hostname: "127.0.0.1",
+        port: gatewayPort,
+        path: "/health",
+        headers: gatewayToken ? { Authorization: `Bearer ${gatewayToken}` } : {},
+        timeout: kHttpHealthCheckTimeoutMs,
+      },
+      (res) => {
+        clearTimeout(timeout);
+        let body = "";
+        res.on("data", (chunk) => (body += chunk));
+        res.on("end", () => {
+          if (res.statusCode === 200) {
+            try {
+              const parsed = JSON.parse(body);
+              if (parsed.ok === true || parsed.status === "live") {
+                resolve({ ok: true, stdout: body, details: parsed });
+              } else {
+                resolve({ ok: false, reason: "Gateway reports unhealthy" });
+              }
+            } catch {
+              resolve({ ok: true, stdout: body });
+            }
+          } else {
+            resolve({ ok: false, reason: `HTTP ${res.statusCode}` });
+          }
+        });
+      }
+    );
+
+    req.on("error", (err) => {
+      clearTimeout(timeout);
+      resolve({ ok: false, reason: err.message || "HTTP request failed" });
+    });
+  });
+};
+
 const isDuplicateGatewayLaunchExit = ({ code, stderrTail = [] } = {}) => {
   if (code !== 1) return false;
   const stderrText = (Array.isArray(stderrTail) ? stderrTail : [])
@@ -59,6 +112,8 @@ const isDuplicateGatewayLaunchExit = ({ code, stderrTail = [] } = {}) => {
 
 const createWatchdog = ({
   clawCmd,
+  gatewayPort = 18789,
+  gatewayToken = "",
   launchGatewayProcess,
   insertWatchdogEvent,
   notifier,
@@ -413,7 +468,9 @@ const createWatchdog = ({
     const gatewayStartedAtAtStart = state.gatewayStartedAt;
     const correlationId = createCorrelationId();
     state.lastHealthCheckAt = new Date().toISOString();
-    const result = await clawCmd("health --json", { quiet: true });
+    
+    // Use HTTP /health endpoint instead of WS CLI to avoid Tailscale Serve issues (fixes #21)
+    const result = await httpHealthCheck({ gatewayPort, gatewayToken });
     const parsed = parseHealthResult(result);
     const staleAfterRestart =
       gatewayStartedAtAtStart != null &&


### PR DESCRIPTION
Fixes #21

## Problem

When `gateway.tailscale.mode` is set to `serve`, OpenClaw CLI commands using WebSocket connections fail with `gateway closed (1000)`. This affects:

- `openclaw health --json` (used by AlphaClaw watchdog for health checks)
- `openclaw nodes status --json` and `openclaw nodes pending --json` (used by `/api/nodes` route)

**Impact:**
- False health failures in watchdog UI showing gateway as "constantly restarting"
- Zombie process accumulation from hanging WS connections consuming CPU and memory
- Gateway performance degradation from timeout floods

## Root Cause

Tailscale Serve intercepts loopback traffic and breaks the WS handshake for CLI subprocess connections. HTTP endpoints work fine.

## Solution

1. **Watchdog health checks:** Replace `openclaw health --json` (WS CLI) with HTTP GET to `/health` endpoint
2. **Nodes API calls:** Add 5-second timeouts to prevent zombie processes
3. **Pass gateway credentials:** Provide `gatewayPort` and `gatewayToken` to `createWatchdog()`

## Changes

- **lib/server/watchdog.js:** Add `httpHealthCheck()` function using native `http` module, replace WS CLI health check
- **lib/server/routes/nodes.js:** Add `timeoutMs: kNodeRouteCliTimeoutMs` to nodes CLI calls
- **lib/server.js:** Pass `gatewayPort` and `gatewayToken` to watchdog initialization

## Benefits

- ✅ Eliminates false health failures under Tailscale Serve mode
- ✅ Prevents zombie process accumulation
- ✅ Resolves gateway performance issues
- ✅ HTTP endpoint more reliable than spawning CLI subprocesses
- ✅ Maintains backward compatibility (works with or without Tailscale)

## Testing

- [x] Syntax validation passes for all modified files
- [x] HTTP health check tested against live OpenClaw gateway
- [x] No breaking changes to API surface