### PR TITLE
Add multi-account Slack channel support

### DIFF
--- a/lib/public/js/components/agents-tab/create-channel-modal.js
+++ b/lib/public/js/components/agents-tab/create-channel-modal.js
@@ -2,12 +2,15 @@ import { h } from "preact";
 import { useEffect, useMemo, useState } from "preact/hooks";
 import htm from "htm";
 import { ActionButton } from "../action-button.js";
-import { CloseIcon } from "../icons.js";
+import { CloseIcon, FileCopyLineIcon } from "../icons.js";
 import { ModalShell } from "../modal-shell.js";
 import { PageHeader } from "../page-header.js";
 import { SecretInput } from "../secret-input.js";
 import { fetchChannelAccountToken } from "../../lib/api.js";
+import { copyTextToClipboard } from "../../lib/clipboard.js";
+import { isSingleAccountChannelProvider } from "../../lib/channel-provider-availability.js";
 import { ALL_CHANNELS, getChannelMeta } from "../channels.js";
+import { showToast } from "../toast.js";
 
 const html = htm.bind(h);
 
@@ -25,14 +28,32 @@ const kSlackBotScopes = [
   "channels:history",
   "channels:read",
   "chat:write",
+  "commands",
+  "emoji:read",
+  "files:read",
+  "files:write",
+  "groups:read",
   "groups:history",
   "im:history",
   "im:read",
   "im:write",
   "mpim:history",
+  "mpim:read",
+  "mpim:write",
+  "pins:read",
+  "pins:write",
   "reactions:read",
   "reactions:write",
   "users:read",
+];
+const kSlackBotEvents = [
+  "app_mention",
+  "message.channels",
+  "message.groups",
+  "message.im",
+  "message.mpim",
+  "reaction_added",
+  "reaction_removed",
 ];
 const kSlackInstructionsLink = "https://docs.openclaw.ai/channels/slack";
 
@@ -50,7 +71,63 @@ const deriveChannelEnvKey = ({ provider, accountId }) => {
   if (!normalizedAccountId || normalizedAccountId === "default") return baseKey;
   return `${baseKey}_${normalizedAccountId.replace(/-/g, "_").toUpperCase()}`;
 };
+const deriveChannelExtraEnvKey = ({ provider, accountId, index = 0 }) => {
+  const baseKeys = [kChannelExtraEnvKeys[String(provider || "").trim()]].filter(
+    Boolean,
+  );
+  const baseKey = String(baseKeys[index] || "").trim();
+  const normalizedAccountId = String(accountId || "").trim();
+  if (!baseKey) return "";
+  if (!normalizedAccountId || normalizedAccountId === "default") return baseKey;
+  return `${baseKey}_${normalizedAccountId.replace(/-/g, "_").toUpperCase()}`;
+};
 const isMaskedTokenValue = (value) => /^\*+$/.test(String(value || "").trim());
