### PR TITLE
feat: make OpenRouter a core provider in setup UI

### DIFF
--- a/lib/public/js/lib/model-config.js
+++ b/lib/public/js/lib/model-config.js
@@ -266,7 +266,7 @@ export const kProviderOrder = [
   "vllm",
 ];
 
-export const kCoreProviders = new Set(["anthropic", "openai", "google"]);
+export const kCoreProviders = new Set(["anthropic", "openai", "google", "openrouter"]);
 
 export const kProviderFeatures = {
   anthropic: ["Agent Model"],


### PR DESCRIPTION
## Summary

Makes OpenRouter visible in the main provider selection during setup and in the Providers tab, addressing user feedback in #30.

## Problem

OpenRouter was already fully implemented in AlphaClaw (API key handling, auth, model support) but was hidden in the 'other providers' section. Users couldn't easily discover it during setup or in the UI.

From #30:
> "When setting up Alphaclaw, we only have the option to set up OpenAI and Anthropic, not OpenRouter, right? Even in Alphaclaw, after setup, there is no OpenRouter option."

## Solution

Add OpenRouter to `kCoreProviders` alongside Anthropic, OpenAI, and Google. This makes it visible in:
- Main setup wizard provider selection
- Providers tab in the UI
- Model picker (when OpenRouter is configured)

## Changes

**File:** `lib/public/js/lib/model-config.js` (1 line)

```diff
-export const kCoreProviders = new Set(["anthropic", "openai", "google"]);
+export const kCoreProviders = new Set(["anthropic", "openai", "google", "openrouter"]);
```

That's it! Everything else (API key handling, auth, model support) was already implemented.

## Why OpenRouter Deserves Core Status

- **100+ models** via single API (GPT-4, Claude, Gemini, Llama, etc.)
- **Caching system** (reduces costs)
- **Load balancing** and fallbacks
- **Cost optimization** across providers
- Already fully supported in AlphaClaw backend

## Testing

- [x] Verified OpenRouter config exists in `kProviderAuthFields`
- [x] Verified OpenRouter in `kProviderOrder`
- [x] Verified OpenRouter has "Agent Model" feature
- [x] Change limited to UI visibility only (no backend changes needed)

## Impact

- Users can now easily discover and configure OpenRouter
- Access to 100+ models through AlphaClaw's setup wizard
- No breaking changes (additive only)

Fixes #30