### PR TITLE
Make managed OpenClaw plugin installs durable

### DIFF
--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -509,6 +509,7 @@ if (!kSetupPassword) {
 
 process.env.OPENCLAW_HOME = rootDir;
 process.env.OPENCLAW_CONFIG_PATH = path.join(openclawDir, "openclaw.json");
+process.env.OPENCLAW_STATE_DIR = openclawDir;
 process.env.GOG_KEYRING_PASSWORD =
   process.env.GOG_KEYRING_PASSWORD || "alphaclaw";
 

--- a/lib/server/gateway.js
+++ b/lib/server/gateway.js
@@ -45,6 +45,7 @@ const gatewayEnv = () => ({
   ...process.env,
   OPENCLAW_HOME: kRootDir,
   OPENCLAW_CONFIG_PATH: `${OPENCLAW_DIR}/openclaw.json`,
+  OPENCLAW_STATE_DIR: OPENCLAW_DIR,
   XDG_CONFIG_HOME: OPENCLAW_DIR,
 });
 

--- a/lib/server/model-catalog-cache.js
+++ b/lib/server/model-catalog-cache.js
@@ -123,7 +123,7 @@ const createModelCatalogCache = ({
   const loadFreshCatalog = async () => {
     const output = await shellCmd("openclaw models list --all --json", {
       env: gatewayEnv(),
-      timeout: 20000,
+      timeout: 30000,
     });
     const parsed = parseJsonFromNoisyOutput(output);
     const models = normalizeOnboardingModels(parsed?.models || []);

--- a/lib/server/onboarding/index.js
+++ b/lib/server/onboarding/index.js
@@ -495,6 +495,8 @@ const createOnboardingService = ({
             ...process.env,
             OPENCLAW_HOME: kRootDir,
             OPENCLAW_CONFIG_PATH: `${OPENCLAW_DIR}/openclaw.json`,
+            OPENCLAW_STATE_DIR: OPENCLAW_DIR,
+            XDG_CONFIG_HOME: OPENCLAW_DIR,
           },
           timeout: 120000,
         },

--- a/lib/setup/core-prompts/AGENTS.md
+++ b/lib/setup/core-prompts/AGENTS.md
@@ -25,6 +25,18 @@ If any of these apply, outline your approach first — what you intend to do, in
 
 Your `.openclaw` directory is version-controlled and this is how work survives container restarts.
 
+### Persistent Storage Rules
+
+This deployment runs in an ephemeral container. `/tmp`, other temp directories, and files outside `/data` can disappear on restart or redeploy.
+
+Anything that must survive redeploys must live under `/data/.openclaw`.
+
+For plugins and other durable artifacts:
+
+- Prefer normal `openclaw plugins install <spec>` flows for persistent installs.
+- If you must stage or unpack a local plugin first, stage it under `/data/.openclaw/...`, not `/tmp/...`.
+- Never persist `plugins.load.paths` entries that point at temp directories.
+
 Anytime you add, edit, or remove workspace files, openclaw.json, cron.json, skills, or external resources (third-party pages, databases, integrations), **commit and push your changes to git**. Never force push; always pull first if there might be remote changes.
 
 Whenever you do this, end your message with a **Changes committed** summary. Use workspace-relative paths for local files.

--- a/lib/setup/core-prompts/TOOLS.md
+++ b/lib/setup/core-prompts/TOOLS.md
@@ -21,6 +21,18 @@ Do not deflect actionable requests to the Setup UI. If a command or tool is avai
 
 Changes to env vars are made through the **Envars** tab (`{{SETUP_UI_URL}}#envars`). After saving, a gateway restart may be required to pick up the changes — the UI prompts for this automatically. Do not edit `/data/.env` directly; use the Setup UI so changes are validated and the gateway restart is handled.
 
+### Persistent storage
+
+This deployment runs in an ephemeral container. `/tmp` and other temp locations do not survive redeploys.
+
+Anything persistent must live under `/data/.openclaw`.
+
+For plugins and local tooling:
+
+- Prefer normal `openclaw plugins install <spec>` flows for durable installs.
+- If you need to stage a local plugin or helper files first, put them under `/data/.openclaw/...`, not `/tmp/...`.
+- Do not leave durable `plugins.load.paths` entries pointing at temp directories.
+
 ### Google Workspace
 
 Google Workspace is connected via the **General** tab (`{{SETUP_UI_URL}}#general`). The user provides OAuth client credentials from Google Cloud Console, then authorizes access to the services they need (Gmail, Calendar, Drive, Sheets, Docs, Tasks, Contacts, Meet). Connected accounts and `gog` CLI usage are covered by the gog-cli skill.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "express": "^4.21.0",
         "http-proxy": "^1.18.1",
-        "openclaw": "2026.4.9",
+        "openclaw": "2026.4.10",
         "patch-package": "^8.0.1",
         "ws": "^8.19.0"
       },
@@ -38,9 +38,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.18.0.tgz",
-      "integrity": "sha512-JQGEi3EetQ38DLPpYxxnnz1fyo1/3qQEkKfUmj4JfiOJCEtjGWQ0nl54IH4LZceO7zIOrtUUxc+2cJRQbBOChA==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.18.2.tgz",
+      "integrity": "sha512-l/o9NKvUc00GPa6RFJ4AccQq2O/PAf83xQ75mThHuL3H571iN4+PEdwnTBez67sS8Nv2aSA373xCZ5CbTXEwzA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.80.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
-      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
+      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@anthropic-ai/vertex-sdk": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.14.4.tgz",
-      "integrity": "sha512-BZUPRWghZxfSFtAxU563wH+jfWBPoedAwsVxG35FhmNsjeV8tyfN+lFriWhCpcZApxA4NdT6Soov+PzfnxxD5g==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.15.0.tgz",
+      "integrity": "sha512-i2LDdu6VB8Lqqip+kbNSXRxQgFsCg6GPBO/X2zRJwLl99dNzf28nb6Rdi0EodONXsyJfY2TKdGR+y5l1/AKFEg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": ">=0.50.3 <1",
@@ -229,49 +229,49 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1024.0.tgz",
-      "integrity": "sha512-rrnOL57KL/bL0uXYqCHpVj9eCpy+BUqEfoHCh2WKL7frCsfkMd2F23KdhBB8mxhChXTF2QsAOLrnfTBxQ1Hf9Q==",
+      "version": "3.1028.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock/-/client-bedrock-3.1028.0.tgz",
+      "integrity": "sha512-YEUikjoImgUjv2UEpnD/WP0JiLdoLRnkajnSQR9LPCa8+BGy3+j879jimPlAuypOux1/CgqMA7Fwt13IpF2+UA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/token-providers": "3.1024.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-node": "^3.972.30",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/token-providers": "3.1028.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -280,56 +280,56 @@
       }
     },
     "node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1024.0.tgz",
-      "integrity": "sha512-nIhsn0/eYrL2fTh4kMO7Hpfmhv+AkkXl0KGNpD6+fdmotGvRBWcDv9/PmP/+sT6gvrKTYyzH3vu4efpTPzzP0Q==",
+      "version": "3.1028.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1028.0.tgz",
+      "integrity": "sha512-FFdtkxWFmKX1Ka/vjDRKpYsm0/HTlab5qpHl8LAXRmJjhSSiLGiCnJYsYFN+zp3NucL02kM1DlpFU8Xnm7d8Ng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/credential-provider-node": "^3.972.29",
-        "@aws-sdk/eventstream-handler-node": "^3.972.12",
-        "@aws-sdk/middleware-eventstream": "^3.972.8",
-        "@aws-sdk/middleware-host-header": "^3.972.8",
-        "@aws-sdk/middleware-logger": "^3.972.8",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.9",
-        "@aws-sdk/middleware-user-agent": "^3.972.28",
-        "@aws-sdk/middleware-websocket": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.10",
-        "@aws-sdk/token-providers": "3.1024.0",
-        "@aws-sdk/types": "^3.973.6",
-        "@aws-sdk/util-endpoints": "^3.996.5",
-        "@aws-sdk/util-user-agent-browser": "^3.972.8",
-        "@aws-sdk/util-user-agent-node": "^3.973.14",
-        "@smithy/config-resolver": "^4.4.13",
-        "@smithy/core": "^3.23.13",
-        "@smithy/eventstream-serde-browser": "^4.2.12",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
-        "@smithy/eventstream-serde-node": "^4.2.12",
-        "@smithy/fetch-http-handler": "^5.3.15",
-        "@smithy/hash-node": "^4.2.12",
-        "@smithy/invalid-dependency": "^4.2.12",
-        "@smithy/middleware-content-length": "^4.2.12",
-        "@smithy/middleware-endpoint": "^4.4.28",
-        "@smithy/middleware-retry": "^4.4.46",
-        "@smithy/middleware-serde": "^4.2.16",
-        "@smithy/middleware-stack": "^4.2.12",
-        "@smithy/node-config-provider": "^4.3.12",
-        "@smithy/node-http-handler": "^4.5.1",
-        "@smithy/protocol-http": "^5.3.12",
-        "@smithy/smithy-client": "^4.12.8",
-        "@smithy/types": "^4.13.1",
-        "@smithy/url-parser": "^4.2.12",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/credential-provider-node": "^3.972.30",
+        "@aws-sdk/eventstream-handler-node": "^3.972.13",
+        "@aws-sdk/middleware-eventstream": "^3.972.9",
+        "@aws-sdk/middleware-host-header": "^3.972.9",
+        "@aws-sdk/middleware-logger": "^3.972.9",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.29",
+        "@aws-sdk/middleware-websocket": "^3.972.15",
+        "@aws-sdk/region-config-resolver": "^3.972.11",
+        "@aws-sdk/token-providers": "3.1028.0",
+        "@aws-sdk/types": "^3.973.7",
+        "@aws-sdk/util-endpoints": "^3.996.6",
+        "@aws-sdk/util-user-agent-browser": "^3.972.9",
+        "@aws-sdk/util-user-agent-node": "^3.973.15",
+        "@smithy/config-resolver": "^4.4.14",
+        "@smithy/core": "^3.23.14",
+        "@smithy/eventstream-serde-browser": "^4.2.13",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.13",
+        "@smithy/eventstream-serde-node": "^4.2.13",
+        "@smithy/fetch-http-handler": "^5.3.16",
+        "@smithy/hash-node": "^4.2.13",
+        "@smithy/invalid-dependency": "^4.2.13",
+        "@smithy/middleware-content-length": "^4.2.13",
+        "@smithy/middleware-endpoint": "^4.4.29",
+        "@smithy/middleware-retry": "^4.5.0",
+        "@smithy/middleware-serde": "^4.2.17",
+        "@smithy/middleware-stack": "^4.2.13",
+        "@smithy/node-config-provider": "^4.3.13",
+        "@smithy/node-http-handler": "^4.5.2",
+        "@smithy/protocol-http": "^5.3.13",
+        "@smithy/smithy-client": "^4.12.9",
+        "@smithy/types": "^4.14.0",
+        "@smithy/url-parser": "^4.2.13",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.44",
-        "@smithy/util-defaults-mode-node": "^4.2.48",
-        "@smithy/util-endpoints": "^3.3.3",
-        "@smithy/util-middleware": "^4.2.12",
-        "@smithy/util-retry": "^4.2.13",
-        "@smithy/util-stream": "^4.5.21",
+        "@smithy/util-defaults-mode-browser": "^4.3.45",
+        "@smithy/util-defaults-mode-node": "^4.2.49",
+        "@smithy/util-endpoints": "^3.3.4",
+        "@smithy/util-middleware": "^4.2.13",
+        "@smithy/util-retry": "^4.3.0",
+        "@smithy/util-stream": "^4.5.22",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -381,29 +381,6 @@
         "@smithy/util-middleware": "^4.2.13",
         "@smithy/util-retry": "^4.3.0",
         "@smithy/util-utf8": "^4.2.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
-        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -532,22 +509,22 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.29.tgz",
-      "integrity": "sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
+      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.24",
-        "@aws-sdk/credential-provider-http": "^3.972.26",
-        "@aws-sdk/credential-provider-ini": "^3.972.28",
-        "@aws-sdk/credential-provider-process": "^3.972.24",
-        "@aws-sdk/credential-provider-sso": "^3.972.28",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.28",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/credential-provider-imds": "^4.2.12",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/credential-provider-env": "^3.972.25",
+        "@aws-sdk/credential-provider-http": "^3.972.27",
+        "@aws-sdk/credential-provider-ini": "^3.972.29",
+        "@aws-sdk/credential-provider-process": "^3.972.25",
+        "@aws-sdk/credential-provider-sso": "^3.972.29",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/credential-provider-imds": "^4.2.13",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -650,29 +627,6 @@
         "@smithy/credential-provider-imds": "^4.2.13",
         "@smithy/node-config-provider": "^4.3.13",
         "@smithy/property-provider": "^4.2.13",
-        "@smithy/types": "^4.14.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.30.tgz",
-      "integrity": "sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.25",
-        "@aws-sdk/credential-provider-http": "^3.972.27",
-        "@aws-sdk/credential-provider-ini": "^3.972.29",
-        "@aws-sdk/credential-provider-process": "^3.972.25",
-        "@aws-sdk/credential-provider-sso": "^3.972.29",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.29",
-        "@aws-sdk/types": "^3.973.7",
-        "@smithy/credential-provider-imds": "^4.2.13",
-        "@smithy/property-provider": "^4.2.13",
-        "@smithy/shared-ini-file-loader": "^4.4.8",
         "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
@@ -863,17 +817,17 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1024.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1024.0.tgz",
-      "integrity": "sha512-eoyTMgd6OzoE1dq50um5Y53NrosEkWsjH0W6pswi7vrv1W9hY/7hR43jDcPevqqj+OQksf/5lc++FTqRlb8Y1Q==",
+      "version": "3.1028.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1028.0.tgz",
+      "integrity": "sha512-2vDFrEhJDlUHyvDxqDyOk97cejMM8GJDyQbFfOCEWclGwhTjlj1mdyj36xsxh7DYyuquhjqfbvhpl6ZzsVol0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.26",
-        "@aws-sdk/nested-clients": "^3.996.18",
-        "@aws-sdk/types": "^3.973.6",
-        "@smithy/property-provider": "^4.2.12",
-        "@smithy/shared-ini-file-loader": "^4.4.7",
-        "@smithy/types": "^4.13.1",
+        "@aws-sdk/core": "^3.973.27",
+        "@aws-sdk/nested-clients": "^3.996.19",
+        "@aws-sdk/types": "^3.973.7",
+        "@smithy/property-provider": "^4.2.13",
+        "@smithy/shared-ini-file-loader": "^4.4.8",
+        "@smithy/types": "^4.14.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1096,52 +1050,21 @@
       }
     },
     "node_modules/@buape/carbon": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@buape/carbon/-/carbon-0.14.0.tgz",
