### PR TITLE
feat: Extend Slack API with message management and info methods

### DIFF
--- a/lib/server/slack-api.js
+++ b/lib/server/slack-api.js
@@ -233,6 +233,72 @@ const createSlackApi = (getToken) => {
     });
   };
 
+  /**
+   * Update an existing message
+   * @param {string} channel - Channel ID
+   * @param {string} timestamp - Message timestamp
+   * @param {string} text - New message text
+   * @returns {Promise<object>} Update response
+   * @requires chat:write OAuth scope
+   */
+  const updateMessage = (channel, timestamp, text) => {
+    return call("chat.update", {
+      channel,
+      ts: timestamp,
+      text: String(text || ""),
+    });
+  };
+
+  /**
+   * Delete a message
+   * @param {string} channel - Channel ID
+   * @param {string} timestamp - Message timestamp
+   * @requires chat:write OAuth scope
+   */
+  const deleteMessage = (channel, timestamp) => {
+    return call("chat.delete", { channel, ts: timestamp });
+  };
+
+  /**
+   * Pin a message to a channel
+   * @param {string} channel - Channel ID
+   * @param {string} timestamp - Message timestamp
+   * @requires pins:write OAuth scope
+   */
+  const pinMessage = (channel, timestamp) => {
+    return call("pins.add", { channel, timestamp });
+  };
+
+  /**
+   * Unpin a message from a channel
+   * @param {string} channel - Channel ID
+   * @param {string} timestamp - Message timestamp
+   * @requires pins:write OAuth scope
+   */
+  const unpinMessage = (channel, timestamp) => {
+    return call("pins.remove", { channel, timestamp });
+  };
+
+  /**
+   * Get user information
+   * @param {string} userId - User ID
+   * @returns {Promise<object>} User info (name, real_name, email, etc.)
+   * @requires users:read OAuth scope
+   */
+  const getUserInfo = (userId) => {
+    return call("users.info", { user: userId });
+  };
+
+  /**
+   * Get channel information
+   * @param {string} channelId - Channel ID
+   * @returns {Promise<object>} Channel info (name, topic, purpose, etc.)
+   * @requires channels:read or groups:read OAuth scope (depending on channel type)
+   */
+  const getChannelInfo = (channelId) => {
+    return call("conversations.info", { channel: channelId });
+  };
+
   return {
     authTest,
     postMessage,
@@ -241,6 +307,12 @@ const createSlackApi = (getToken) => {
     removeReaction,
     uploadFile,
     uploadTextSnippet,
+    updateMessage,
+    deleteMessage,
+    pinMessage,
+    unpinMessage,
+    getUserInfo,
+    getChannelInfo,
   };
 };
 

