### PR TITLE
Load git shim token from repo .env when exec env is sanitized

### DIFF
--- a/lib/scripts/git
+++ b/lib/scripts/git
@@ -125,6 +125,12 @@ fi
 
 EFFECTIVE_PWD="$(resolve_effective_pwd "$@")"
 
+if [ -z "${GITHUB_TOKEN:-}" ] && in_openclaw_root "$EFFECTIVE_PWD" && [ -f "$OPENCLAW_REPO_ROOT/.env" ]; then
+  set -a
+  . "$OPENCLAW_REPO_ROOT/.env" >/dev/null 2>&1 || true
+  set +a
+fi
+
 if [ "${ALPHACLAW_GIT_NO_AUTH:-}" = "1" ] || [ -z "${GITHUB_TOKEN:-}" ] || ! in_openclaw_root "$EFFECTIVE_PWD"; then
   exec "$REAL_GIT" "$@"
 fi

--- a/tests/server/git-shim.test.js
+++ b/tests/server/git-shim.test.js
@@ -111,6 +111,31 @@ describe("server git shim scripts", () => {
     expect(log).toContain("ASKPASS_PASS=ghp_test_token");
   });
 
+  it("loads GITHUB_TOKEN from repo .env when exec env is sanitized", () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-root-"));
+    const repoRoot = path.join(tempRoot, "repo");
+    const outsideDir = path.join(tempRoot, "outside");
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(outsideDir, { recursive: true });
+    fs.writeFileSync(path.join(repoRoot, ".env"), 'GITHUB_TOKEN="ghp_env_token"\n');
+
+    const harness = createBehaviorHarness({ repoRoot });
+    const env = { ...process.env };
+    delete env.GITHUB_TOKEN;
+    execFileSync(harness.shimPath, ["-C", repoRoot, "push", "origin", "main"], {
+      cwd: outsideDir,
+      env,
+      stdio: "pipe",
+    });
+
+    const log = fs.readFileSync(harness.logPath, "utf8");
+    expect(log).toContain("ARG_1=-C");
+    expect(log).toContain(`ARG_2=${repoRoot}`);
+    expect(log).toContain("ARG_3=push");
+    expect(log).toContain("GIT_TERMINAL_PROMPT=0");
+    expect(log).toContain("ASKPASS_PASS=ghp_env_token");
+  });
+
   it("passes auth through when valued global options precede -C repo push commands", () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-git-root-"));
     const repoRoot = path.join(tempRoot, "repo");


### PR DESCRIPTION
## Summary
- load `GITHUB_TOKEN` from `/data/.openclaw/.env` when the git shim is running inside the managed OpenClaw repo and exec started with a sanitized environment
- keep the scope narrow so auth is still only injected for repo-local git commands
- add a regression test covering the `GITHUB_TOKEN only exists in .env` case

## Why
OpenClaw exec can start with a scrubbed environment, which means `GITHUB_TOKEN` may be missing even though the token still exists on disk in the managed repo's `.env`. In that case the git shim currently falls through to real git without auth, and plain `git push` fails for AlphaClaw-managed users.

## Testing
- `./node_modules/.bin/vitest run tests/server/git-shim.test.js`