-      "integrity": "sha512-mavllPK2iVpRNRtC4C8JOUdJ1hdV0+LDelFW+pjpJaM31MBLMfIJ+f/LlYTIK5QrEcQsXOC+6lU2e0gmgjWhIQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@buape/carbon/-/carbon-0.15.0.tgz",
+      "integrity": "sha512-3V3XXIqtBzU5vSpCp4avX0RKbYyCIh493XDS/nRJvL7Num/9gB8Ylhd1ywt39gBGaNJScJW1hoWxRyN6Il6thw==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^25.0.9",
-        "discord-api-types": "0.38.37"
+        "@types/node": "^25.6.0",
+        "discord-api-types": "0.38.45"
       },
       "optionalDependencies": {
-        "@cloudflare/workers-types": "4.20260120.0",
-        "@discordjs/voice": "0.19.0",
-        "@hono/node-server": "1.19.9",
-        "@types/bun": "1.3.6",
+        "@cloudflare/workers-types": "4.20260405.1",
+        "@discordjs/voice": "0.19.2",
+        "@hono/node-server": "1.19.13",
+        "@types/bun": "1.3.11",
         "@types/ws": "8.18.1",
-        "ws": "8.19.0"
-      }
-    },
-    "node_modules/@buape/carbon/node_modules/discord-api-types": {
-      "version": "0.38.37",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.37.tgz",
-      "integrity": "sha512-Cv47jzY1jkGkh5sv0bfHYqGgKOWO1peOrGMkDFM4UmaGMOTgOW8QSexhvixa9sVOiz8MnVOBryWYyw/CEVhj7w==",
-      "license": "MIT",
-      "workspaces": [
-        "scripts/actions/documentation"
-      ]
-    },
-    "node_modules/@buape/carbon/node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "ws": "8.20.0"
       }
     },
     "node_modules/@clack/core": {
@@ -1167,9 +1090,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260120.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260120.0.tgz",
-      "integrity": "sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==",
+      "version": "4.20260405.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
+      "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
       "license": "MIT OR Apache-2.0",
       "optional": true
     },