+const buildSlackManifest = (appName = "AlphaClaw") =>
+  JSON.stringify(
+    {
+      _metadata: {
+        major_version: 1,
+      },
+      display_information: {
+        name: String(appName || "").trim() || "AlphaClaw",
+        description: "Slack connector for AlphaClaw",
+      },
+      features: {
+        bot_user: {
+          display_name: String(appName || "").trim() || "AlphaClaw",
+          always_online: false,
+        },
+        app_home: {
+          messages_tab_enabled: true,
+          messages_tab_read_only_enabled: false,
+        },
+      },
+      oauth_config: {
+        scopes: {
+          bot: kSlackBotScopes,
+        },
+      },
+      settings: {
+        event_subscriptions: {
+          bot_events: kSlackBotEvents,
+        },
+        org_deploy_enabled: false,
+        socket_mode_enabled: true,
+        is_hosted: false,
+        token_rotation_enabled: false,
+      },
+    },
+    null,
+    2,
+  );
+const copyAndToast = async (value, label = "text") => {
+  const copied = await copyTextToClipboard(value);
+  if (copied) {
+    showToast("Copied to clipboard", "success");
+    return;
+  }
+  showToast(`Could not copy ${label}`, "error");
+};
 
 export const CreateChannelModal = ({
   visible = false,
@@ -152,9 +229,7 @@ export const CreateChannelModal = ({
     }
     setName(providerLabel);
   }, [provider, providerHasAccounts, nameEditedManually, isEditMode]);
-  const isSingleAccountProvider =
-    String(provider || "").trim() === "discord" ||
-    String(provider || "").trim() === "slack";
+  const isSingleAccountProvider = isSingleAccountChannelProvider(provider);
   const needsAppToken = String(provider || "").trim() === "slack";
 
   const accountId = useMemo(() => {
@@ -169,6 +244,24 @@ export const CreateChannelModal = ({
   const envKey = useMemo(
     () => deriveChannelEnvKey({ provider, accountId }),
     [provider, accountId],
+  );
+  const extraEnvKey = useMemo(
+    () =>
+      deriveChannelExtraEnvKey({
+        provider,
+        accountId,
+      }),
+    [provider, accountId],
+  );
+  const slackManifestName = useMemo(() => {
+    const normalizedName = String(name || "").trim();
+    if (!normalizedName) return "AlphaClaw";
+    if (normalizedName.toLowerCase() === "slack") return "AlphaClaw";
+    return normalizedName;
+  }, [name]);
+  const slackManifest = useMemo(
+    () => buildSlackManifest(slackManifestName),
+    [slackManifestName],
   );
 
   const accountExists = useMemo(
@@ -269,7 +362,7 @@ export const CreateChannelModal = ({
     <${ModalShell}
       visible=${visible}
       onClose=${onClose}
-      panelClassName="bg-modal border border-border rounded-xl p-6 max-w-lg w-full space-y-4"
+      panelClassName="bg-modal border border-border rounded-xl p-6 max-w-lg w-full max-h-[calc(100vh-2rem)] overflow-y-auto space-y-4"
     >
       <${PageHeader}
         title=${
@@ -360,7 +453,7 @@ export const CreateChannelModal = ({
                   <p class="text-xs text-fg-muted">
                     Saved behind the scenes as
                     <code class="font-mono text-fg-muted ml-1">
-                      ${kChannelExtraEnvKeys.slack}
+                      ${extraEnvKey || kChannelExtraEnvKeys.slack}
                     </code>
                     .
                   </p>
@@ -371,60 +464,167 @@ export const CreateChannelModal = ({
         ${
           needsAppToken
             ? html`
-                <details class="rounded-lg border border-border bg-field px-3 py-2.5">
-                  <summary class="cursor-pointer text-xs text-body hover:text-body">
-                    Slack-specific instructions (step-by-step)
-                  </summary>
-                  <div class="mt-2 space-y-2 text-xs text-fg-muted">
-                    <ol class="list-decimal list-inside space-y-1.5">
-                      <li>
-                        In Slack app settings, turn on
-                        ${" "}
-                        <span class="text-body">Socket Mode</span>.
-                      </li>
-                      <li>
-                        In
-                        ${" "}
-                        <span class="text-body">App Home</span>, enable
-                        <code class="font-mono text-fg-muted ml-1">
-                          Allow users to send Slash commands and messages from the messages tab
-                        </code>.
-                      </li>
-                      <li>
-                        In
-                        ${" "}
-                        <span class="text-body">Event Subscriptions</span>, toggle on
-                        <code class="font-mono text-fg-muted ml-1">Subscribe to bot events</code>
-                        ${" "}
-                        and add
-                        <code class="font-mono text-fg-muted ml-1">message.im</code>.
-                      </li>
-                      <li>
-                        Create a Bot Token (<code class="font-mono text-fg-muted">xoxb-...</code>)
-                        with scopes:
-                        <code class="font-mono text-fg-muted ml-1">
-                          ${kSlackBotScopes.join(", ")}
-                        </code>
-                      </li>
-                      <li>
-                        Create an App Token (<code class="font-mono text-fg-muted">xapp-...</code>)
-                        with
-                        <code class="font-mono text-fg-muted ml-1">connections:write</code>.
-                      </li>
-                      <li>
-                        Reinstall the app after changing scopes.
-                      </li>
-                    </ol>
-                    <a
-                      href=${kSlackInstructionsLink}
-                      target="_blank"
-                      class="hover:underline"
-                      style="color: var(--accent-link)"
+                <div class="space-y-2">
+                  <details
+                    class="rounded-lg border border-border bg-field px-3 py-2.5"
+                  >
+                    <summary
+                      class="cursor-pointer text-xs text-body hover:text-body"
                     >
-                      Open full Slack setup guide
-                    </a>
-                  </div>
-                </details>
+                      <span class="inline-block ml-1">
+                        Create app from manifest (recommended)
+                      </span>
+                    </summary>
+                    <div class="mt-2 space-y-2 text-xs text-fg-muted">
+                      <div class="flex items-center justify-between gap-3 pt-1">
+                        <div class="space-y-0.5">
+                          <p class="text-[12px] text-fg-muted">
+                            ${slackManifestName} App Manifest
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onclick=${() =>
+                            copyAndToast(slackManifest, "Slack manifest")}
+                          class="text-xs px-2 py-1 rounded-lg ac-btn-cyan inline-flex items-center gap-1.5 shrink-0"
+                        >
+                          <${FileCopyLineIcon} className="w-3.5 h-3.5" />
+                          Copy
+                        </button>
+                      </div>
+                      <pre
+                        class="max-h-72 overflow-auto rounded-lg border border-border bg-field p-3 text-[11px] leading-5 whitespace-pre-wrap break-all font-mono text-body"
+                      >
+${slackManifest}</pre
+                      >
+                      <ol
+                        class="list-decimal list-inside space-y-1.5 text-[11px] text-fg-muted"
+                      >
+                        <li>
+                          In Slack, click ${" "}
+                          <span class="text-body"
+                            >Create app from manifest</span
+                          >
+                          ${" "} and paste this manifest.
+                        </li>
+                        <li>
+                          Open ${" "}
+                          <span class="text-body">Basic Information</span>
+                          ${" "} and create an ${" "}
+                          <span class="text-body">App-Level Token</span>
+                          ${" "} with
+                          <code class="font-mono text-fg-muted ml-1"
+                            >connections:write</code
+                          >.
+                        </li>
+                        <li>
+                          Open ${" "}
+                          <span class="text-body">OAuth & Permissions</span>
+                          ${" "} and use ${" "}
+                          <span class="text-body">Install to Workspace</span>
+                          ${" "} or ${" "}
+                          <span class="text-body">Reinstall to Workspace</span>
+                          ${" "} so Slack issues a bot token.
+                        </li>
+                        <li>
+                          In ${" "}
+                          <span class="text-body">OAuth & Permissions</span>
+                          ${" "} copy the ${" "}
+                          <span class="text-body">Bot User OAuth Token</span>
+                          ${" "} (
+                          <code class="font-mono text-fg-muted">xoxb-...</code>
+                          ).
+                        </li>
+                        <li>
+                          Paste the generated ${" "}
+                          <code class="font-mono text-fg-muted">xoxb-...</code>
+                          ${" "} and ${" "}
+                          <code class="font-mono text-fg-muted">xapp-...</code>
+                          ${" "} tokens here.
+                        </li>
+                      </ol>
+                    </div>
+                  </details>
+                  <details
+                    class="rounded-lg border border-border bg-field px-3 py-2.5"
+                  >
+                    <summary
+                      class="cursor-pointer text-xs text-body hover:text-body"
+                    >
+                      <span class="inline-block ml-1">
+                        Manual setup instructions
+                      </span>
+                    </summary>
+                    <div class="mt-2 space-y-2 text-xs text-fg-muted">
+                      <p>
+                        Use this if you want to configure the Slack app by hand
+                        instead of importing a manifest.
+                      </p>
+                      <ol class="list-decimal list-inside space-y-1.5">
+                        <li>
+                          In Slack app settings, turn on ${" "}
+                          <span class="text-body">Socket Mode</span>.
+                        </li>
+                        <li>
+                          In ${" "}
+                          <span class="text-body">App Home</span>, enable
+                          <code class="font-mono text-fg-muted ml-1">
+                            Allow users to send Slash commands and messages from
+                            the messages tab </code
+                          >.
+                        </li>
+                        <li>
+                          In ${" "}
+                          <span class="text-body">Event Subscriptions</span>,
+                          toggle on
+                          <code class="font-mono text-fg-muted ml-1"
+                            >Subscribe to bot events</code
+                          >
+                          ${" "} and add
+                          <code class="font-mono text-fg-muted ml-1"
+                            >message.im</code
+                          >.
+                        </li>
+                        <li>
+                          In ${" "}
+                          <span class="text-body">OAuth & Permissions</span>,
+                          add the bot scopes:
+                          <code class="font-mono text-fg-muted ml-1">
+                            ${kSlackBotScopes.join(", ")}
+                          </code>
+                        </li>
+                        <li>
+                          In ${" "}
+                          <span class="text-body">Basic Information</span>,
+                          create an App Token (<code
+                            class="font-mono text-fg-muted"
+                            >xapp-...</code
+                          >) with
+                          <code class="font-mono text-fg-muted ml-1"
+                            >connections:write</code
+                          >.
+                        </li>
+                        <li>
+                          Back in ${" "}
+                          <span class="text-body">OAuth & Permissions</span>,
+                          install or reinstall the app, then copy the ${" "}
+                          <span class="text-body">Bot User OAuth Token</span>
+                          ${" "} (
+                          <code class="font-mono text-fg-muted">xoxb-...</code>
+                          ).
+                        </li>
+                      </ol>
+                      <a
+                        href=${kSlackInstructionsLink}
+                        target="_blank"
+                        class="hover:underline"
+                        style="color: var(--accent-link)"
+                      >
+                        Open full Slack setup guide
+                      </a>
+                    </div>
+                  </details>
+                </div>
               `
             : null
         }

--- a/lib/public/js/components/modal-shell.js
+++ b/lib/public/js/components/modal-shell.js
@@ -29,7 +29,7 @@ export const ModalShell = ({
   return createPortal(
     html`
       <div
-        class="fixed inset-0 bg-overlay flex items-center justify-center p-4 z-50"
+        class="fixed inset-0 bg-overlay flex items-start justify-center overflow-y-auto p-4 sm:items-center z-50"
         onclick=${(event) => {
           if (closeOnOverlayClick && event.target === event.currentTarget) onClose?.();
         }}

--- a/lib/public/js/lib/channel-provider-availability.js
+++ b/lib/public/js/lib/channel-provider-availability.js
@@ -1,4 +1,4 @@
-const kSingleAccountChannelProviders = new Set(["discord", "slack"]);
+const kSingleAccountChannelProviders = new Set(["discord"]);
 
 const hasConfiguredAccounts = ({ configuredChannelMap, provider }) => {
   const channelEntry = configuredChannelMap instanceof Map
@@ -20,4 +20,3 @@ export const isChannelProviderDisabledForAdd = ({
   if (!isSingleAccountChannelProvider(provider)) return false;
   return hasConfiguredAccounts({ configuredChannelMap, provider });
 };
-

--- a/lib/server.js
+++ b/lib/server.js
@@ -223,7 +223,12 @@ const webhookMiddleware = createWebhookMiddleware({
 const telegramApi = createTelegramApi(() => process.env.TELEGRAM_BOT_TOKEN);
 const discordApi = createDiscordApi(() => process.env.DISCORD_BOT_TOKEN);
 const slackApi = createSlackApi(() => process.env.SLACK_BOT_TOKEN);
-const watchdogNotifier = createWatchdogNotifier({ telegramApi, discordApi, slackApi });
+const watchdogNotifier = createWatchdogNotifier({
+  telegramApi,
+  discordApi,
+  slackApi,
+  readEnvFile,
+});
 const watchdog = createWatchdog({
   clawCmd,
   launchGatewayProcess,

--- a/lib/server/agents/channels.js
+++ b/lib/server/agents/channels.js
@@ -143,10 +143,7 @@ const createChannelsDomain = ({
           `Channel account "${provider}/${accountId}" already exists`,
         );
       }
-      if (
-        (provider === "discord" || provider === "slack") &&
-        Object.keys(existingAccounts).length > 0
-      ) {
+      if (provider === "discord" && Object.keys(existingAccounts).length > 0) {
         throw new Error(
           `${kChannelLabels[provider] || "This provider"} supports a single channel account`,
         );

--- a/lib/server/watchdog-notify.js
+++ b/lib/server/watchdog-notify.js
@@ -1,34 +1,94 @@
 const fs = require("fs");
 const path = require("path");
 const { OPENCLAW_DIR } = require("./constants");
+const { createSlackApi } = require("./slack-api");
 
-const getPairedIds = (channel) => {
+const kSlackBotEnvKey = "SLACK_BOT_TOKEN";
+
+const normalizeAccountId = (value) =>
+  String(value || "").trim().toLowerCase() || "default";
+
+const resolveCredentialPairingAccountId = ({ channel, fileName }) => {
+  const prefix = `${String(channel || "").trim().toLowerCase()}-`;
+  const suffix = "-allowFrom.json";
+  const rawFileName = String(fileName || "").trim();
+  if (!rawFileName.startsWith(prefix) || !rawFileName.endsWith(suffix)) {
+    return "";
+  }
+  return normalizeAccountId(rawFileName.slice(prefix.length, -suffix.length));
+};
+
+const deriveSlackBotEnvKey = (accountId = "default") => {
+  const normalizedAccountId = normalizeAccountId(accountId);
+  if (normalizedAccountId === "default") return kSlackBotEnvKey;
+  return `${kSlackBotEnvKey}_${normalizedAccountId.replace(/-/g, "_").toUpperCase()}`;
+};
+
+const getPairedTargetsByAccount = ({
+  channel,
+  fsImpl = fs,
+  openclawDir = OPENCLAW_DIR,
+}) => {
   const safeChannel = String(channel || "").trim().toLowerCase();
-  if (!safeChannel) return [];
-  const credentialsDir = path.join(OPENCLAW_DIR, "credentials");
-  if (!fs.existsSync(credentialsDir)) return [];
-  const ids = new Set();
+  if (!safeChannel) return new Map();
+  const credentialsDir = path.join(openclawDir, "credentials");
+  if (!fsImpl.existsSync(credentialsDir)) return new Map();
+  const idsByAccount = new Map();
   try {
-    const files = fs
+    const files = fsImpl
       .readdirSync(credentialsDir)
       .filter(
         (fileName) =>
           fileName.startsWith(`${safeChannel}-`) && fileName.endsWith("-allowFrom.json"),
       );
     for (const fileName of files) {
+      const accountId = resolveCredentialPairingAccountId({
+        channel: safeChannel,
+        fileName,
+      });
+      if (!accountId) continue;
       const filePath = path.join(credentialsDir, fileName);
-      const raw = fs.readFileSync(filePath, "utf8");
+      const raw = fsImpl.readFileSync(filePath, "utf8");
       const parsed = JSON.parse(raw);
       const allowFrom = Array.isArray(parsed?.allowFrom) ? parsed.allowFrom : [];
+      const ids =
+        idsByAccount.get(accountId) instanceof Set
+          ? idsByAccount.get(accountId)
+          : new Set();
       for (const id of allowFrom) {
         if (id == null) continue;
         const value = String(id).trim();
         if (!value) continue;
         ids.add(value);
       }
+      idsByAccount.set(accountId, ids);
     }
   } catch (err) {
     console.error(`[watchdog] could not resolve ${safeChannel} allowFrom IDs: ${err.message}`);
+  }
+  return new Map(
+    Array.from(idsByAccount.entries()).map(([accountId, ids]) => [
+      accountId,
+      Array.from(ids),
+    ]),
+  );
+};
+
+const getPairedIds = ({
+  channel,
+  fsImpl = fs,
+  openclawDir = OPENCLAW_DIR,
+}) => {
+  const ids = new Set();
+  const idsByAccount = getPairedTargetsByAccount({
+    channel,
+    fsImpl,
+    openclawDir,
+  });
+  for (const accountIds of idsByAccount.values()) {
+    for (const id of accountIds) {
+      ids.add(id);
+    }
   }
   return Array.from(ids);
 };
@@ -38,18 +98,30 @@ const formatDiscordMessage = (message) =>
 
 /**
  * Track thread state for Slack notifications
- * Key: userId, Value: { threadTs, lastEvent }
+ * Key: accountId:userId, Value: { threadTs, lastEvent }
  */
 const slackThreads = new Map();
 
-const createWatchdogNotifier = ({ telegramApi, discordApi, slackApi }) => {
+const createWatchdogNotifier = ({
+  telegramApi,
+  discordApi,
+  slackApi,
+  readEnvFile = () => [],
+  createSlackApi: createSlackApiFactory = createSlackApi,
+  fsImpl = fs,
+  openclawDir = OPENCLAW_DIR,
+}) => {
   const notify = async (message, opts = {}) => {
     const summary = {
       telegram: { sent: 0, failed: 0, skipped: false, targets: 0 },
       discord: { sent: 0, failed: 0, skipped: false, targets: 0 },
       slack: { sent: 0, failed: 0, skipped: false, targets: 0 },
     };
-    const telegramTargets = getPairedIds("telegram");
+    const telegramTargets = getPairedIds({
+      channel: "telegram",
+      fsImpl,
+      openclawDir,
+    });
     summary.telegram.targets = telegramTargets.length;
     if (!telegramApi?.sendMessage || !process.env.TELEGRAM_BOT_TOKEN || telegramTargets.length === 0) {
       summary.telegram.skipped = true;
@@ -67,7 +139,11 @@ const createWatchdogNotifier = ({ telegramApi, discordApi, slackApi }) => {
       }
     }
 
-    const discordTargets = getPairedIds("discord");
+    const discordTargets = getPairedIds({
+      channel: "discord",
+      fsImpl,
+      openclawDir,
+    });
     summary.discord.targets = discordTargets.length;
     if (!discordApi?.sendDirectMessage || !process.env.DISCORD_BOT_TOKEN || discordTargets.length === 0) {
       summary.discord.skipped = true;
@@ -85,61 +161,102 @@ const createWatchdogNotifier = ({ telegramApi, discordApi, slackApi }) => {
     }
 
     // Enhanced Slack notifications with threading and reactions
-    const slackTargets = getPairedIds("slack");
-    summary.slack.targets = slackTargets.length;
-    if (!slackApi?.postMessage || !process.env.SLACK_BOT_TOKEN || slackTargets.length === 0) {
+    const slackTargetsByAccount = getPairedTargetsByAccount({
+      channel: "slack",
+      fsImpl,
+      openclawDir,
+    });
+    summary.slack.targets = Array.from(slackTargetsByAccount.values()).reduce(
+      (total, targets) => total + targets.length,
+      0,
+    );
+    if (summary.slack.targets === 0) {
       summary.slack.skipped = true;
     } else {
       const eventType = opts.eventType || "info"; // crash, recovery, health, info
-      
-      for (const userId of slackTargets) {
-        try {
-          let threadTs = null;
-          let shouldCreateNewThread = true;
+      const envVars = typeof readEnvFile === "function" ? readEnvFile() : [];
 
-          // Check if we have an active thread for this user
-          const existingThread = slackThreads.get(userId);
-          if (existingThread && existingThread.lastEvent === "crash" && eventType === "recovery") {
-            // Recovery message goes in the crash thread
-            threadTs = existingThread.threadTs;
-            shouldCreateNewThread = false;
+      const envMap = new Map(
+        (Array.isArray(envVars) ? envVars : [])
+          .map((entry) => [
+            String(entry?.key || "").trim(),
+            String(entry?.value || "").trim(),
+          ])
+          .filter(([key]) => key),
+      );
+
+      for (const [accountId, slackTargets] of slackTargetsByAccount.entries()) {
+        if (!slackTargets.length) continue;
+        const envKey = deriveSlackBotEnvKey(accountId);
+        const botToken = String(envMap.get(envKey) || process.env[envKey] || "").trim();
+        if (!botToken) {
+          summary.slack.failed += slackTargets.length;
+          for (const userId of slackTargets) {
+            console.error(
+              `[watchdog] slack notification failed for ${accountId}/${userId}: missing ${envKey}`,
+            );
           }
+          continue;
+        }
 
-          // Send message (in thread if continuing conversation)
-          const result = await slackApi.postMessage(userId, String(message || ""), {
-            thread_ts: threadTs,
-            mrkdwn: true,
-          });
+        const accountSlackApi =
+          accountId === "default" &&
+          slackApi?.postMessage &&
+          botToken === String(process.env.SLACK_BOT_TOKEN || "").trim()
+            ? slackApi
+            : createSlackApiFactory(() => botToken);
 
-          // Store thread for future related messages
-          if (shouldCreateNewThread && result.ts) {
-            slackThreads.set(userId, {
-              threadTs: result.ts,
-              lastEvent: eventType,
-            });
-          }
+        for (const userId of slackTargets) {
+          try {
+            let threadTs = null;
+            let shouldCreateNewThread = true;
+            const threadKey = `${accountId}:${userId}`;
 
-          // Add reactions based on event type
-          // Use result.channel (the actual conversation/DM ID) instead of userId
-          if (result.ts && result.channel && slackApi.addReaction) {
-            try {
-              if (eventType === "crash") {
-                await slackApi.addReaction(result.channel, result.ts, "x");
-              } else if (eventType === "recovery") {
-                await slackApi.addReaction(result.channel, result.ts, "white_check_mark");
-              } else if (eventType === "health") {
-                await slackApi.addReaction(result.channel, result.ts, "heart");
-              }
-            } catch (reactionErr) {
-              // Reactions are nice-to-have, don't fail the whole notification
-              console.error(`[watchdog] slack reaction failed for ${userId}: ${reactionErr.message}`);
+            const existingThread = slackThreads.get(threadKey);
+            if (existingThread && existingThread.lastEvent === "crash" && eventType === "recovery") {
+              threadTs = existingThread.threadTs;
+              shouldCreateNewThread = false;
             }
-          }
 
-          summary.slack.sent += 1;
-        } catch (err) {
-          summary.slack.failed += 1;
-          console.error(`[watchdog] slack notification failed for ${userId}: ${err.message}`);
+            const result = await accountSlackApi.postMessage(userId, String(message || ""), {
+              thread_ts: threadTs,
+              mrkdwn: true,
+            });
+
+            if (shouldCreateNewThread && result.ts) {
+              slackThreads.set(threadKey, {
+                threadTs: result.ts,
+                lastEvent: eventType,
+              });
+            }
+
+            if (result.ts && result.channel && accountSlackApi.addReaction) {
+              try {
+                if (eventType === "crash") {
+                  await accountSlackApi.addReaction(result.channel, result.ts, "x");
+                } else if (eventType === "recovery") {
+                  await accountSlackApi.addReaction(
+                    result.channel,
+                    result.ts,
+                    "white_check_mark",
+                  );
+                } else if (eventType === "health") {
+                  await accountSlackApi.addReaction(result.channel, result.ts, "heart");
+                }
+              } catch (reactionErr) {
+                console.error(
+                  `[watchdog] slack reaction failed for ${accountId}/${userId}: ${reactionErr.message}`,
+                );
+              }
+            }
+
+            summary.slack.sent += 1;
+          } catch (err) {
+            summary.slack.failed += 1;
+            console.error(
+              `[watchdog] slack notification failed for ${accountId}/${userId}: ${err.message}`,
+            );
+          }
         }
       }
     }

--- a/tests/frontend/channel-provider-availability.test.js
+++ b/tests/frontend/channel-provider-availability.test.js
@@ -1,0 +1,34 @@
+const loadChannelProviderAvailabilityModule = async () =>
+  import("../../lib/public/js/lib/channel-provider-availability.js");
+
+describe("frontend/channel-provider-availability", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("allows multiple Slack accounts while keeping Discord single-account", async () => {
+    const {
+      isSingleAccountChannelProvider,
+      isChannelProviderDisabledForAdd,
+    } = await loadChannelProviderAvailabilityModule();
+    const configuredChannelMap = new Map([
+      ["slack", { accounts: [{ id: "default" }] }],
+      ["discord", { accounts: [{ id: "default" }] }],
+    ]);
+
+    expect(isSingleAccountChannelProvider("slack")).toBe(false);
+    expect(isSingleAccountChannelProvider("discord")).toBe(true);
+    expect(
+      isChannelProviderDisabledForAdd({
+        configuredChannelMap,
+        provider: "slack",
+      }),
+    ).toBe(false);
+    expect(
+      isChannelProviderDisabledForAdd({
+        configuredChannelMap,
+        provider: "discord",
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/server/agents-service.test.js
+++ b/tests/server/agents-service.test.js
@@ -1311,7 +1311,7 @@ describe("server/agents/service", () => {
     ).rejects.toThrow("Discord supports a single channel account");
   });
 
-  it("prevents creating multiple slack channel accounts", async () => {
+  it("creates an additional named slack channel account with suffixed env vars", async () => {
     const fsMock = buildFsMock({
       initialConfig: {
         agents: {
@@ -1332,6 +1332,8 @@ describe("server/agents/service", () => {
         },
       },
     });
+    const writeEnvFile = vi.fn();
+    const clawCmd = vi.fn(async () => ({ ok: true, stdout: "", stderr: "" }));
     const service = createAgentsService({
       fs: fsMock,
       OPENCLAW_DIR: "/tmp/openclaw",
@@ -1339,21 +1341,71 @@ describe("server/agents/service", () => {
         { key: "SLACK_BOT_TOKEN", value: "xoxb-bot-token" },
         { key: "SLACK_APP_TOKEN", value: "xapp-app-token" },
       ]),
-      writeEnvFile: vi.fn(),
+      writeEnvFile,
       reloadEnv: vi.fn(),
-      clawCmd: vi.fn(async () => ({ ok: true, stdout: "", stderr: "" })),
+      clawCmd,
     });
 
-    await expect(
-      service.createChannelAccount({
-        provider: "slack",
-        name: "Slack 2",
-        accountId: "alerts",
-        token: "xoxb-bot-token-2",
-        appToken: "xapp-app-token-2",
+    const result = await service.createChannelAccount({
+      provider: "slack",
+      name: "Slack Alerts",
+      accountId: "alerts",
+      token: "xoxb-bot-token-2",
+      appToken: "xapp-app-token-2",
+      agentId: "main",
+    });
+
+    expect(result).toEqual({
+      channel: "slack",
+      account: {
+        id: "alerts",
+        name: "Slack Alerts",
+        envKey: "SLACK_BOT_TOKEN_ALERTS",
+      },
+      binding: {
         agentId: "main",
+        match: { channel: "slack", accountId: "alerts" },
+      },
+    });
+    expect(writeEnvFile).toHaveBeenCalledWith([
+      { key: "SLACK_BOT_TOKEN", value: "xoxb-bot-token" },
+      { key: "SLACK_APP_TOKEN", value: "xapp-app-token" },
+      { key: "SLACK_BOT_TOKEN_ALERTS", value: "xoxb-bot-token-2" },
+      { key: "SLACK_APP_TOKEN_ALERTS", value: "xapp-app-token-2" },
+    ]);
+    expect(clawCmd).toHaveBeenNthCalledWith(
+      1,
+      "channels add --channel 'slack' --account 'alerts' --name 'Slack Alerts' --bot-token 'xoxb-bot-token-2' --app-token 'xapp-app-token-2'",
+      { quiet: true, timeoutMs: 30000 },
+    );
+    expect(clawCmd).toHaveBeenNthCalledWith(
+      2,
+      "agents bind --agent 'main' --bind 'slack:alerts'",
+      { quiet: true, timeoutMs: 30000 },
+    );
+    expect(fsMock.readConfig()).toEqual(
+      expect.objectContaining({
+        channels: {
+          slack: {
+            enabled: true,
+            defaultAccount: "default",
+            accounts: {
+              default: {
+                botToken: "${SLACK_BOT_TOKEN}",
+                appToken: "${SLACK_APP_TOKEN}",
+                dmPolicy: "pairing",
+              },
+              alerts: {
+                name: "Slack Alerts",
+                botToken: "${SLACK_BOT_TOKEN_ALERTS}",
+                appToken: "${SLACK_APP_TOKEN_ALERTS}",
+                dmPolicy: "pairing",
+              },
+            },
+          },
+        },
       }),
-    ).rejects.toThrow("Slack supports a single channel account");
+    );
   });
 
   it("updates channel account name and bound agent", () => {
@@ -1735,6 +1787,58 @@ describe("server/agents/service", () => {
     });
   });
 
+  it("loads named slack channel bot and app tokens by provider/account id", () => {
+    const fsMock = buildFsMock({
+      initialConfig: {
+        agents: {
+          list: [{ id: "main", default: true }],
+        },
+        channels: {
+          slack: {
+            enabled: true,
+            defaultAccount: "default",
+            accounts: {
+              default: {
+                botToken: "${SLACK_BOT_TOKEN}",
+                appToken: "${SLACK_APP_TOKEN}",
+                name: "Slack",
+              },
+              alerts: {
+                botToken: "${SLACK_BOT_TOKEN_ALERTS}",
+                appToken: "${SLACK_APP_TOKEN_ALERTS}",
+                name: "Slack Alerts",
+              },
+            },
+          },
+        },
+      },
+    });
+    const service = createAgentsService({
+      fs: fsMock,
+      OPENCLAW_DIR: "/tmp/openclaw",
+      readEnvFile: vi.fn(() => [
+        { key: "SLACK_BOT_TOKEN", value: "xoxb-token-123" },
+        { key: "SLACK_APP_TOKEN", value: "xapp-token-123" },
+        { key: "SLACK_BOT_TOKEN_ALERTS", value: "xoxb-alerts-token" },
+        { key: "SLACK_APP_TOKEN_ALERTS", value: "xapp-alerts-token" },
+      ]),
+    });
+
+    const result = service.getChannelAccountToken({
+      provider: "slack",
+      accountId: "alerts",
+    });
+
+    expect(result).toEqual({
+      provider: "slack",
+      accountId: "alerts",
+      envKey: "SLACK_BOT_TOKEN_ALERTS",
+      token: "xoxb-alerts-token",
+      appEnvKey: "SLACK_APP_TOKEN_ALERTS",
+      appToken: "xapp-alerts-token",
+    });
+  });
+
   it("deletes channel accounts and removes their env entry", async () => {
     const fsMock = buildFsMock({
       initialConfig: {
@@ -2000,6 +2104,96 @@ describe("server/agents/service", () => {
     expect(result).toEqual({ ok: true });
     expect(writeEnvFile).toHaveBeenCalledWith([]);
     expect(reloadEnv).toHaveBeenCalled();
+  });
+
+  it("deletes named slack channel env vars and keeps default slack tokens", async () => {
+    const fsMock = buildFsMock({
+      initialConfig: {
+        agents: {
+          list: [{ id: "main", default: true }],
+        },
+        channels: {
+          slack: {
+            enabled: true,
+            defaultAccount: "default",
+            accounts: {
+              default: {
+                botToken: "${SLACK_BOT_TOKEN}",
+                appToken: "${SLACK_APP_TOKEN}",
+                name: "Slack",
+              },
+              alerts: {
+                botToken: "${SLACK_BOT_TOKEN_ALERTS}",
+                appToken: "${SLACK_APP_TOKEN_ALERTS}",
+                name: "Slack Alerts",
+              },
+            },
+          },
+        },
+        bindings: [
+          {
+            agentId: "main",
+            match: { channel: "slack", accountId: "default" },
+          },
+          {
+            agentId: "main",
+            match: { channel: "slack", accountId: "alerts" },
+          },
+        ],
+      },
+    });
+    const readEnvFile = vi.fn(() => [
+      { key: "SLACK_BOT_TOKEN", value: "xoxb-token" },
+      { key: "SLACK_APP_TOKEN", value: "xapp-token" },
+      { key: "SLACK_BOT_TOKEN_ALERTS", value: "xoxb-alerts-token" },
+      { key: "SLACK_APP_TOKEN_ALERTS", value: "xapp-alerts-token" },
+    ]);
+    const writeEnvFile = vi.fn();
+    const reloadEnv = vi.fn();
+    const clawCmd = vi.fn(async () => ({ ok: true, stdout: "", stderr: "" }));
+    const service = createAgentsService({
+      fs: fsMock,
+      OPENCLAW_DIR: "/tmp/openclaw",
+      readEnvFile,
+      writeEnvFile,
+      reloadEnv,
+      clawCmd,
+    });
+
+    const result = await service.deleteChannelAccount({
+      provider: "slack",
+      accountId: "alerts",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(writeEnvFile).toHaveBeenCalledWith([
+      { key: "SLACK_BOT_TOKEN", value: "xoxb-token" },
+      { key: "SLACK_APP_TOKEN", value: "xapp-token" },
+    ]);
+    expect(reloadEnv).toHaveBeenCalled();
+    expect(fsMock.readConfig()).toEqual(
+      expect.objectContaining({
+        channels: {
+          slack: {
+            enabled: true,
+            defaultAccount: "default",
+            accounts: {
+              default: {
+                botToken: "${SLACK_BOT_TOKEN}",
+                appToken: "${SLACK_APP_TOKEN}",
+                name: "Slack",
+              },
+            },
+          },
+        },
+        bindings: [
+          {
+            agentId: "main",
+            match: { channel: "slack", accountId: "default" },
+          },
+        ],
+      }),
+    );
   });
 
   it("overwrites orphaned env var when channel is not in config", async () => {

--- a/tests/server/watchdog-notify.test.js
+++ b/tests/server/watchdog-notify.test.js
@@ -1,0 +1,159 @@
+const path = require("path");
+
+const { createWatchdogNotifier } = require("../../lib/server/watchdog-notify");
+
+const buildCredentialsFsMock = (entries = {}) => {
+  const credentialsDir = "/tmp/openclaw/credentials";
+  const files = new Map(
+    Object.entries(entries).map(([fileName, allowFrom]) => [
+      path.join(credentialsDir, fileName),
+      JSON.stringify({ allowFrom }),
+    ]),
+  );
+
+  return {
+    existsSync: vi.fn((targetPath) => {
+      const normalizedTargetPath = String(targetPath || "");
+      return normalizedTargetPath === credentialsDir || files.has(normalizedTargetPath);
+    }),
+    readdirSync: vi.fn((targetPath) => {
+      if (String(targetPath || "") !== credentialsDir) return [];
+      return Array.from(files.keys()).map((filePath) => path.basename(filePath));
+    }),
+    readFileSync: vi.fn((targetPath) => {
+      const normalizedTargetPath = String(targetPath || "");
+      const value = files.get(normalizedTargetPath);
+      if (value === undefined) {
+        throw new Error(`Unexpected read: ${normalizedTargetPath}`);
+      }
+      return value;
+    }),
+  };
+};
+
+const buildSlackApiFactory = () => {
+  const clientsByToken = new Map();
+  const countersByToken = new Map();
+  const createSlackApi = vi.fn((getToken) => {
+    const token = typeof getToken === "function" ? getToken() : getToken;
+    if (clientsByToken.has(token)) {
+      return clientsByToken.get(token);
+    }
+    const client = {
+      postMessage: vi.fn(async (_userId, _text, _opts = {}) => {
+        const nextCount = Number(countersByToken.get(token) || 0) + 1;
+        countersByToken.set(token, nextCount);
+        return {
+          ts: `${token}-ts-${nextCount}`,
+          channel: `dm-${token}`,
+        };
+      }),
+      addReaction: vi.fn(async () => ({ ok: true })),
+    };
+    clientsByToken.set(token, client);
+    return client;
+  });
+
+  return {
+    createSlackApi,
+    clientsByToken,
+  };
+};
+
+describe("server/watchdog-notify", () => {
+  let consoleErrorSpy = null;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("sends Slack watchdog notifications across default and named accounts with isolated threads", async () => {
+    const fsMock = buildCredentialsFsMock({
+      "slack-default-allowFrom.json": ["U_SHARED_THREAD"],
+      "slack-alerts-allowFrom.json": ["U_SHARED_THREAD"],
+    });
+    const { createSlackApi, clientsByToken } = buildSlackApiFactory();
+    const notifier = createWatchdogNotifier({
+      fsImpl: fsMock,
+      openclawDir: "/tmp/openclaw",
+      readEnvFile: () => [
+        { key: "SLACK_BOT_TOKEN", value: "xoxb-default" },
+        { key: "SLACK_BOT_TOKEN_ALERTS", value: "xoxb-alerts" },
+      ],
+      createSlackApi,
+    });
+
+    const crashResult = await notifier.notify("Crash detected", {
+      eventType: "crash",
+    });
+    const recoveryResult = await notifier.notify("Recovered", {
+      eventType: "recovery",
+    });
+
+    expect(crashResult.channels.slack).toEqual({
+      sent: 2,
+      failed: 0,
+      skipped: false,
+      targets: 2,
+    });
+    expect(recoveryResult.channels.slack).toEqual({
+      sent: 2,
+      failed: 0,
+      skipped: false,
+      targets: 2,
+    });
+
+    const defaultClient = clientsByToken.get("xoxb-default");
+    const alertsClient = clientsByToken.get("xoxb-alerts");
+    expect(defaultClient.postMessage.mock.calls[0][2]).toEqual({
+      thread_ts: null,
+      mrkdwn: true,
+    });
+    expect(defaultClient.postMessage.mock.calls[1][2]).toEqual({
+      thread_ts: "xoxb-default-ts-1",
+      mrkdwn: true,
+    });
+    expect(alertsClient.postMessage.mock.calls[0][2]).toEqual({
+      thread_ts: null,
+      mrkdwn: true,
+    });
+    expect(alertsClient.postMessage.mock.calls[1][2]).toEqual({
+      thread_ts: "xoxb-alerts-ts-1",
+      mrkdwn: true,
+    });
+  });
+
+  it("reports partial Slack delivery failure when one account is missing a bot token", async () => {
+    const fsMock = buildCredentialsFsMock({
+      "slack-default-allowFrom.json": ["U_DEFAULT_OK"],
+      "slack-alerts-allowFrom.json": ["U_ALERTS_MISSING"],
+    });
+    const { createSlackApi, clientsByToken } = buildSlackApiFactory();
+    const notifier = createWatchdogNotifier({
+      fsImpl: fsMock,
+      openclawDir: "/tmp/openclaw",
+      readEnvFile: () => [{ key: "SLACK_BOT_TOKEN", value: "xoxb-default" }],
+      createSlackApi,
+    });
+
+    const result = await notifier.notify("Health check", {
+      eventType: "health",
+    });
+
+    expect(result.channels.slack).toEqual({
+      sent: 1,
+      failed: 1,
+      skipped: false,
+      targets: 2,
+    });
+    expect(createSlackApi).toHaveBeenCalledTimes(1);
+    expect(Array.from(clientsByToken.keys())).toEqual(["xoxb-default"]);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[watchdog] slack notification failed for alerts/U_ALERTS_MISSING: missing SLACK_BOT_TOKEN_ALERTS",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add multi-account Slack account support to the shared channel account flow
- improve Slack setup UX with manifest/manual guidance, token tab instructions, and modal scrolling fixes
- update watchdog Slack delivery and add coverage for the new Slack account behavior

## Testing
- npm test -- tests/server/agents-service.test.js tests/server/watchdog-notify.test.js tests/frontend/channel-provider-availability.test.js tests/server/routes-agents.test.js tests/server/routes-watchdog-test-notification.test.js
- npm run build:ui