### PR TITLE
Compat: preserve gogcli config under managed home

### DIFF
--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -508,6 +508,7 @@ if (!kSetupPassword) {
 // ---------------------------------------------------------------------------
 
 process.env.OPENCLAW_HOME = rootDir;
+process.env.HOME = rootDir;
 process.env.OPENCLAW_CONFIG_PATH = path.join(openclawDir, "openclaw.json");
 process.env.OPENCLAW_STATE_DIR = openclawDir;
 process.env.GOG_KEYRING_PASSWORD =
@@ -518,6 +519,39 @@ process.env.GOG_KEYRING_PASSWORD =
 // ---------------------------------------------------------------------------
 
 process.env.XDG_CONFIG_HOME = openclawDir;
+
+const ensureGogCliCompatConfigPath = () => {
+  const configDir = path.join(rootDir, ".config");
+  const compatPath = path.join(configDir, "gogcli");
+  const managedPath = path.join(openclawDir, "gogcli");
+
+  try {
+    fs.mkdirSync(configDir, { recursive: true });
+    if (!fs.existsSync(compatPath)) {
+      fs.symlinkSync(managedPath, compatPath, "dir");
+      console.log(
+        `[alphaclaw] Linked gogcli config path ${compatPath} -> ${managedPath}`,
+      );
+      return;
+    }
+
+    const stat = fs.lstatSync(compatPath);
+    if (!stat.isSymbolicLink()) return;
+    const linkTarget = fs.readlinkSync(compatPath);
+    const resolvedTarget = path.resolve(configDir, linkTarget);
+    if (resolvedTarget !== managedPath) {
+      console.log(
+        `[alphaclaw] gogcli config path already exists at ${compatPath}; leaving existing symlink in place`,
+      );
+    }
+  } catch (error) {
+    console.log(
+      `[alphaclaw] gogcli config path compatibility setup skipped: ${error.message}`,
+    );
+  }
+};
+
+ensureGogCliCompatConfigPath();
 
 const gogInstalled = (() => {
   try {

--- a/lib/server/gateway.js
+++ b/lib/server/gateway.js
@@ -43,6 +43,7 @@ const setGatewayLaunchHandler = (handler) => {
 
 const gatewayEnv = () => ({
   ...process.env,
+  HOME: kRootDir,
   OPENCLAW_HOME: kRootDir,
   OPENCLAW_CONFIG_PATH: `${OPENCLAW_DIR}/openclaw.json`,
   OPENCLAW_STATE_DIR: OPENCLAW_DIR,

--- a/lib/server/gog-skill.js
+++ b/lib/server/gog-skill.js
@@ -105,6 +105,19 @@ const buildGogSkillContent = ({ fs, accounts }) => {
   lines.push("```");
   lines.push("");
 
+  lines.push("## Runtime Notes");
+  lines.push("");
+  lines.push(
+    "- In AlphaClaw-managed deployments, gog state lives under `$OPENCLAW_STATE_DIR` (typically `/data/.openclaw`).",
+  );
+  lines.push(
+    "- If a direct shell `gog ...` command falls back to `/root/.config/gogcli` or `/root/.openclaw`, rerun it with `XDG_CONFIG_HOME=\"${OPENCLAW_STATE_DIR:-$OPENCLAW_HOME/.openclaw}\"` so gog uses the managed state dir.",
+  );
+  lines.push(
+    "- Always pass `--account <email>` (and `--client <name>` if not \"default\") so gog targets the correct account.",
+  );
+  lines.push("");
+
   // Account table
   lines.push("## Connected Accounts");
   lines.push("");
@@ -116,10 +129,6 @@ const buildGogSkillContent = ({ fs, accounts }) => {
     const services = uniqueServiceLabels(account.services).join(", ");
     lines.push(`| ${email} | ${client} | ${services} |`);
   }
-  lines.push("");
-  lines.push(
-    "Always pass `--account <email>` (and `--client <name>` if not \"default\") so gog targets the correct account.",
-  );
   lines.push("");
 
   // Per-service sections (read from markdown files)

--- a/lib/server/onboarding/index.js
+++ b/lib/server/onboarding/index.js
@@ -493,6 +493,7 @@ const createOnboardingService = ({
         {
           env: {
             ...process.env,
+            HOME: kRootDir,
             OPENCLAW_HOME: kRootDir,
             OPENCLAW_CONFIG_PATH: `${OPENCLAW_DIR}/openclaw.json`,
             OPENCLAW_STATE_DIR: OPENCLAW_DIR,

--- a/tests/bin/alphaclaw.test.js
+++ b/tests/bin/alphaclaw.test.js
@@ -167,6 +167,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
     fs.writeFileSync(
       capturePath,
       JSON.stringify({
+        HOME: process.env.HOME,
         OPENCLAW_HOME: process.env.OPENCLAW_HOME,
         OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
         OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
@@ -195,10 +196,220 @@ Module._load = function patchedLoad(request, parent, isMain) {
 
     const reportedEnv = JSON.parse(fs.readFileSync(capturePath, "utf8"));
     expect(reportedEnv).toEqual({
+      HOME: tmpDir,
       OPENCLAW_HOME: tmpDir,
       OPENCLAW_CONFIG_PATH: path.join(tmpDir, ".openclaw", "openclaw.json"),
       OPENCLAW_STATE_DIR: path.join(tmpDir, ".openclaw"),
       XDG_CONFIG_HOME: path.join(tmpDir, ".openclaw"),
     });
+
+  });
+
+  it("creates a gogcli compatibility symlink under the managed home", () => {
+    const preloadPath = path.join(tmpDir, "capture-openclaw-env.js");
+    fs.writeFileSync(
+      preloadPath,
+      `
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const Module = require("module");
+const childProcess = require("child_process");
+
+const realLoad = Module._load;
+const realCopyFileSync = fs.copyFileSync;
+const realWriteFileSync = fs.writeFileSync;
+const realUnlinkSync = fs.unlinkSync;
+const realChmodSync = fs.chmodSync;
+
+const testHome = process.env.ALPHACLAW_TEST_HOME;
+if (testHome) {
+  os.homedir = () => testHome;
+}
+
+childProcess.execSync = (command, options = {}) => {
+  const cmd = String(command || "");
+  if (
+    cmd.startsWith("command -v ") ||
+    cmd === "pgrep -x cron" ||
+    cmd === "cron"
+  ) {
+    return "";
+  }
+  if (cmd.startsWith("git ")) {
+    return "";
+  }
+  return "";
+};
+
+fs.copyFileSync = (src, dest, ...rest) => {
+  const target = String(dest || "");
+  if (
+    target.startsWith("/usr/local/bin/") ||
+    target.startsWith("/etc/cron.d/")
+  ) {
+    return;
+  }
+  return realCopyFileSync(src, dest, ...rest);
+};
+
+fs.writeFileSync = (targetPath, data, ...rest) => {
+  const target = String(targetPath || "");
+  if (
+    target.startsWith("/usr/local/bin/") ||
+    target.startsWith("/etc/cron.d/")
+  ) {
+    return;
+  }
+  return realWriteFileSync(targetPath, data, ...rest);
+};
+
+fs.unlinkSync = (targetPath, ...rest) => {
+  const target = String(targetPath || "");
+  if (target.startsWith("/etc/cron.d/")) return;
+  return realUnlinkSync(targetPath, ...rest);
+};
+
+fs.chmodSync = (targetPath, ...rest) => {
+  const target = String(targetPath || "");
+  if (target.startsWith("/usr/local/bin/")) return;
+  return realChmodSync(targetPath, ...rest);
+};
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  const parentFile = String(parent && parent.filename ? parent.filename : "");
+  if (
+    (request === "../lib/server.js" || String(request || "").endsWith("/lib/server.js")) &&
+    parentFile.endsWith(path.join("bin", "alphaclaw.js"))
+  ) {
+    return {};
+  }
+  return realLoad.apply(this, arguments);
+};
+      `.trim(),
+    );
+
+    execSync(`node "${binPath}" start`, {
+      stdio: "pipe",
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SETUP_PASSWORD: "test-password",
+        ALPHACLAW_ROOT_DIR: tmpDir,
+        ALPHACLAW_TEST_HOME: tmpHome,
+        NODE_OPTIONS: `--require=${preloadPath}`,
+      },
+    });
+
+    const compatPath = path.join(tmpDir, ".config", "gogcli");
+    const managedPath = path.join(tmpDir, ".openclaw", "gogcli");
+    expect(fs.lstatSync(compatPath).isSymbolicLink()).toBe(true);
+    expect(path.resolve(path.dirname(compatPath), fs.readlinkSync(compatPath))).toBe(
+      managedPath,
+    );
+  });
+
+  it("does not replace an existing gogcli config directory", () => {
+    const preloadPath = path.join(tmpDir, "capture-openclaw-env.js");
+    fs.writeFileSync(
+      preloadPath,
+      `
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const Module = require("module");
+const childProcess = require("child_process");
+
+const realLoad = Module._load;
+const realCopyFileSync = fs.copyFileSync;
+const realWriteFileSync = fs.writeFileSync;
+const realUnlinkSync = fs.unlinkSync;
+const realChmodSync = fs.chmodSync;
+
+const testHome = process.env.ALPHACLAW_TEST_HOME;
+if (testHome) {
+  os.homedir = () => testHome;
+}
+
+childProcess.execSync = (command, options = {}) => {
+  const cmd = String(command || "");
+  if (
+    cmd.startsWith("command -v ") ||
+    cmd === "pgrep -x cron" ||
+    cmd === "cron"
+  ) {
+    return "";
+  }
+  if (cmd.startsWith("git ")) {
+    return "";
+  }
+  return "";
+};
+
+fs.copyFileSync = (src, dest, ...rest) => {
+  const target = String(dest || "");
+  if (
+    target.startsWith("/usr/local/bin/") ||
+    target.startsWith("/etc/cron.d/")
+  ) {
+    return;
+  }
+  return realCopyFileSync(src, dest, ...rest);
+};
+
+fs.writeFileSync = (targetPath, data, ...rest) => {
+  const target = String(targetPath || "");
+  if (
+    target.startsWith("/usr/local/bin/") ||
+    target.startsWith("/etc/cron.d/")
+  ) {
+    return;
+  }
+  return realWriteFileSync(targetPath, data, ...rest);
+};
+
+fs.unlinkSync = (targetPath, ...rest) => {
+  const target = String(targetPath || "");
+  if (target.startsWith("/etc/cron.d/")) return;
+  return realUnlinkSync(targetPath, ...rest);
+};
+
+fs.chmodSync = (targetPath, ...rest) => {
+  const target = String(targetPath || "");
+  if (target.startsWith("/usr/local/bin/")) return;
+  return realChmodSync(targetPath, ...rest);
+};
+
+Module._load = function patchedLoad(request, parent, isMain) {
+  const parentFile = String(parent && parent.filename ? parent.filename : "");
+  if (
+    (request === "../lib/server.js" || String(request || "").endsWith("/lib/server.js")) &&
+    parentFile.endsWith(path.join("bin", "alphaclaw.js"))
+  ) {
+    return {};
+  }
+  return realLoad.apply(this, arguments);
+};
+      `.trim(),
+    );
+
+    const compatPath = path.join(tmpDir, ".config", "gogcli");
+    fs.mkdirSync(compatPath, { recursive: true });
+    fs.writeFileSync(path.join(compatPath, "config.json"), "{}");
+
+    execSync(`node "${binPath}" start`, {
+      stdio: "pipe",
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        SETUP_PASSWORD: "test-password",
+        ALPHACLAW_ROOT_DIR: tmpDir,
+        ALPHACLAW_TEST_HOME: tmpHome,
+        NODE_OPTIONS: `--require=${preloadPath}`,
+      },
+    });
+
+    expect(fs.lstatSync(compatPath).isDirectory()).toBe(true);
+    expect(fs.existsSync(path.join(compatPath, "config.json"))).toBe(true);
   });
 });

--- a/tests/server/gateway.test.js
+++ b/tests/server/gateway.test.js
@@ -102,12 +102,14 @@ describe("server/gateway restart behavior", () => {
 
     expect(gateway.gatewayEnv()).toEqual(
       expect.objectContaining({
+        HOME: expect.any(String),
         OPENCLAW_HOME: expect.any(String),
         OPENCLAW_CONFIG_PATH: `${OPENCLAW_DIR}/openclaw.json`,
         OPENCLAW_STATE_DIR: OPENCLAW_DIR,
         XDG_CONFIG_HOME: OPENCLAW_DIR,
       }),
     );
+    expect(gateway.gatewayEnv().HOME).toBe(gateway.gatewayEnv().OPENCLAW_HOME);
   });
 
   it("uses force restart when no managed child exists", () => {

--- a/tests/server/gog-skill.test.js
+++ b/tests/server/gog-skill.test.js
@@ -1,0 +1,27 @@
+const { buildGogSkillContent } = require("../../lib/server/gog-skill");
+
+describe("server/gog-skill", () => {
+  it("includes managed runtime guidance for direct gog shell usage", () => {
+    const fs = {
+      readFileSync: vi.fn(() => "## Sheets\n\n```bash\ngog sheets get <id> 'Sheet1!A1:B2'\n```"),
+    };
+    const content = buildGogSkillContent({
+      fs,
+      accounts: [
+        {
+          email: "chrys@example.com",
+          client: "default",
+          authenticated: true,
+          services: ["sheets:read"],
+        },
+      ],
+    });
+
+    expect(content).toContain("## Runtime Notes");
+    expect(content).toContain("$OPENCLAW_STATE_DIR");
+    expect(content).toContain(
+      'XDG_CONFIG_HOME="${OPENCLAW_STATE_DIR:-$OPENCLAW_HOME/.openclaw}"',
+    );
+    expect(content).toContain("--account <email>");
+  });
+});

--- a/tests/server/routes-onboarding.test.js
+++ b/tests/server/routes-onboarding.test.js
@@ -507,6 +507,7 @@ describe("server/routes/onboarding", () => {
     expect(onboardCall[0]).not.toContain("sk-ant-oat01-stale-token");
     expect(onboardCall[1]).toMatchObject({
       env: expect.objectContaining({
+        HOME: expect.any(String),
         OPENCLAW_CONFIG_PATH: "/tmp/openclaw/openclaw.json",
         OPENCLAW_STATE_DIR: "/tmp/openclaw",
         XDG_CONFIG_HOME: "/tmp/openclaw",


### PR DESCRIPTION
## Summary
- set managed AlphaClaw child processes to use the managed root as HOME
- create a narrow gogcli compatibility symlink under the managed home when no config exists there yet
- add regressions for the managed env wiring and gog skill guidance

## Testing
- npm test -- tests/bin/alphaclaw.test.js tests/server/gateway.test.js tests/server/routes-onboarding.test.js tests/server/gog-skill.test.js
- node --check bin/alphaclaw.js && node --check lib/server/gateway.js && node --check lib/server/onboarding/index.js && node --check lib/server/gog-skill.js