@@ -1361,17 +1284,18 @@
       }
     },
     "node_modules/@discordjs/voice": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.0.tgz",
-      "integrity": "sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.19.2.tgz",
+      "integrity": "sha512-3yJ255e4ag3wfZu/DSxeOZK1UtnqNxnspmLaQetGT0pDkThNZoHs+Zg6dgZZ19JEVomXygvfHn9lNpICZuYtEA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
+        "@snazzah/davey": "^0.1.9",
         "@types/ws": "^8.18.1",
-        "discord-api-types": "^0.38.16",
+        "discord-api-types": "^0.38.41",
         "prism-media": "^1.3.5",
         "tslib": "^2.8.1",
-        "ws": "^8.18.3"
+        "ws": "^8.19.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -1415,12 +1339,35 @@
         }
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
       "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2011,9 +1958,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3319,23 +3266,23 @@
       "license": "MIT"
     },
     "node_modules/@lydell/node-pty": {
-      "version": "1.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.10.tgz",
-      "integrity": "sha512-Fv+A3+MZVA8qhkBIZsM1E6dCdHNMyXXz22mAYiMWd03LlyK///F3OH6CKPX9mj4id7LUlxpr45yPzyBVy9aDPw==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==",
       "license": "MIT",
       "optionalDependencies": {
-        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.10",
-        "@lydell/node-pty-darwin-x64": "1.2.0-beta.10",
-        "@lydell/node-pty-linux-arm64": "1.2.0-beta.10",
-        "@lydell/node-pty-linux-x64": "1.2.0-beta.10",
-        "@lydell/node-pty-win32-arm64": "1.2.0-beta.10",
-        "@lydell/node-pty-win32-x64": "1.2.0-beta.10"
+        "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-darwin-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-linux-x64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-arm64": "1.2.0-beta.12",
+        "@lydell/node-pty-win32-x64": "1.2.0-beta.12"
       }
     },
     "node_modules/@lydell/node-pty-darwin-arm64": {
-      "version": "1.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.10.tgz",
-      "integrity": "sha512-C+eqDyRNHRYvx7RaHj6VVCx6nCpRBPuuxhTcc3JH3GuBMoxTsYeY4GkWH2XOktrgbAq1BG8e/Y8bu/wNQreCEw==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-arm64/-/node-pty-darwin-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-tqaifcY9Cr41SblO1+FLzh8oxxtkNhuW9Dhl22lKme9BreYvKvxEZcdPIXTuqkJc5tagOEC4QHShKmJjLyLXLQ==",
       "cpu": [
         "arm64"
       ],
@@ -3346,9 +3293,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-darwin-x64": {
-      "version": "1.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.10.tgz",
-      "integrity": "sha512-aZoIK6HtJO5BiT4ELm683U4dyHtt8b7wNgq3NJqYAQwSXrcPv576Z8vY3BIulVxfcFkht/SPLKou9TtdFXdNpg==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-darwin-x64/-/node-pty-darwin-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-4LrS5pCJwqHKDVf1zS2gyNV0m4hKAXch+XZNhbZ6LY8uwVL8BhchzQBO40Os5anuRxRCWzHpw4Sp64Ie8q7E4Q==",
       "cpu": [
         "x64"
       ],
@@ -3359,9 +3306,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-linux-arm64": {
-      "version": "1.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.10.tgz",
-      "integrity": "sha512-0cKX2iMyXFNBE4fGtGK6B7IkdXcDMZajyEDoGMOgQQs/DDtoI5tSPcBcqNY9VitVrsRQA8+gFt6eKYU9Ye/lUA==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-arm64/-/node-pty-linux-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-Sx+A71x5BDGHt9ansfrtGxwq2VFVDWvJUAdlUL0Hv0qeiJUfts+hgopx+CgT4PSwahKjdEgtu0+FAfY9rICKRw==",
       "cpu": [
         "arm64"
       ],
@@ -3372,9 +3319,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-linux-x64": {
-      "version": "1.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.10.tgz",
-      "integrity": "sha512-J9HnxvSzEeMH748+Ul1VrmCLWMo7iCVJy9EGijRR62+YO/Yk5GaCydUTZ+KzlH0/X5aTrgt5cfiof4vx45tRRg==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-linux-x64/-/node-pty-linux-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-bJzs94njofYhGg/UDqW1nj0dtvvu+2OvxMY+RlLS1T17VgcktKoIR6PuenTwE5HJ/D6StCPADmXcT0nNsCKmIQ==",
       "cpu": [
         "x64"
       ],
@@ -3385,9 +3332,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-win32-arm64": {
-      "version": "1.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.10.tgz",
-      "integrity": "sha512-PlDJpJX/pnKyy6OmADKzhf+INZDDnzTBGaI0LT4laVNc6NblZNqUSkCMjLFWbeakeuQp0VG37M49WQSN9FDfeA==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-arm64/-/node-pty-win32-arm64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-p7POgjVEiFaBC3/y+AKuV1FzePCsJ6HmZDv2XK+jBZSfwP8+uBAw181ZiKYN1YuRa/XpmBGaWezcI8hZkbW++g==",
       "cpu": [
         "arm64"
       ],
@@ -3398,9 +3345,9 @@
       ]
     },
     "node_modules/@lydell/node-pty-win32-x64": {
-      "version": "1.2.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.10.tgz",
-      "integrity": "sha512-ExFgWrzyldNAMi45U9PLIOu+g/RatP+f0c/dZxaooifME6yLW32BoHveH26/TtoAjZyJrc2iL0u48pgnR1fzmg==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/@lydell/node-pty-win32-x64/-/node-pty-win32-x64-1.2.0-beta.12.tgz",
+      "integrity": "sha512-IDFa00g7qUDGUYgByrUBJtC+mOjYVt/8KYyWivCg5JjGOHbBUACUQZLl0jTWmnr+tld/UyTpX90a2PY6oTVtRw==",
       "cpu": [
         "x64"
       ],
@@ -3603,21 +3550,21 @@
       }
     },
     "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.65.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.65.2.tgz",
