### PR TITLE
Fix git auth shim handling for global git options

### DIFF
--- a/lib/scripts/git
+++ b/lib/scripts/git
@@ -7,12 +7,61 @@ OPENCLAW_REPO_ROOT="@@OPENCLAW_REPO_ROOT@@"
 ASKPASS_PATH="/tmp/alphaclaw-git-askpass.sh"
 
 SUBCMD=""
-for arg in "$@"; do
-  case "$arg" in
-    -*) ;;
-    *) SUBCMD="$arg"; break ;;
-  esac
-done
+EFFECTIVE_CWD="$(pwd -P 2>/dev/null || pwd)"
+
+resolve_effective_cwd() {
+  local base_dir target_dir
+  base_dir="$1"
+  target_dir="$2"
+  (
+    cd "$base_dir" 2>/dev/null || exit 1
+    cd "$target_dir" 2>/dev/null || exit 1
+    pwd -P
+  )
+}
+
+parse_invocation() {
+  local expect_value=""
+  local arg resolved_dir
+
+  for arg in "$@"; do
+    if [ -n "$expect_value" ]; then
+      case "$expect_value" in
+        chdir)
+          resolved_dir="$(resolve_effective_cwd "$EFFECTIVE_CWD" "$arg" || true)"
+          [ -n "$resolved_dir" ] && EFFECTIVE_CWD="$resolved_dir"
+          ;;
+        skip)
+          ;;
+      esac
+      expect_value=""
+      continue
+    fi
+
+    case "$arg" in
+      -C)
+        expect_value="chdir"
+        ;;
+      -c|--exec-path|--git-dir|--work-tree|--namespace|--super-prefix|--config-env|--list-cmds|--attr-source)
+        expect_value="skip"
+        ;;
+      --exec-path=*|--git-dir=*|--work-tree=*|--namespace=*|--super-prefix=*|--config-env=*|--list-cmds=*|--attr-source=*)
+        ;;
+      --)
+        SUBCMD=""
+        break
+        ;;
+      -*)
+        ;;
+      *)
+        SUBCMD="$arg"
+        break
+        ;;
+    esac
+  done
+}
+
+parse_invocation "$@"
 
 needs_auth() {
   case "$SUBCMD" in
@@ -65,7 +114,7 @@ in_openclaw_root() {
   if [ -z "$OPENCLAW_REPO_ROOT" ]; then
     return 1
   fi
-  case "$(pwd)" in
+  case "$EFFECTIVE_CWD" in
     "$OPENCLAW_REPO_ROOT"|"${OPENCLAW_REPO_ROOT}"/*) return 0 ;;
     *) return 1 ;;
   esac

--- a/tests/server/git-shim.test.js
+++ b/tests/server/git-shim.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const { execFileSync } = require("child_process");
 
@@ -24,5 +25,88 @@ describe("server git shim scripts", () => {
     const content = fs.readFileSync(kGitAskPassPath, "utf8");
     expect(content).toContain("*Username*)");
     expect(content).toContain("*Password*)");
+  });
+
+  it("injects auth for git -C <repo> push even when called from outside the repo", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-shim-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const outsideDir = path.join(tempRoot, "outside");
+    const fakeGitPath = path.join(tempRoot, "git-real.sh");
+    const shimPath = path.join(tempRoot, "git-shim.sh");
+
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(
+      fakeGitPath,
+      [
+        "#!/bin/sh",
+        'printf "ASKPASS=%s\\n" "${GIT_ASKPASS:-}"',
+        'printf "PROMPT=%s\\n" "${GIT_TERMINAL_PROMPT:-}"',
+        'printf "PWD=%s\\n" "$(pwd)"',
+        'printf "ARGS=%s\\n" "$*"',
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const shimTemplate = fs.readFileSync(kGitShimPath, "utf8");
+    fs.writeFileSync(
+      shimPath,
+      shimTemplate.replace("@@OPENCLAW_REPO_ROOT@@", repoRoot),
+      { mode: 0o755 },
+    );
+
+    const output = execFileSync(shimPath, ["-C", repoRoot, "push", "origin", "main"], {
+      cwd: outsideDir,
+      env: {
+        ...process.env,
+        GITHUB_TOKEN: "test-token",
+        ALPHACLAW_REAL_GIT: fakeGitPath,
+      },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    expect(output).toContain("ASKPASS=/tmp/alphaclaw-git-askpass.sh");
+    expect(output).toContain("PROMPT=0");
+    expect(output).toContain(`ARGS=-C ${repoRoot} push origin main`);
+  });
+
+  it("injects auth for git -c key=value push inside the repo", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-shim-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const fakeGitPath = path.join(tempRoot, "git-real.sh");
+    const shimPath = path.join(tempRoot, "git-shim.sh");
+
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.writeFileSync(
+      fakeGitPath,
+      [
+        "#!/bin/sh",
+        'printf "ASKPASS=%s\\n" "${GIT_ASKPASS:-}"',
+        'printf "ARGS=%s\\n" "$*"',
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    const shimTemplate = fs.readFileSync(kGitShimPath, "utf8");
+    fs.writeFileSync(
+      shimPath,
+      shimTemplate.replace("@@OPENCLAW_REPO_ROOT@@", repoRoot),
+      { mode: 0o755 },
+    );
+
+    const output = execFileSync(shimPath, ["-c", "http.extraHeader=test", "push", "origin", "main"], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GITHUB_TOKEN: "test-token",
+        ALPHACLAW_REAL_GIT: fakeGitPath,
+      },
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    expect(output).toContain("ASKPASS=/tmp/alphaclaw-git-askpass.sh");
+    expect(output).toContain("ARGS=-c http.extraHeader=test push origin main");
   });
 });


### PR DESCRIPTION
## Summary
- fix the git auth shim so it keeps parsing past global options that take values, like `-C` and `-c`
- evaluate repo scope using the effective git working directory after applying `-C`
- add regression tests for `git -C <repo> push` and `git -c key=value push`

## Why
The shim currently treats the first non-dash argument as the subcommand. For commands like `git -C /data/.openclaw push origin main`, it mistakes `/data/.openclaw` for the subcommand, so auth never gets injected.

## Test
- `./node_modules/.bin/vitest run tests/server/git-shim.test.js`
- `sh -n lib/scripts/git`