### PR TITLE
Avoid blocking on cold model catalog loads

### DIFF
--- a/lib/public/js/components/models-tab/use-models.js
+++ b/lib/public/js/components/models-tab/use-models.js
@@ -70,11 +70,13 @@ export const useModels = (agentId) => {
   const catalogFetchState = useCachedFetch(kModelCatalogCacheKey, fetchModels, {
     maxAgeMs: 30000,
   });
-  const configFetchState = useCachedFetch(
-    modelsConfigCacheKey,
+  const fetchModelsConfigForScope = useCallback(
     () => fetchModelsConfig(isScoped ? { agentId } : undefined),
-    { maxAgeMs: 30000 },
+    [agentId, isScoped],
   );
+  const configFetchState = useCachedFetch(modelsConfigCacheKey, fetchModelsConfigForScope, {
+    maxAgeMs: 30000,
+  });
   const codexFetchState = useCachedFetch("/api/codex/status", fetchCodexStatus, {
     maxAgeMs: 15000,
   });
@@ -119,7 +121,7 @@ export const useModels = (agentId) => {
     setError("");
     try {
       const [catalogResult, configResult, codex] = await Promise.all([
-        catalogFetchState.refresh({ force: true }),
+        catalogFetchState.refresh(),
         configFetchState.refresh({ force: true }),
         codexFetchState.refresh({ force: true }),
       ]);

--- a/lib/server/model-catalog-cache.js
+++ b/lib/server/model-catalog-cache.js
@@ -1,10 +1,32 @@
 const fs = require("fs");
 const path = require("path");
-const { ALPHACLAW_DIR, kFallbackOnboardingModels } = require("./constants");
+const {
+  ALPHACLAW_DIR,
+  OPENCLAW_DIR,
+  kFallbackOnboardingModels,
+} = require("./constants");
 
 const kModelCatalogCacheVersion = 1;
 const kModelCatalogRefreshBackoffMs = 30 * 1000;
-const kDefaultCachePath = path.join(ALPHACLAW_DIR, "cache", "model-catalog.json");
+const kDefaultCachePath = path.join(
+  OPENCLAW_DIR,
+  "cache",
+  "model-catalog.json",
+);
+const kLegacyCachePath = path.join(ALPHACLAW_DIR, "cache", "model-catalog.json");
+
+const uniquePaths = (items = []) => {
+  const seen = new Set();
+  return items
+    .map((item) => String(item || "").trim())
+    .filter((item) => {
+      if (!item || seen.has(item)) return false;
+      seen.add(item);
+      return true;
+    });
+};
+
+const kDefaultCacheReadPaths = uniquePaths([kDefaultCachePath, kLegacyCachePath]);
 
 const createResponse = ({
   source = "fallback",
@@ -26,20 +48,41 @@ const normalizeCachedModels = ({
   normalizeOnboardingModels = (items) => items,
 } = {}) =>
   normalizeOnboardingModels(
-    (Array.isArray(models) ? models : []).map((model) => ({
-      key: model?.key,
-      name: model?.label || model?.name || model?.key,
-    })),
+    (Array.isArray(models) ? models : []).map((model) => {
+      const key = getCachedModelKey(model);
+      return {
+        key,
+        name: model?.label || model?.name || key,
+      };
+    }),
   );
+
+const getCachedModelKey = (model) => {
+  const explicitKey = String(model?.key || model?.modelKey || "").trim();
+  if (explicitKey) return explicitKey;
+  const provider = String(model?.provider || "").trim();
+  const id = String(model?.id || model?.model || "").trim();
+  return provider && id ? `${provider}/${id}` : "";
+};
+
+const getRawCacheModels = (raw) => {
+  if (Array.isArray(raw)) return raw;
+  if (!raw || typeof raw !== "object") return [];
+  if (Array.isArray(raw.models)) return raw.models;
+  if (Array.isArray(raw.catalog)) return raw.catalog;
+  if (Array.isArray(raw.entries)) return raw.entries;
+  return [];
+};
 
 const normalizeCacheEntry = ({
   raw,
+  fallbackFetchedAt = null,
   normalizeOnboardingModels = (items) => items,
 } = {}) => {
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-  const fetchedAt = Number(raw.fetchedAt || 0);
+  if (!raw || typeof raw !== "object") return null;
+  const fetchedAt = Number(raw.fetchedAt || fallbackFetchedAt || 0);
   const models = normalizeCachedModels({
-    models: raw.models,
+    models: getRawCacheModels(raw),
     normalizeOnboardingModels,
   });
   if (!Number.isFinite(fetchedAt) || fetchedAt <= 0 || models.length === 0) {
@@ -52,21 +95,24 @@ const normalizeCacheEntry = ({
   };
 };
 
-const createModelCatalogCache = ({
-  fsModule = fs,
-  pathModule = path,
-  shellCmd,
-  gatewayEnv = () => ({}),
-  parseJsonFromNoisyOutput = () => ({}),
-  normalizeOnboardingModels = (items) => items,
-  fallbackModels = kFallbackOnboardingModels,
-  cachePath = kDefaultCachePath,
-  refreshBackoffMs = kModelCatalogRefreshBackoffMs,
-  now = () => Date.now(),
-  setTimeoutFn = setTimeout,
-  clearTimeoutFn = clearTimeout,
-  logger = console,
-} = {}) => {
+const createModelCatalogCache = (options = {}) => {
+  const {
+    fsModule = fs,
+    pathModule = path,
+    shellCmd,
+    gatewayEnv = () => ({}),
+    parseJsonFromNoisyOutput = () => ({}),
+    normalizeOnboardingModels = (items) => items,
+    fallbackModels = kFallbackOnboardingModels,
+    cachePath = kDefaultCachePath,
+    cacheReadPaths = options.cachePath ? [cachePath] : kDefaultCacheReadPaths,
+    refreshBackoffMs = kModelCatalogRefreshBackoffMs,
+    now = () => Date.now(),
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+    logger = console,
+  } = options;
+
   let cacheLoaded = false;
   let memoryCache = null;
   let cacheIsStale = false;
@@ -91,24 +137,39 @@ const createModelCatalogCache = ({
     return memoryCache;
   };
 
+  const getCacheFileFetchedAt = (candidatePath) => {
+    try {
+      const stat = fsModule.statSync(candidatePath);
+      const mtimeMs = Number(stat?.mtimeMs || 0);
+      return Number.isFinite(mtimeMs) && mtimeMs > 0 ? mtimeMs : null;
+    } catch {
+      return null;
+    }
+  };
+
   const readDiskCache = () => {
     if (cacheLoaded) return memoryCache;
     cacheLoaded = true;
-    try {
-      const raw = JSON.parse(fsModule.readFileSync(cachePath, "utf8"));
-      const entry = normalizeCacheEntry({
-        raw,
-        normalizeOnboardingModels,
-      });
-      if (!entry) return null;
-      memoryCache = entry;
-      cacheIsStale = true;
-      return memoryCache;
-    } catch {
-      memoryCache = null;
-      cacheIsStale = false;
-      return null;
+    for (const candidatePath of uniquePaths([cachePath, ...cacheReadPaths])) {
+      try {
+        const raw = JSON.parse(fsModule.readFileSync(candidatePath, "utf8"));
+        const entry = normalizeCacheEntry({
+          raw,
+          fallbackFetchedAt: getCacheFileFetchedAt(candidatePath),
+          normalizeOnboardingModels,
+        });
+        if (!entry) continue;
+        memoryCache = entry;
+        cacheIsStale = true;
+        return memoryCache;
+      } catch {
+        // Try the next candidate. Older deployments used a different path, and
+        // operators may also have created a CLI-shaped cache file by hand.
+      }
     }
+    memoryCache = null;
+    cacheIsStale = false;
+    return null;
   };
 
   const writeDiskCache = (entry) => {
@@ -237,4 +298,6 @@ module.exports = {
   kModelCatalogCacheVersion,
   kModelCatalogRefreshBackoffMs,
   kDefaultCachePath,
+  kDefaultCacheReadPaths,
+  kLegacyCachePath,
 };

--- a/lib/server/model-catalog-cache.js
+++ b/lib/server/model-catalog-cache.js
@@ -166,9 +166,9 @@ const createModelCatalogCache = ({
     );
   };
 
-  const startBackgroundRefresh = () => {
+  const startBackgroundRefresh = ({ allowEmptyCache = false } = {}) => {
     readDiskCache();
-    if (!memoryCache) return null;
+    if (!memoryCache && !allowEmptyCache) return null;
     if (refreshPromise) return refreshPromise;
     if (retryTimer) return null;
     if (backoffUntilMs > now()) {
@@ -209,25 +209,14 @@ const createModelCatalogCache = ({
           models: memoryCache.models,
         });
       }
-      try {
-        const freshEntry = await loadFreshCatalog();
-        return createResponse({
-          source: "openclaw",
-          fetchedAt: freshEntry.fetchedAt,
-          stale: false,
-          refreshing: false,
-          models: freshEntry.models,
-        });
-      } catch (err) {
-        handleRefreshFailure(err);
-        return createResponse({
-          source: "fallback",
-          fetchedAt: null,
-          stale: false,
-          refreshing: false,
-          models: fallbackModels,
-        });
-      }
+      startBackgroundRefresh({ allowEmptyCache: true });
+      return createResponse({
+        source: "fallback",
+        fetchedAt: null,
+        stale: false,
+        refreshing: isRefreshPending(),
+        models: fallbackModels,
+      });
     },
 
     markStale() {

--- a/tests/server/model-catalog-cache.test.js
+++ b/tests/server/model-catalog-cache.test.js
@@ -4,7 +4,11 @@ const path = require("path");
 
 const {
   createModelCatalogCache,
+  kDefaultCachePath,
+  kDefaultCacheReadPaths,
+  kLegacyCachePath,
   kModelCatalogRefreshBackoffMs,
+  normalizeCacheEntry,
 } = require("../../lib/server/model-catalog-cache");
 const { kFallbackOnboardingModels } = require("../../lib/server/constants");
 
@@ -96,6 +100,92 @@ describe("server/model-catalog-cache", () => {
     expect(written.models).toEqual(
       normalizeModels([{ key: "openai/gpt-fresh", name: "Fresh" }]),
     );
+  });
+
+  it("normalizes OpenClaw-shaped cache entries using provider/id keys", () => {
+    const entry = normalizeCacheEntry({
+      raw: {
+        models: [{ provider: "openai", id: "gpt-cached", name: "Cached" }],
+      },
+      fallbackFetchedAt: 333,
+      normalizeOnboardingModels: normalizeModels,
+    });
+
+    expect(entry).toEqual({
+      version: 1,
+      fetchedAt: 333,
+      models: normalizeModels([{ key: "openai/gpt-cached", name: "Cached" }]),
+    });
+  });
+
+  it("accepts raw array cache files using the file timestamp as fetchedAt", () => {
+    const entry = normalizeCacheEntry({
+      raw: [{ provider: "openai", id: "gpt-array", name: "Array" }],
+      fallbackFetchedAt: 444,
+      normalizeOnboardingModels: normalizeModels,
+    });
+
+    expect(entry).toEqual({
+      version: 1,
+      fetchedAt: 444,
+      models: normalizeModels([{ key: "openai/gpt-array", name: "Array" }]),
+    });
+  });
+
+  it("reads legacy cache files and writes refreshed data to the primary cache path", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "alphaclaw-model-catalog-legacy-"),
+    );
+    const primaryCachePath = path.join(
+      tempRoot,
+      ".openclaw",
+      "cache",
+      "model-catalog.json",
+    );
+    const legacyCachePath = path.join(tempRoot, "cache", "model-catalog.json");
+    writeCacheFile({
+      cachePath: legacyCachePath,
+      fetchedAt: 555,
+      models: [{ provider: "openai", id: "gpt-legacy", name: "Legacy" }],
+    });
+
+    const shellCmd = vi.fn().mockResolvedValue("{}");
+    const parseJsonFromNoisyOutput = vi.fn(() => ({
+      models: [{ key: "openai/gpt-primary", name: "Primary" }],
+    }));
+    const cache = createModelCatalogCache({
+      cachePath: primaryCachePath,
+      cacheReadPaths: [primaryCachePath, legacyCachePath],
+      shellCmd,
+      parseJsonFromNoisyOutput,
+      normalizeOnboardingModels: normalizeModels,
+    });
+
+    const cached = await cache.getCatalogResponse();
+
+    expect(cached).toEqual({
+      ok: true,
+      source: "cache",
+      fetchedAt: 555,
+      stale: true,
+      refreshing: true,
+      models: normalizeModels([{ key: "openai/gpt-legacy", name: "Legacy" }]),
+    });
+
+    await flushPromises();
+    expect(fs.existsSync(primaryCachePath)).toBe(true);
+    const written = JSON.parse(fs.readFileSync(primaryCachePath, "utf8"));
+    expect(written.models).toEqual(
+      normalizeModels([{ key: "openai/gpt-primary", name: "Primary" }]),
+    );
+  });
+
+  it("keeps the default cache under .openclaw and reads the previous root cache path", () => {
+    expect(kDefaultCachePath).toContain(
+      `${path.sep}.openclaw${path.sep}cache${path.sep}model-catalog.json`,
+    );
+    expect(kDefaultCacheReadPaths).toContain(kDefaultCachePath);
+    expect(kDefaultCacheReadPaths).toContain(kLegacyCachePath);
   });
 
   it("keeps serving cache after refresh failures and retries after backoff", async () => {

--- a/tests/server/model-catalog-cache.test.js
+++ b/tests/server/model-catalog-cache.test.js
@@ -161,6 +161,59 @@ describe("server/model-catalog-cache", () => {
     });
   });
 
+  it("returns fallback immediately on cold cache and refreshes in the background", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "alphaclaw-model-catalog-cold-"),
+    );
+    const cachePath = path.join(tempRoot, "cache", "model-catalog.json");
+    let resolveShell;
+    const shellCmd = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveShell = resolve;
+        }),
+    );
+    const parseJsonFromNoisyOutput = vi.fn(() => ({
+      models: [{ key: "openai/gpt-fresh", name: "Fresh" }],
+    }));
+    const cache = createModelCatalogCache({
+      cachePath,
+      shellCmd,
+      parseJsonFromNoisyOutput,
+      normalizeOnboardingModels: normalizeModels,
+    });
+
+    const response = await cache.getCatalogResponse();
+
+    expect(response).toEqual({
+      ok: true,
+      source: "fallback",
+      fetchedAt: null,
+      stale: false,
+      refreshing: true,
+      models: kFallbackOnboardingModels,
+    });
+    expect(shellCmd).toHaveBeenCalledTimes(1);
+
+    const secondResponse = await cache.getCatalogResponse();
+    expect(secondResponse.source).toBe("fallback");
+    expect(secondResponse.refreshing).toBe(true);
+    expect(shellCmd).toHaveBeenCalledTimes(1);
+
+    resolveShell("{}");
+    await flushPromises();
+
+    const fresh = await cache.getCatalogResponse();
+    expect(fresh).toEqual({
+      ok: true,
+      source: "openclaw",
+      fetchedAt: expect.any(Number),
+      stale: false,
+      refreshing: false,
+      models: normalizeModels([{ key: "openai/gpt-fresh", name: "Fresh" }]),
+    });
+  });
+
   it("falls back when no cache exists and the CLI load fails", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "alphaclaw-model-catalog-fallback-"),
@@ -181,8 +234,11 @@ describe("server/model-catalog-cache", () => {
       source: "fallback",
       fetchedAt: null,
       stale: false,
-      refreshing: false,
+      refreshing: true,
       models: kFallbackOnboardingModels,
     });
+    expect(shellCmd).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
   });
 });

--- a/tests/server/routes-models.test.js
+++ b/tests/server/routes-models.test.js
@@ -62,7 +62,7 @@ const createApp = (deps) => {
 };
 
 describe("server/routes/models", () => {
-  it("returns normalized models from openclaw output", async () => {
+  it("returns fallback immediately while refreshing a cold model catalog", async () => {
     const deps = createModelDeps();
     deps.shellCmd.mockResolvedValue("noise");
     deps.parseJsonFromNoisyOutput.mockReturnValue({
@@ -72,6 +72,38 @@ describe("server/routes/models", () => {
       { key: "openai/gpt-5.1-codex", provider: "openai", label: "GPT" },
     ]);
     const app = createApp(deps);
+
+    const res = await request(app).get("/api/models");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      source: "fallback",
+      fetchedAt: null,
+      stale: false,
+      refreshing: true,
+      models: kFallbackOnboardingModels,
+    });
+    expect(deps.shellCmd).toHaveBeenCalledWith("openclaw models list --all --json", {
+      env: { OPENCLAW_GATEWAY_TOKEN: "token" },
+      timeout: 30000,
+    });
+  });
+
+  it("returns normalized models from the background-refreshed catalog", async () => {
+    const deps = createModelDeps();
+    deps.shellCmd.mockResolvedValue("noise");
+    deps.parseJsonFromNoisyOutput.mockReturnValue({
+      models: [{ key: "openai/gpt-5.1-codex", name: "GPT" }],
+    });
+    deps.normalizeOnboardingModels.mockReturnValue([
+      { key: "openai/gpt-5.1-codex", provider: "openai", label: "GPT" },
+    ]);
+    const app = createApp(deps);
+
+    await request(app).get("/api/models");
+    await Promise.resolve();
+    await Promise.resolve();
 
     const res = await request(app).get("/api/models");
 
@@ -86,10 +118,7 @@ describe("server/routes/models", () => {
         models: [{ key: "openai/gpt-5.1-codex", provider: "openai", label: "GPT" }],
       }),
     );
-    expect(deps.shellCmd).toHaveBeenCalledWith("openclaw models list --all --json", {
-      env: { OPENCLAW_GATEWAY_TOKEN: "token" },
-      timeout: 30000,
-    });
+    expect(deps.shellCmd).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to static models when normalized list is empty", async () => {
@@ -107,7 +136,7 @@ describe("server/routes/models", () => {
       source: "fallback",
       fetchedAt: null,
       stale: false,
-      refreshing: false,
+      refreshing: true,
       models: kFallbackOnboardingModels,
     });
   });
@@ -125,7 +154,7 @@ describe("server/routes/models", () => {
       source: "fallback",
       fetchedAt: null,
       stale: false,
-      refreshing: false,
+      refreshing: true,
       models: kFallbackOnboardingModels,
     });
   });


### PR DESCRIPTION
## Summary
- return fallback models immediately when the server has no model catalog cache yet
- start the slow OpenClaw model catalog load in the background instead of blocking `/api/models`
- store the primary model catalog cache under `/data/.openclaw/cache/model-catalog.json` while reading the old `/data/cache/model-catalog.json` path as a migration fallback
- accept cache files shaped like OpenClaw catalog entries (`provider` + `id`) or raw arrays, using the file mtime when `fetchedAt` is absent
- stop force-refreshing `/api/models` on normal Models/Agent model-card mount so client-side cache can be reused across tab revisits

## Testing
- `npm run build:ui`
- `npm test -- tests/server/model-catalog-cache.test.js tests/server/routes-models.test.js`
- `npm test -- tests/frontend/model-catalog.test.js`
- `npm test`