-      "integrity": "sha512-GYOrX5aRUpSDMPtKR174Tv72CWH92anqlRuiGn8PV05OowPAahT99JoxvZEP4fcKANBdHsyDfMMwFYpPhvPBUQ==",
+      "version": "0.66.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.66.1.tgz",
+      "integrity": "sha512-Nj54A7SuB/EQi8r3Gs+glFOr9wz/a9uxYFf0pCLf2DE7VmzA9O7WSejrvArna17K6auftLSdNyRRe2bIO0qezg==",
       "license": "MIT",
       "dependencies": {
-        "@mariozechner/pi-ai": "^0.65.2"
+        "@mariozechner/pi-ai": "^0.66.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@mariozechner/pi-ai": {
-      "version": "0.65.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.65.2.tgz",
-      "integrity": "sha512-XCbXncmh10Q89tvS0880Ms6pv3DTxFTEtanfVHEPXKQBi0FBYnrkAlOnP5VRU8vCfe18P1AMNsWCndsCBUqY7g==",
+      "version": "0.66.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.66.1.tgz",
+      "integrity": "sha512-7IZHvpsFdKEBkTmjNrdVL7JLUJVIpha6bwTr12cZ5XyDrxij06wP6Ncpnf4HT5BXAzD5w2JnoqTOSbMEIZj3dg==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -3839,15 +3786,15 @@
       }
     },
     "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.65.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.65.2.tgz",
-      "integrity": "sha512-/rpFzPQ+CishxrSwJHSSRZBQHHWy2K3Rbu/iV0HcMq/hl9cSI2ygpwjVTRbPW+NuP1tHxVV3AMxz69VLAs5Ztg==",
+      "version": "0.66.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.66.1.tgz",
+      "integrity": "sha512-cNmatT+5HvYzQ78cRhRih00wCeUTH/fFx9ecJh5AbN7axgWU+bwiZYy0cjrTsGVgMGF4xMYlPRn/Nze9JEB+/w==",
       "license": "MIT",
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.65.2",
-        "@mariozechner/pi-ai": "^0.65.2",
-        "@mariozechner/pi-tui": "^0.65.2",
+        "@mariozechner/pi-agent-core": "^0.66.1",
+        "@mariozechner/pi-ai": "^0.66.1",
+        "@mariozechner/pi-tui": "^0.66.1",
         "@silvia-odwyer/photon-node": "^0.3.4",
         "ajv": "^8.17.1",
         "chalk": "^5.5.0",