--- a/tests/server/slack-api.test.js
+++ b/tests/server/slack-api.test.js
@@ -21,6 +21,12 @@ describe("server/slack-api", () => {
     expect(typeof api.removeReaction).toBe("function");
     expect(typeof api.uploadFile).toBe("function");
     expect(typeof api.uploadTextSnippet).toBe("function");
+    expect(typeof api.updateMessage).toBe("function");
+    expect(typeof api.deleteMessage).toBe("function");
+    expect(typeof api.pinMessage).toBe("function");
+    expect(typeof api.unpinMessage).toBe("function");
+    expect(typeof api.getUserInfo).toBe("function");
+    expect(typeof api.getChannelInfo).toBe("function");
   });
 
   it("postMessage requires token", async () => {
@@ -134,5 +140,128 @@ describe("server/slack-api", () => {
     const api = createSlackApi(() => "test-token");
 
     await expect(api.postMessage("INVALID", "test")).rejects.toThrow(/invalid_channel/);
+  });
+
+  it("updateMessage calls chat.update without mrkdwn field", async () => {
+    let capturedPayload = null;
+
+    global.fetch = async (url, options) => {
+      capturedPayload = JSON.parse(options.body);
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          channel: "C123",
+          ts: "1234.5678",
+          text: "Updated text",
+        }),
+      };
+    };
+
+    const api = createSlackApi(() => "test-token");
+    await api.updateMessage("C123", "1234.5678", "Updated text");
+
+    expect(capturedPayload.channel).toBe("C123");
+    expect(capturedPayload.ts).toBe("1234.5678");
+    expect(capturedPayload.text).toBe("Updated text");
+    expect(capturedPayload.mrkdwn).toBeUndefined();
+  });
+
+  it("deleteMessage calls chat.delete", async () => {
+    let capturedPayload = null;
+
+    global.fetch = async (url, options) => {
+      capturedPayload = JSON.parse(options.body);
+      return {
+        ok: true,
+        json: async () => ({ ok: true, channel: "C123", ts: "1234.5678" }),
+      };
+    };
+
+    const api = createSlackApi(() => "test-token");
+    await api.deleteMessage("C123", "1234.5678");
+
+    expect(capturedPayload.channel).toBe("C123");
+    expect(capturedPayload.ts).toBe("1234.5678");
+  });
+
+  it("pinMessage calls pins.add with channel and timestamp", async () => {
+    let capturedPayload = null;
+
+    global.fetch = async (url, options) => {
+      capturedPayload = JSON.parse(options.body);
+      return {
+        ok: true,
+        json: async () => ({ ok: true }),
+      };
+    };
+
+    const api = createSlackApi(() => "test-token");
+    await api.pinMessage("C123", "1234.5678");
+
+    expect(capturedPayload.channel).toBe("C123");
+    expect(capturedPayload.timestamp).toBe("1234.5678");
+  });
+
+  it("unpinMessage calls pins.remove with channel and timestamp", async () => {
+    let capturedPayload = null;
+
+    global.fetch = async (url, options) => {
+      capturedPayload = JSON.parse(options.body);
+      return {
+        ok: true,
+        json: async () => ({ ok: true }),
+      };
+    };
+
+    const api = createSlackApi(() => "test-token");
+    await api.unpinMessage("C123", "1234.5678");
+
+    expect(capturedPayload.channel).toBe("C123");
+    expect(capturedPayload.timestamp).toBe("1234.5678");
+  });
+
+  it("getUserInfo calls users.info with user ID", async () => {
+    let capturedPayload = null;
+
+    global.fetch = async (url, options) => {
+      capturedPayload = JSON.parse(options.body);
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          user: { id: "U123", name: "testuser" },
+        }),
+      };
+    };
+
+    const api = createSlackApi(() => "test-token");
+    const result = await api.getUserInfo("U123");
+
+    expect(capturedPayload.user).toBe("U123");
+    expect(result.user.id).toBe("U123");
+    expect(result.user.name).toBe("testuser");
+  });
+
+  it("getChannelInfo calls conversations.info with channel ID", async () => {
+    let capturedPayload = null;
+
+    global.fetch = async (url, options) => {
+      capturedPayload = JSON.parse(options.body);
+      return {
+        ok: true,
+        json: async () => ({
+          ok: true,
+          channel: { id: "C123", name: "general" },
+        }),
+      };
+    };
+
+    const api = createSlackApi(() => "test-token");
+    const result = await api.getChannelInfo("C123");
+
+    expect(capturedPayload.channel).toBe("C123");
+    expect(result.channel.id).toBe("C123");
+    expect(result.channel.name).toBe("general");
   });
 });


### PR DESCRIPTION
## Description

Extends the Slack API client with additional methods for message management and metadata lookups.

## New Methods

**Message Management:**
- `updateMessage(channel, timestamp, text)` - Edit existing messages
- `deleteMessage(channel, timestamp)` - Remove messages
- `pinMessage(channel, timestamp)` - Pin to channel
- `unpinMessage(channel, timestamp)` - Unpin from channel

**Information Lookups:**
- `getUserInfo(userId)` - Get user details (name, email, etc.)
- `getChannelInfo(channelId)` - Get channel metadata (topic, purpose, etc.)

## Use Cases

- **Status updates:** Edit bot messages as tasks progress
- **Cleanup:** Remove temporary messages after completion
- **Announcements:** Pin important notifications
- **Context:** Look up user/channel info for richer interactions

## Implementation

- Follows existing API patterns (same `call()` wrapper)
- Comprehensive JSDoc documentation
- Full test coverage (all new methods tested)
- Backward compatible (only adds methods, doesn't change existing)

## Testing

```bash
npm test tests/server/slack-api.test.js
```

All tests pass including new test cases for:
- updateMessage payload validation
- pinMessage/unpinMessage behavior
- getUserInfo response handling