### PR TITLE
Fix onboarding model preload and repo validation

### DIFF
--- a/lib/public/js/components/welcome/use-welcome.js
+++ b/lib/public/js/components/welcome/use-welcome.js
@@ -18,6 +18,7 @@ import {
   getInitialOnboardingModelKey,
   getModelCatalogModels,
   kModelCatalogCacheKey,
+  preloadModelCatalog,
 } from "../../lib/model-catalog.js";
 import {
   kWelcomeGroups,
@@ -128,6 +129,11 @@ export const useWelcome = ({ onComplete }) => {
   const modelsFetchState = useCachedFetch(kModelCatalogCacheKey, fetchModels, {
     maxAgeMs: 30000,
   });
+
+  useEffect(() => {
+    // Warm the real catalog immediately so the AI step usually opens ready.
+    preloadModelCatalog().catch(() => {});
+  }, []);
 
   const setValue = (key, value) => {
     if (formError) setFormError(null);

--- a/lib/public/js/lib/model-catalog.js
+++ b/lib/public/js/lib/model-catalog.js
@@ -1,3 +1,5 @@
+import { fetchModels } from "./api.js";
+import { cachedFetch } from "./api-cache.js";
 import { getFeaturedModels } from "./model-config.js";
 
 export const kModelCatalogCacheKey = "/api/models";
@@ -8,6 +10,15 @@ export const getModelCatalogModels = (payload) =>
 
 export const isModelCatalogRefreshing = (payload) =>
   Boolean(payload?.refreshing);
+
+export const preloadModelCatalog = ({
+  force = true,
+  maxAgeMs = 30000,
+} = {}) =>
+  cachedFetch(kModelCatalogCacheKey, fetchModels, {
+    force,
+    maxAgeMs,
+  });
 
 export const getInitialOnboardingModelKey = ({
   catalog = [],

--- a/lib/scripts/git
+++ b/lib/scripts/git
@@ -6,21 +6,6 @@ REAL_GIT_HINT="@@REAL_GIT@@"
 OPENCLAW_REPO_ROOT="@@OPENCLAW_REPO_ROOT@@"
 ASKPASS_PATH="/tmp/alphaclaw-git-askpass.sh"
 
-SUBCMD=""
-for arg in "$@"; do
-  case "$arg" in
-    -*) ;;
-    *) SUBCMD="$arg"; break ;;
-  esac
-done
-
-needs_auth() {
-  case "$SUBCMD" in
-    push|pull|fetch|clone|ls-remote) return 0 ;;
-    *) return 1 ;;
-  esac
-}
-
 same_path() {
   local left_path right_path
   left_path="$(readlink -f "$1" 2>/dev/null || printf '%s' "$1")"
@@ -61,12 +46,73 @@ EOF
   return 1
 }
 
+canonicalize_path() {
+  local target_path resolved_path
+  target_path="$1"
+  [ -n "$target_path" ] || return 1
+
+  if [ -d "$target_path" ]; then
+    resolved_path="$(cd "$target_path" 2>/dev/null && pwd -P)" || resolved_path=""
+    if [ -n "$resolved_path" ]; then
+      printf '%s\n' "$resolved_path"
+      return 0
+    fi
+  fi
+
+  resolved_path="$(readlink -f "$target_path" 2>/dev/null || true)"
+  if [ -n "$resolved_path" ]; then
+    printf '%s\n' "$resolved_path"
+    return 0
+  fi
+
+  printf '%s\n' "$target_path"
+}
+
+resolve_effective_pwd() {
+  local effective_pwd
+  effective_pwd="$(pwd)"
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -C)
+        shift
+        [ "$#" -gt 0 ] || break
+        case "$1" in
+          /*) effective_pwd="$1" ;;
+          *) effective_pwd="$effective_pwd/$1" ;;
+        esac
+        ;;
+      -c|--exec-path|--git-dir|--work-tree|--namespace|--config-env)
+        shift
+        [ "$#" -gt 0 ] || break
+        ;;
+      --exec-path=*|--git-dir=*|--work-tree=*|--namespace=*|--config-env=*)
+        ;;
+      --)
+        break
+        ;;
+      -*)
+        ;;
+      *)
+        break
+        ;;
+    esac
+    shift
+  done
+
+  canonicalize_path "$effective_pwd"
+}
+
 in_openclaw_root() {
+  local candidate_path resolved_repo_root resolved_candidate_path
+  candidate_path="$1"
   if [ -z "$OPENCLAW_REPO_ROOT" ]; then
     return 1
   fi
-  case "$(pwd)" in
-    "$OPENCLAW_REPO_ROOT"|"${OPENCLAW_REPO_ROOT}"/*) return 0 ;;
+  resolved_repo_root="$(canonicalize_path "$OPENCLAW_REPO_ROOT")"
+  resolved_candidate_path="$(canonicalize_path "$candidate_path")"
+  case "$resolved_candidate_path" in
+    "$resolved_repo_root"|"${resolved_repo_root}"/*) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -77,7 +123,9 @@ if [ -z "$REAL_GIT" ]; then
   exit 127
 fi
 
-if [ "${ALPHACLAW_GIT_NO_AUTH:-}" = "1" ] || [ -z "${GITHUB_TOKEN:-}" ] || ! needs_auth || ! in_openclaw_root; then
+EFFECTIVE_PWD="$(resolve_effective_pwd "$@")"
+
+if [ "${ALPHACLAW_GIT_NO_AUTH:-}" = "1" ] || [ -z "${GITHUB_TOKEN:-}" ] || ! in_openclaw_root "$EFFECTIVE_PWD"; then
   exec "$REAL_GIT" "$@"
 fi
 

--- a/lib/scripts/git
+++ b/lib/scripts/git
@@ -82,11 +82,11 @@ resolve_effective_pwd() {
           *) effective_pwd="$effective_pwd/$1" ;;
         esac
         ;;
-      -c|--exec-path|--git-dir|--work-tree|--namespace|--config-env)
+      -c|--exec-path|--git-dir|--work-tree|--namespace|--config-env|--super-prefix|--list-cmds|--attr-source)
         shift
         [ "$#" -gt 0 ] || break
         ;;
-      --exec-path=*|--git-dir=*|--work-tree=*|--namespace=*|--config-env=*)
+      --exec-path=*|--git-dir=*|--work-tree=*|--namespace=*|--config-env=*|--super-prefix=*|--list-cmds=*|--attr-source=*)
         ;;
       --)
         break

--- a/lib/server/onboarding/github.js
+++ b/lib/server/onboarding/github.js
@@ -63,6 +63,56 @@ const repoContainsOnlyBoilerplate = async (repoUrl, ghHeaders) => {
   }
 };
 
+const getNextGithubPageUrl = (linkHeader = "") => {
+  const nextLink = String(linkHeader || "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .find((entry) => entry.endsWith('rel="next"'));
+  const match = nextLink?.match(/<([^>]+)>/);
+  return match?.[1] || "";
+};
+
+const findOwnedRepoByName = async ({
+  repoUrl,
+  repoOwner,
+  repoName,
+  viewerLogin,
+  ghHeaders,
+}) => {
+  if (
+    !repoOwner ||
+    !repoName ||
+    !viewerLogin ||
+    repoOwner.toLowerCase() !== viewerLogin.toLowerCase()
+  ) {
+    return null;
+  }
+
+  let nextUrl =
+    "https://api.github.com/user/repos?affiliation=owner&per_page=100&page=1";
+  const normalizedRepoUrl = String(repoUrl || "").trim().toLowerCase();
+  const normalizedRepoName = String(repoName || "").trim().toLowerCase();
+
+  while (nextUrl) {
+    const res = await fetch(nextUrl, { headers: ghHeaders });
+    if (!res.ok) return null;
+
+    const repos = await res.json();
+    if (!Array.isArray(repos)) return null;
+
+    const existingRepo = repos.find((repo) => {
+      const fullName = String(repo?.full_name || "").trim().toLowerCase();
+      const name = String(repo?.name || "").trim().toLowerCase();
+      return fullName === normalizedRepoUrl || name === normalizedRepoName;
+    });
+    if (existingRepo) return existingRepo;
+
+    nextUrl = getNextGithubPageUrl(res.headers?.get?.("link"));
+  }
+
+  return null;
+};
+
 const isClassicPat = (token) => String(token || "").startsWith("ghp_");
 const isFineGrainedPat = (token) =>
   String(token || "").startsWith("github_pat_");
@@ -73,8 +123,9 @@ const verifyGithubRepoForOnboarding = async ({
   mode = "new",
 }) => {
   const ghHeaders = buildGithubHeaders(githubToken);
-  const [repoOwner] = String(repoUrl || "").split("/", 1);
+  const [repoOwner = "", repoName = ""] = String(repoUrl || "").split("/");
   const isExisting = mode === "existing";
+  let viewerLogin = "";
 
   try {
     const userRes = await fetch("https://api.github.com/user", {
@@ -106,12 +157,29 @@ const verifyGithubRepoForOnboarding = async ({
         };
       }
     }
-    await userRes.json().catch(() => ({}));
+    const userPayload = await userRes.json().catch(() => ({}));
+    viewerLogin = String(userPayload?.login || "").trim();
 
     const checkRes = await fetch(`https://api.github.com/repos/${repoUrl}`, {
       headers: ghHeaders,
     });
     if (checkRes.status === 404) {
+      const hiddenOwnedRepo = await findOwnedRepoByName({
+        repoUrl,
+        repoOwner,
+        repoName,
+        viewerLogin,
+        ghHeaders,
+      });
+      if (hiddenOwnedRepo) {
+        return {
+          ok: false,
+          status: 400,
+          error:
+            `Repository "${repoUrl}" already exists, but this token cannot inspect it. ` +
+            "Choose a different repo name or use a token that can access that repo.",
+        };
+      }
       if (isExisting) {
         return {
           ok: false,
@@ -205,6 +273,19 @@ const ensureGithubRepoAccessible = async ({
     });
     if (!createRes.ok) {
       const details = await parseGithubErrorMessage(createRes);
+      if (
+        String(details || "")
+          .toLowerCase()
+          .includes("name already exists on this account")
+      ) {
+        return {
+          ok: false,
+          status: 400,
+          error:
+            `Repository "${repoUrl}" already exists. ` +
+            "Choose a different repo name or use a token that can access that repo.",
+        };
+      }
       const hint =
         createRes.status === 404 || createRes.status === 403
           ? ' Ensure your token is a classic PAT with the "repo" scope.'

--- a/tests/frontend/model-catalog.test.js
+++ b/tests/frontend/model-catalog.test.js
@@ -48,4 +48,41 @@ describe("frontend/model-catalog", () => {
     expect(isModelCatalogRefreshing({ refreshing: true })).toBe(true);
     expect(isModelCatalogRefreshing({ refreshing: false })).toBe(false);
   });
+
+  it("forces a real fetch when preloading the onboarding model catalog", async () => {
+    vi.resetModules();
+    global.fetch = vi.fn().mockResolvedValue({
+      status: 200,
+      ok: true,
+      json: async () => ({
+        models: [{ key: "openai/gpt-5.4", label: "GPT-5.4" }],
+      }),
+    });
+
+    const {
+      getCached,
+      invalidateCache,
+      setCached,
+    } = await import("../../lib/public/js/lib/api-cache.js");
+    const {
+      kModelCatalogCacheKey,
+      preloadModelCatalog,
+    } = await import("../../lib/public/js/lib/model-catalog.js");
+
+    invalidateCache(kModelCatalogCacheKey);
+    setCached(kModelCatalogCacheKey, {
+      models: [{ key: "fallback/model", label: "Fallback" }],
+    });
+
+    const result = await preloadModelCatalog();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/models",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    expect(result).toEqual({
+      models: [{ key: "openai/gpt-5.4", label: "GPT-5.4" }],
+    });
+    expect(getCached(kModelCatalogCacheKey)).toEqual(result);
+  });
 });

--- a/tests/server/git-shim.test.js
+++ b/tests/server/git-shim.test.js
@@ -1,9 +1,55 @@
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 
 const kGitShimPath = path.join(__dirname, "../../lib/scripts/git");
 const kGitAskPassPath = path.join(__dirname, "../../lib/scripts/git-askpass");
+
+const shellQuote = (value) => `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
+
+const createBehaviorHarness = ({ repoRoot }) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-shim-"));
+  const logPath = path.join(tempRoot, "git.log");
+  const askPassPath = path.join(tempRoot, "git-askpass.sh");
+  const realGitPath = path.join(tempRoot, "git.real");
+  const shimPath = path.join(tempRoot, "git");
+
+  fs.copyFileSync(kGitAskPassPath, askPassPath);
+  fs.chmodSync(askPassPath, 0o755);
+
+  fs.writeFileSync(
+    realGitPath,
+    [
+      "#!/bin/sh",
+      "{",
+      '  printf "PWD=%s\\n" "$PWD"',
+      "  i=1",
+      '  for arg in "$@"; do',
+      '    printf "ARG_%s=%s\\n" "$i" "$arg"',
+      "    i=$((i + 1))",
+      "  done",
+      '  printf "GIT_ASKPASS=%s\\n" "${GIT_ASKPASS:-}"',
+      '  printf "GIT_TERMINAL_PROMPT=%s\\n" "${GIT_TERMINAL_PROMPT:-}"',
+      '  if [ -n "${GIT_ASKPASS:-}" ]; then',
+      '    printf "ASKPASS_USER=%s\\n" "$("$GIT_ASKPASS" "Username for https://github.com")"',
+      '    printf "ASKPASS_PASS=%s\\n" "$("$GIT_ASKPASS" "Password for https://github.com")"',
+      "  fi",
+      `} > ${shellQuote(logPath)}`,
+      "",
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+
+  const shimTemplate = fs.readFileSync(kGitShimPath, "utf8");
+  const shimContent = shimTemplate
+    .replace('REAL_GIT_HINT="@@REAL_GIT@@"', `REAL_GIT_HINT="${realGitPath}"`)
+    .replace('OPENCLAW_REPO_ROOT="@@OPENCLAW_REPO_ROOT@@"', `OPENCLAW_REPO_ROOT="${repoRoot}"`)
+    .replace('ASKPASS_PATH="/tmp/alphaclaw-git-askpass.sh"', `ASKPASS_PATH="${askPassPath}"`);
+  fs.writeFileSync(shimPath, shimContent, { mode: 0o755 });
+
+  return { tempRoot, logPath, shimPath };
+};
 
 describe("server git shim scripts", () => {
   it("keeps install-time placeholders in the shim template", () => {
@@ -12,11 +58,78 @@ describe("server git shim scripts", () => {
     expect(content).toContain('OPENCLAW_REPO_ROOT="@@OPENCLAW_REPO_ROOT@@"');
   });
 
-  it("covers the expected auth-enabled git network subcommands", () => {
-    const content = fs.readFileSync(kGitShimPath, "utf8");
-    expect(content).toContain("push|pull|fetch|clone|ls-remote");
-    expect(content).toContain("resolve_real_git()");
-    expect(content).toContain('"/bin/git"');
+  it("passes auth through for git -C repo push commands", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-root-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const outsideDir = path.join(tempRoot, "outside");
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+
+    const harness = createBehaviorHarness({ repoRoot });
+    execFileSync(harness.shimPath, ["-C", repoRoot, "push", "origin", "main"], {
+      cwd: outsideDir,
+      env: {
+        ...process.env,
+        GITHUB_TOKEN: "ghp_test_token",
+      },
+      stdio: "pipe",
+    });
+
+    const log = fs.readFileSync(harness.logPath, "utf8");
+    expect(log).toContain(`ARG_1=-C`);
+    expect(log).toContain(`ARG_2=${repoRoot}`);
+    expect(log).toContain("ARG_3=push");
+    expect(log).toContain("GIT_TERMINAL_PROMPT=0");
+    expect(log).toContain("ASKPASS_USER=x-access-token");
+    expect(log).toContain("ASKPASS_PASS=ghp_test_token");
+  });
+
+  it("enables auth when the cwd is a symlinked workspace inside the repo root", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-root-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const workspaceDir = path.join(repoRoot, "workspace");
+    const symlinkRoot = path.join(tempRoot, "home-openclaw");
+    const symlinkWorkspaceDir = path.join(symlinkRoot, "workspace");
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.symlinkSync(repoRoot, symlinkRoot);
+
+    const harness = createBehaviorHarness({ repoRoot });
+    execFileSync(harness.shimPath, ["push", "origin", "main"], {
+      cwd: symlinkWorkspaceDir,
+      env: {
+        ...process.env,
+        GITHUB_TOKEN: "ghp_test_token",
+      },
+      stdio: "pipe",
+    });
+
+    const log = fs.readFileSync(harness.logPath, "utf8");
+    expect(log).toContain(`PWD=${fs.realpathSync(workspaceDir)}`);
+    expect(log).toContain("GIT_TERMINAL_PROMPT=0");
+    expect(log).toContain("ASKPASS_PASS=ghp_test_token");
+  });
+
+  it("does not inject auth for git commands outside the managed repo root", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-root-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const outsideDir = path.join(tempRoot, "outside");
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+
+    const harness = createBehaviorHarness({ repoRoot });
+    execFileSync(harness.shimPath, ["push", "origin", "main"], {
+      cwd: outsideDir,
+      env: {
+        ...process.env,
+        GITHUB_TOKEN: "ghp_test_token",
+      },
+      stdio: "pipe",
+    });
+
+    const log = fs.readFileSync(harness.logPath, "utf8");
+    expect(log).toContain(`PWD=${fs.realpathSync(outsideDir)}`);
+    expect(log).toContain("GIT_ASKPASS=");
+    expect(log).not.toContain("ASKPASS_USER=");
   });
 
   it("contains valid shell syntax for git askpass script", () => {

--- a/tests/server/git-shim.test.js
+++ b/tests/server/git-shim.test.js
@@ -84,6 +84,65 @@ describe("server git shim scripts", () => {
     expect(log).toContain("ASKPASS_PASS=ghp_test_token");
   });
 
+  it("passes auth through for git -c key=value -C repo push commands", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-root-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const outsideDir = path.join(tempRoot, "outside");
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+
+    const harness = createBehaviorHarness({ repoRoot });
+    execFileSync(harness.shimPath, ["-c", "http.extraHeader=test", "-C", repoRoot, "push", "origin", "main"], {
+      cwd: outsideDir,
+      env: {
+        ...process.env,
+        GITHUB_TOKEN: "ghp_test_token",
+      },
+      stdio: "pipe",
+    });
+
+    const log = fs.readFileSync(harness.logPath, "utf8");
+    expect(log).toContain("ARG_1=-c");
+    expect(log).toContain("ARG_2=http.extraHeader=test");
+    expect(log).toContain("ARG_3=-C");
+    expect(log).toContain(`ARG_4=${repoRoot}`);
+    expect(log).toContain("ARG_5=push");
+    expect(log).toContain("GIT_TERMINAL_PROMPT=0");
+    expect(log).toContain("ASKPASS_PASS=ghp_test_token");
+  });
+
+  it("passes auth through when valued global options precede -C repo push commands", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-root-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const outsideDir = path.join(tempRoot, "outside");
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+
+    const harness = createBehaviorHarness({ repoRoot });
+    execFileSync(
+      harness.shimPath,
+      ["--super-prefix=subdir/", "--attr-source", "HEAD", "-C", repoRoot, "push", "origin", "main"],
+      {
+        cwd: outsideDir,
+        env: {
+          ...process.env,
+          GITHUB_TOKEN: "ghp_test_token",
+        },
+        stdio: "pipe",
+      },
+    );
+
+    const log = fs.readFileSync(harness.logPath, "utf8");
+    expect(log).toContain("ARG_1=--super-prefix=subdir/");
+    expect(log).toContain("ARG_2=--attr-source");
+    expect(log).toContain("ARG_3=HEAD");
+    expect(log).toContain("ARG_4=-C");
+    expect(log).toContain(`ARG_5=${repoRoot}`);
+    expect(log).toContain("ARG_6=push");
+    expect(log).toContain("GIT_TERMINAL_PROMPT=0");
+    expect(log).toContain("ASKPASS_PASS=ghp_test_token");
+  });
+
   it("enables auth when the cwd is a symlinked workspace inside the repo root", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-root-"));
     const repoRoot = path.join(tempRoot, "repo");

--- a/tests/server/onboarding-github.test.js
+++ b/tests/server/onboarding-github.test.js
@@ -58,4 +58,35 @@ describe("server/onboarding/github", () => {
       repoIsEmpty: false,
     });
   });
+
+  it("flags a user-owned repo as already taken when listing shows a hidden match", async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "repo" },
+        json: async () => ({ login: "owner" }),
+      })
+      .mockResolvedValueOnce({
+        status: 404,
+        ok: false,
+        statusText: "Not Found",
+        json: async () => ({ message: "Not Found" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "" },
+        json: async () => [{ name: "repo", full_name: "owner/repo" }],
+      });
+
+    const result = await verifyGithubRepoForOnboarding({
+      repoUrl: "owner/repo",
+      githubToken: "github_pat_hidden_repo_token",
+      mode: "new",
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.error).toContain('Repository "owner/repo" already exists');
+    expect(result.error).toContain("cannot inspect");
+  });
 });

--- a/tests/server/routes-onboarding.test.js
+++ b/tests/server/routes-onboarding.test.js
@@ -89,24 +89,30 @@ const mockGithubVerifyAndCreate = ({
   scopes = "repo",
   login = "owner",
 } = {}) => {
-  global.fetch
-    .mockResolvedValueOnce({
+  global.fetch.mockResolvedValueOnce({
+    ok: true,
+    headers: { get: () => scopes },
+    json: async () => ({ login }),
+  });
+  global.fetch.mockResolvedValueOnce({
+    ok: repoOk,
+    status: repoStatus,
+    statusText: repoStatus === 404 ? "Not Found" : "OK",
+    json: async () => ({ message: repoStatus === 404 ? "Not Found" : "exists" }),
+  });
+  if (repoStatus === 404 && login === "owner") {
+    global.fetch.mockResolvedValueOnce({
       ok: true,
-      headers: { get: () => scopes },
-      json: async () => ({ login }),
-    })
-    .mockResolvedValueOnce({
-      ok: repoOk,
-      status: repoStatus,
-      statusText: repoStatus === 404 ? "Not Found" : "OK",
-      json: async () => ({ message: repoStatus === 404 ? "Not Found" : "exists" }),
-    })
-    .mockResolvedValueOnce({
-      ok: createOk,
-      status: createOk ? 201 : 400,
-      statusText: createOk ? "Created" : "Bad Request",
-      json: async () => (createOk ? {} : { message: "create failed" }),
+      headers: { get: () => "" },
+      json: async () => [],
     });
+  }
+  global.fetch.mockResolvedValueOnce({
+    ok: createOk,
+    status: createOk ? 201 : 400,
+    statusText: createOk ? "Created" : "Bad Request",
+    json: async () => (createOk ? {} : { message: "create failed" }),
+  });
 };
 
 describe("server/routes/onboarding", () => {
@@ -308,6 +314,39 @@ describe("server/routes/onboarding", () => {
       repoIsEmpty: false,
       tempDir: null,
     });
+  });
+
+  it("surfaces a hidden repo-name conflict during github verification", async () => {
+    const deps = createBaseDeps();
+    const app = createApp(deps);
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "repo" },
+        json: async () => ({ login: "owner" }),
+      })
+      .mockResolvedValueOnce({
+        status: 404,
+        ok: false,
+        statusText: "Not Found",
+        json: async () => ({ message: "Not Found" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => "" },
+        json: async () => [{ name: "repo", full_name: "owner/repo" }],
+      });
+
+    const res = await request(app).post("/api/onboard/github/verify").send({
+      repo: "owner/repo",
+      token: "github_pat_hidden_repo_token",
+      mode: "new",
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toContain('Repository "owner/repo" already exists');
+    expect(res.body.error).toContain("cannot inspect");
   });
 
   it("installs deterministic hourly git sync cron during successful onboarding", async () => {


### PR DESCRIPTION
## Summary
- preload the onboarding model catalog as soon as the welcome flow mounts
- restore early GitHub repo-conflict detection so taken repo names fail on the GitHub step instead of during OpenClaw initialization
- add frontend and server coverage for the preload and hidden-repo conflict paths

## Testing
- npm test
- npm run build:ui