@@ -3915,9 +3862,9 @@
       }
     },
     "node_modules/@mariozechner/pi-tui": {
-      "version": "0.65.2",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.65.2.tgz",
-      "integrity": "sha512-LBPbIBASjCF4QLrc/dwmPdBzVMsbkDhzmBIAFgglX5rZBnGRppB7ekSA+1kb5pdxDpDn8IbxJX+bl7ZaeqZqxw==",
+      "version": "0.66.1",
+      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.66.1.tgz",
+      "integrity": "sha512-hNFN42ebjwtfGooqoUwM+QaPR1XCyqPuueuP3aLOWS1bZ2nZP/jq8MBuGNrmMw1cgiDcotvOlSNj3BatzEOGsw==",
       "license": "MIT",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -4591,6 +4538,24 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@noble/ciphers": {
@@ -6237,6 +6202,259 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@snazzah/davey": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey/-/davey-0.1.11.tgz",
+      "integrity": "sha512-oBN+msHzPnm1M5DDx3wVD7iBwpNXFUtkh2MrAbUJu0OhKjliLChi28hq++mu1+qdMpAVQO5JKAvQQxYVbyneiw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Snazzah"
+      },
+      "optionalDependencies": {
+        "@snazzah/davey-android-arm-eabi": "0.1.11",
+        "@snazzah/davey-android-arm64": "0.1.11",
+        "@snazzah/davey-darwin-arm64": "0.1.11",
+        "@snazzah/davey-darwin-x64": "0.1.11",
+        "@snazzah/davey-freebsd-x64": "0.1.11",
+        "@snazzah/davey-linux-arm-gnueabihf": "0.1.11",
+        "@snazzah/davey-linux-arm64-gnu": "0.1.11",
+        "@snazzah/davey-linux-arm64-musl": "0.1.11",
+        "@snazzah/davey-linux-x64-gnu": "0.1.11",
+        "@snazzah/davey-linux-x64-musl": "0.1.11",
+        "@snazzah/davey-wasm32-wasi": "0.1.11",
+        "@snazzah/davey-win32-arm64-msvc": "0.1.11",
+        "@snazzah/davey-win32-ia32-msvc": "0.1.11",
+        "@snazzah/davey-win32-x64-msvc": "0.1.11"
+      }
+    },
+    "node_modules/@snazzah/davey-android-arm-eabi": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm-eabi/-/davey-android-arm-eabi-0.1.11.tgz",
+      "integrity": "sha512-T1RYbNYKN6tLOcGIDKJd8OI6FBSEemwL7DOYdTMmhqfhhMr3YVN8WOhfoxGg63OcnpTN2e2c5tdY2bAx25RmQQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-android-arm64": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-android-arm64/-/davey-android-arm64-0.1.11.tgz",
+      "integrity": "sha512-ksJn/x2VU8h6w9eku1HT96ugSRZ7lKVkKNKbFleaFN+U99DJaPM+gMu2YvnFU4V54HR06ZBnRihnVG6VLXQpDw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-darwin-arm64": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-arm64/-/davey-darwin-arm64-0.1.11.tgz",
+      "integrity": "sha512-E1d7PbaaVMO3Lj9EiAPqOVbuV0xg5+PsHzHH097DDXiD1+zUDXvJaTnUWsnm5z50pJniHpi4GtaYmk+ieB/guA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-darwin-x64": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-darwin-x64/-/davey-darwin-x64-0.1.11.tgz",
+      "integrity": "sha512-Tl4TI/LTmgJZepgbgVMYDi8RqlAkPtPg1OEBPl7a9Tn3AwR36Vs6lyIT1cs/lGy/ds/+B+mKI4rPObN1cyILTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-freebsd-x64": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-freebsd-x64/-/davey-freebsd-x64-0.1.11.tgz",
+      "integrity": "sha512-T8Iw9FXkuI1T+YBAFzh9v/TXf9IOTOSqnd/BFpTRTrlW72PR2lhIidzSmg027VxO7r5pX47iFwiOkb9I/NU/EA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm-gnueabihf": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm-gnueabihf/-/davey-linux-arm-gnueabihf-0.1.11.tgz",
+      "integrity": "sha512-1Txj+8pqA8uq/OGtaUaBFWAPnNMQzFgIywj0iA7EI4xZl+mab48/pv+YZ1pNb/suC6ynsW44oB9efiXSdcUAgA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm64-gnu": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-gnu/-/davey-linux-arm64-gnu-0.1.11.tgz",
+      "integrity": "sha512-ERzF5nM/IYW1BcN3wLXpEwBCGLFf0kGJUVhaV6yfiInz0tkU8UmvrrgpaMaACfMjIhfWdq5CcX+aTkXo/saNcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-arm64-musl": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-arm64-musl/-/davey-linux-arm64-musl-0.1.11.tgz",
+      "integrity": "sha512-e6pX6Hiabtz99q+H/YHNkm9JVlpqN8HGh0qPib8G2+UY4/SSH8WvqWipk3v581dMy2oyCHt7MOoY1aU1P1N/xA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-x64-gnu": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-gnu/-/davey-linux-x64-gnu-0.1.11.tgz",
+      "integrity": "sha512-TW5bSoqChOJMbvsDb4wAATYrxmAXuNnse7wFNVSAJUaZKSeRfZbu3UAiPWSNn7GwLwSfU6hg322KZUn8IWCuvg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-linux-x64-musl": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-linux-x64-musl/-/davey-linux-x64-musl-0.1.11.tgz",
+      "integrity": "sha512-5j6Pmc+Wzv5lSxVP6quA7teYRJXibkZqQyYGfTDnTsUOO5dPpcojpqlXlkhyvsA1OAQTj4uxbOCciN3cVWwzug==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-wasm32-wasi": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-wasm32-wasi/-/davey-wasm32-wasi-0.1.11.tgz",
+      "integrity": "sha512-rKOwZ/0J8lp+4VEyOdMDBRP9KR+PksZpa9V1Qn0veMzy4FqTVKthkxwGqewheFe0SFg9fdvt798l/PBFrfDeZw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-arm64-msvc": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-arm64-msvc/-/davey-win32-arm64-msvc-0.1.11.tgz",
+      "integrity": "sha512-5fptJU4tX901m3mj0SHiBljMrPT4ZEsynbBhR7bK1yn9TY1jjyhN8EFi7QF5IWtUEni+0mia2BCMHZ5ZkmFZqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-ia32-msvc": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-ia32-msvc/-/davey-win32-ia32-msvc-0.1.11.tgz",
+      "integrity": "sha512-ualexn8SeLsiMHhWfzVrzRcjHgcBapg++FPaVgJJxoh2S/jCRiklXOu3luqIZdJdNKvhe2V9SwO/cImPeIIBKw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@snazzah/davey-win32-x64-msvc": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@snazzah/davey-win32-x64-msvc/-/davey-win32-x64-msvc-0.1.11.tgz",
+      "integrity": "sha512-muNhc8UKXtknzsH/w4AIkbPR2I8BuvApn0pDXar0IEvY8PCjqU/M8MPbOOEYwQVvQRMwVTgExtxzrkBPSXB4nA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -6313,6 +6531,16 @@
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -6325,13 +6553,13 @@
       }
     },
     "node_modules/@types/bun": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.6.tgz",
-      "integrity": "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.11.tgz",
+      "integrity": "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "bun-types": "1.3.6"
+        "bun-types": "1.3.11"
       }
     },
     "node_modules/@types/chai": {
@@ -6444,12 +6672,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/qs": {
@@ -7183,9 +7411,9 @@
       "license": "MIT"
     },
     "node_modules/bun-types": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.6.tgz",
-      "integrity": "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==",
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.11.tgz",
+      "integrity": "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8561,9 +8789,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.0.tgz",
-      "integrity": "sha512-cmBmnYo8Zymabm2+qAP7jTFbKF10bQpYmxoGfuZbRFRcq00BRddJdGNH/P7GA1EMpJy5yQbqa9B7yROb3z8Ziw==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+      "integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
@@ -10298,9 +10526,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/matrix-js-sdk": {
-      "version": "41.3.0-rc.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-41.3.0-rc.0.tgz",
-      "integrity": "sha512-HTGqU6ZWAB9Dl3U9wUQDbk0aq77a6JFVdATTRX3Yy9eLytcK3RSLI6bPwFBrKgV2qRz+gy7bfsqXVDWTXng7jA==",
+      "version": "41.3.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-41.3.0.tgz",
+      "integrity": "sha512-QTNHpBQEKPH3WS4O92CBfFj6GxeyijT8osI/QxNvOrM3rE6CySXRtRRKnzR0ntFSdrk1CxrDGV6h2wmk7B3peQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -10876,37 +11104,37 @@
       }
     },
     "node_modules/openclaw": {
-      "version": "2026.4.9",
-      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.4.9.tgz",
-      "integrity": "sha512-w3DMKeVv7BnKmcQvq2Xu+X51HMv02L00YBX4uRDSuAEIgP3Ehm7JlKG9KTbfhAFu93143MqZNqI75/eXjkRO6Q==",
+      "version": "2026.4.10",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.4.10.tgz",
+      "integrity": "sha512-fpPIZbG19xRIQJgxL2S6PZ+pvHZFR2uYJ+8KaVwrQbOioSWZ5BYbDcrOtTiqXrsJG5mDrVxMVBDeZ5gNHAmm1g==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "0.18.0",
-        "@anthropic-ai/vertex-sdk": "^0.14.4",
-        "@aws-sdk/client-bedrock": "3.1024.0",
-        "@aws-sdk/client-bedrock-runtime": "3.1024.0",
-        "@aws-sdk/credential-provider-node": "3.972.29",
+        "@agentclientprotocol/sdk": "0.18.2",
+        "@anthropic-ai/vertex-sdk": "^0.15.0",
+        "@aws-sdk/client-bedrock": "3.1028.0",
+        "@aws-sdk/client-bedrock-runtime": "3.1028.0",
+        "@aws-sdk/credential-provider-node": "3.972.30",
         "@aws/bedrock-token-generator": "^1.1.0",
-        "@buape/carbon": "0.14.0",
+        "@buape/carbon": "0.15.0",
         "@clack/prompts": "^1.2.0",
-        "@google/genai": "^1.48.0",
+        "@google/genai": "^1.49.0",
         "@grammyjs/runner": "^2.0.3",
         "@grammyjs/transformer-throttler": "^1.2.1",
         "@homebridge/ciao": "^1.3.6",
         "@lancedb/lancedb": "^0.27.2",
         "@larksuiteoapi/node-sdk": "^1.60.0",
         "@line/bot-sdk": "^11.0.0",
-        "@lydell/node-pty": "1.2.0-beta.10",
-        "@mariozechner/pi-agent-core": "0.65.2",
-        "@mariozechner/pi-ai": "0.65.2",
-        "@mariozechner/pi-coding-agent": "0.65.2",
-        "@mariozechner/pi-tui": "0.65.2",
+        "@lydell/node-pty": "1.2.0-beta.12",
+        "@mariozechner/pi-agent-core": "0.66.1",
+        "@mariozechner/pi-ai": "0.66.1",
+        "@mariozechner/pi-coding-agent": "0.66.1",
+        "@mariozechner/pi-tui": "0.66.1",
         "@matrix-org/matrix-sdk-crypto-wasm": "18.0.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "^0.6.0",
         "@sinclair/typebox": "0.34.49",
-        "@slack/bolt": "^4.6.0",
+        "@slack/bolt": "^4.7.0",
         "@slack/web-api": "^7.15.0",
         "ajv": "^8.18.0",
         "chalk": "^5.6.2",
@@ -10914,33 +11142,33 @@
         "cli-highlight": "^2.1.11",
         "commander": "^14.0.3",
         "croner": "^10.0.1",
-        "discord-api-types": "^0.38.44",
-        "dotenv": "^17.4.0",
+        "discord-api-types": "^0.38.45",
+        "dotenv": "^17.4.1",
         "express": "^5.2.1",
-        "file-type": "22.0.0",
+        "file-type": "22.0.1",
         "gaxios": "7.1.4",
         "google-auth-library": "^10.6.2",
         "grammy": "^1.42.0",
         "hono": "4.12.12",
         "https-proxy-agent": "^9.0.0",
         "ipaddr.js": "^2.3.0",
-        "jimp": "^1.6.0",
+        "jimp": "^1.6.1",
         "jiti": "^2.6.1",
         "json5": "^2.2.3",
         "jszip": "^3.10.1",
         "linkedom": "^0.18.12",
         "long": "^5.3.2",
         "markdown-it": "14.1.1",
-        "matrix-js-sdk": "41.3.0-rc.0",
+        "matrix-js-sdk": "41.3.0",
         "mpg123-decoder": "^1.0.3",
         "node-edge-tts": "^1.2.10",
         "nostr-tools": "^2.23.3",
-        "openai": "^6.33.0",
+        "openai": "^6.34.0",
         "opusscript": "^0.1.1",
         "osc-progress": "^0.3.0",
         "pdfjs-dist": "^5.6.205",
         "playwright-core": "1.59.1",
-        "proxy-agent": "^8.0.0",
+        "proxy-agent": "^8.0.1",
         "qrcode-terminal": "^0.12.0",
         "sharp": "^0.34.5",
         "silk-wasm": "^3.7.1",
@@ -12400,9 +12628,9 @@
       "optional": true
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13782,9 +14010,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unhomoglyph": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "express": "^4.21.0",
     "http-proxy": "^1.18.1",
-    "openclaw": "2026.4.9",
+    "openclaw": "2026.4.10",
     "patch-package": "^8.0.1",
     "ws": "^8.19.0"
   },

--- a/tests/bin/alphaclaw.test.js
+++ b/tests/bin/alphaclaw.test.js
@@ -5,15 +5,22 @@ const os = require("os");
 
 describe("bin/alphaclaw port check", () => {
   let tmpDir;
+  let tmpHome;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-test-"));
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-home-"));
   });
 
   afterEach(() => {
     try {
       if (fs.existsSync(tmpDir)) {
         fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    } catch {}
+    try {
+      if (fs.existsSync(tmpHome)) {
+        fs.rmSync(tmpHome, { recursive: true, force: true });
       }
     } catch {}
   });
@@ -76,5 +83,122 @@ describe("bin/alphaclaw port check", () => {
     expect(status).toBe(1);
     expect(output).not.toContain("AlphaClaw cannot be started on port 18789");
     expect(output).toContain("SETUP_PASSWORD is missing or empty");
+  });
+
+  it("exports OPENCLAW_STATE_DIR during managed startup", () => {
+    const preloadPath = path.join(tmpDir, "capture-openclaw-env.js");
+    const capturePath = path.join(tmpDir, "captured-openclaw-env.json");
+    fs.writeFileSync(
+      preloadPath,
+      `
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const Module = require("module");
+const childProcess = require("child_process");
+
+const realLoad = Module._load;
+const realCopyFileSync = fs.copyFileSync;
+const realWriteFileSync = fs.writeFileSync;
+const realUnlinkSync = fs.unlinkSync;
+const realChmodSync = fs.chmodSync;
+
+const capturePath = process.env.ALPHACLAW_CAPTURE_ENV_PATH;
+const testHome = process.env.ALPHACLAW_TEST_HOME;
+if (testHome) {
+  os.homedir = () => testHome;
+}
+
+childProcess.execSync = (command, options = {}) => {
+  const cmd = String(command || "");
+  if (
+    cmd.startsWith("command -v ") ||
+    cmd === "pgrep -x cron" ||
+    cmd === "cron"
+  ) {
+    return "";
+  }
+  if (cmd.startsWith("git ")) {
+    return "";
+  }
+  return "";
+};
+
+fs.copyFileSync = (src, dest, ...rest) => {
+  const target = String(dest || "");
+  if (
+    target.startsWith("/usr/local/bin/") ||
+    target.startsWith("/etc/cron.d/")
+  ) {
+    return;
+  }
+  return realCopyFileSync(src, dest, ...rest);
+};
+
+fs.writeFileSync = (targetPath, data, ...rest) => {
+  const target = String(targetPath || "");
+  if (
+    target.startsWith("/usr/local/bin/") ||
+    target.startsWith("/etc/cron.d/")
+  ) {
+    return;
+  }
+  return realWriteFileSync(targetPath, data, ...rest);
+};
+
+fs.unlinkSync = (targetPath, ...rest) => {
+  const target = String(targetPath || "");
+  if (target.startsWith("/etc/cron.d/")) return;
+  return realUnlinkSync(targetPath, ...rest);
+};
+
+fs.chmodSync = (targetPath, ...rest) => {
+  const target = String(targetPath || "");
+  if (target.startsWith("/usr/local/bin/")) return;
+  return realChmodSync(targetPath, ...rest);
+};
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  const parentFile = String(parent && parent.filename ? parent.filename : "");
+  if (
+    (request === "../lib/server.js" || String(request || "").endsWith("/lib/server.js")) &&
+    parentFile.endsWith(path.join("bin", "alphaclaw.js"))
+  ) {
+    fs.writeFileSync(
+      capturePath,
+      JSON.stringify({
+        OPENCLAW_HOME: process.env.OPENCLAW_HOME,
+        OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
+        OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+        XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+      }),
+    );
+    return {};
+  }
+  return realLoad.apply(this, arguments);
+};
+      `.trim(),
+    );
+
+    execSync(`node "${binPath}" start`, {
+      stdio: "pipe",
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SETUP_PASSWORD: "test-password",
+        ALPHACLAW_ROOT_DIR: tmpDir,
+        ALPHACLAW_TEST_HOME: tmpHome,
+        ALPHACLAW_CAPTURE_ENV_PATH: capturePath,
+        NODE_OPTIONS: `--require=${preloadPath}`,
+      },
+    });
+
+    const reportedEnv = JSON.parse(fs.readFileSync(capturePath, "utf8"));
+    expect(reportedEnv).toEqual({
+      OPENCLAW_HOME: tmpDir,
+      OPENCLAW_CONFIG_PATH: path.join(tmpDir, ".openclaw", "openclaw.json"),
+      OPENCLAW_STATE_DIR: path.join(tmpDir, ".openclaw"),
+      XDG_CONFIG_HOME: path.join(tmpDir, ".openclaw"),
+    });
   });
 });

--- a/tests/server/alphaclaw-version.test.js
+++ b/tests/server/alphaclaw-version.test.js
@@ -69,7 +69,7 @@ describe("server/alphaclaw-version", () => {
     });
     const { service } = createService({
       env: {},
-      readOpenclawVersion: () => "2026.4.9",
+      readOpenclawVersion: () => "2026.4.10",
       fetchMock,
       fsImpl: { ...fs, existsSync: vi.fn(() => false) },
     });
@@ -80,7 +80,7 @@ describe("server/alphaclaw-version", () => {
       expect.objectContaining({
         ok: true,
         currentVersion: expect.any(String),
-        currentOpenclawVersion: "2026.4.9",
+        currentOpenclawVersion: "2026.4.10",
         latestVersion: "99.0.0",
         hasUpdate: true,
         updateStrategy: expect.objectContaining({
@@ -100,7 +100,7 @@ describe("server/alphaclaw-version", () => {
         body: {
           dependencies: {
             "@chrysb/alphaclaw": "0.8.10",
-            openclaw: "2026.4.9",
+            openclaw: "2026.4.10",
           },
         },
       });
@@ -117,7 +117,7 @@ describe("server/alphaclaw-version", () => {
       expect.objectContaining({
         ok: true,
         latestVersion: "0.8.10",
-        latestOpenclawVersion: "2026.4.9",
+        latestOpenclawVersion: "2026.4.10",
         hasUpdate: true,
         updateStrategy: expect.objectContaining({
           action: "instructions",
@@ -135,7 +135,7 @@ describe("server/alphaclaw-version", () => {
         body: {
           dependencies: {
             "@chrysb/alphaclaw": "0.8.10",
-            openclaw: "2026.4.9",
+            openclaw: "2026.4.10",
           },
         },
       }),
@@ -168,7 +168,7 @@ describe("server/alphaclaw-version", () => {
         body: {
           dependencies: {
             "@chrysb/alphaclaw": "0.8.10",
-            openclaw: "2026.4.9",
+            openclaw: "2026.4.10",
           },
         },
       }),
@@ -200,7 +200,7 @@ describe("server/alphaclaw-version", () => {
           body: {
             dependencies: {
               "@chrysb/alphaclaw": "0.8.7",
-              openclaw: "2026.4.9",
+              openclaw: "2026.4.10",
             },
           },
         });
@@ -217,7 +217,7 @@ describe("server/alphaclaw-version", () => {
         repo: "https://github.com/chrysb/openclaw-apex-template.git",
         ref: "aded043defd05bba6787bca75ac6ed8dffd43c6e",
         alphaclawVersion: "0.8.7",
-        openclawVersion: "2026.4.9",
+        openclawVersion: "2026.4.10",
       });
       return createFetchResponse({
         body: { ok: true, phase: "queued", noop: false },
@@ -243,7 +243,7 @@ describe("server/alphaclaw-version", () => {
         managedUpdate: true,
         restarting: true,
         latestVersion: "0.8.7",
-        latestOpenclawVersion: "2026.4.9",
+        latestOpenclawVersion: "2026.4.10",
       }),
     );
   });
@@ -255,7 +255,7 @@ describe("server/alphaclaw-version", () => {
           body: {
             dependencies: {
               "@chrysb/alphaclaw": "0.8.7",
-              openclaw: "2026.4.9",
+              openclaw: "2026.4.10",
             },
           },
         });
@@ -303,7 +303,7 @@ describe("server/alphaclaw-version", () => {
         body: {
           dependencies: {
             "@chrysb/alphaclaw": "0.8.10",
-            openclaw: "2026.4.9",
+            openclaw: "2026.4.10",
           },
         },
       }),

--- a/tests/server/gateway.test.js
+++ b/tests/server/gateway.test.js
@@ -96,6 +96,20 @@ describe("server/gateway restart behavior", () => {
     expect(firstChild.kill).not.toHaveBeenCalled();
   });
 
+  it("exports the durable OpenClaw state dir in gateway env", () => {
+    delete require.cache[modulePath];
+    const gateway = require(modulePath);
+
+    expect(gateway.gatewayEnv()).toEqual(
+      expect.objectContaining({
+        OPENCLAW_HOME: expect.any(String),
+        OPENCLAW_CONFIG_PATH: `${OPENCLAW_DIR}/openclaw.json`,
+        OPENCLAW_STATE_DIR: OPENCLAW_DIR,
+        XDG_CONFIG_HOME: OPENCLAW_DIR,
+      }),
+    );
+  });
+
   it("uses force restart when no managed child exists", () => {
     const spawnMock = vi.fn(() => createChild());
     const execSyncMock = vi.fn(() => "");

--- a/tests/server/routes-models.test.js
+++ b/tests/server/routes-models.test.js
@@ -88,7 +88,7 @@ describe("server/routes/models", () => {
     );
     expect(deps.shellCmd).toHaveBeenCalledWith("openclaw models list --all --json", {
       env: { OPENCLAW_GATEWAY_TOKEN: "token" },
-      timeout: 20000,
+      timeout: 30000,
     });
   });
 

--- a/tests/server/routes-onboarding.test.js
+++ b/tests/server/routes-onboarding.test.js
@@ -505,6 +505,13 @@ describe("server/routes/onboarding", () => {
     expect(onboardCall[0]).toContain("--anthropic-api-key");
     expect(onboardCall[0]).not.toContain("--token-provider");
     expect(onboardCall[0]).not.toContain("sk-ant-oat01-stale-token");
+    expect(onboardCall[1]).toMatchObject({
+      env: expect.objectContaining({
+        OPENCLAW_CONFIG_PATH: "/tmp/openclaw/openclaw.json",
+        OPENCLAW_STATE_DIR: "/tmp/openclaw",
+        XDG_CONFIG_HOME: "/tmp/openclaw",
+      }),
+    });
   });
 
   it("sanitizes onboarding command failures to avoid leaking secrets", async () => {


### PR DESCRIPTION
## Summary
- export `OPENCLAW_STATE_DIR=/data/.openclaw` through AlphaClaw managed startup and child-process paths
- add bootstrap guidance so agents treat `/tmp` as ephemeral and keep durable plugin artifacts under `/data/.openclaw`
- add regression coverage for launcher, gateway env wiring, and onboarding env propagation

## Testing
- `npm test -- tests/bin/alphaclaw.test.js tests/server/gateway.test.js tests/server/routes-onboarding.test.js`
- `node --check bin/alphaclaw.js && node --check lib/server/gateway.js && node --check lib/server/onboarding/index.js`

## Scope
- future installs only
- no migration of existing plugin installs from old ephemeral roots
- no OpenClaw repo changes