### PR TITLE
Fix OpenClaw fallback resolution for template-pinned AlphaClaw versions

### DIFF
--- a/lib/server/alphaclaw-version.js
+++ b/lib/server/alphaclaw-version.js
@@ -96,7 +96,7 @@ const extractTemplateVersions = (pkg) => ({
   latestOpenclawVersion: normalizeOpenclawVersion(pkg?.dependencies?.openclaw),
 });
 
-const fetchLatestVersionFromRegistry = async ({ fetchImpl }) => {
+const fetchLatestVersionFromRegistry = async ({ fetchImpl, version = null }) => {
   if (typeof fetchImpl !== "function") {
     throw new Error("Fetch is not available for AlphaClaw version checks");
   }
@@ -109,7 +109,8 @@ const fetchLatestVersionFromRegistry = async ({ fetchImpl }) => {
     response,
     "Failed to fetch latest AlphaClaw version",
   );
-  const latestVersion = normalizeVersion(data?.["dist-tags"]?.latest);
+  const latestVersion =
+    normalizeVersion(version) || normalizeVersion(data?.["dist-tags"]?.latest);
   const latestOpenclawVersion = latestVersion
     ? normalizeOpenclawVersion(
         data?.versions?.[latestVersion]?.dependencies?.openclaw,
@@ -143,7 +144,10 @@ const fetchTemplatePackageVersions = async ({
   const versions = extractTemplateVersions(data);
   if (!versions.latestOpenclawVersion && versions.latestVersion) {
     try {
-      const registry = await fetchLatestVersionFromRegistry({ fetchImpl });
+      const registry = await fetchLatestVersionFromRegistry({
+        fetchImpl,
+        version: versions.latestVersion,
+      });
       versions.latestOpenclawVersion = registry.latestOpenclawVersion || null;
     } catch {}
   }

--- a/tests/server/alphaclaw-version.test.js
+++ b/tests/server/alphaclaw-version.test.js
@@ -129,6 +129,58 @@ describe("server/alphaclaw-version", () => {
     );
   });
 
+  it("derives the OpenClaw version from the template-pinned AlphaClaw package when the template omits a direct openclaw pin", async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (
+        String(url).includes(
+          "https://raw.githubusercontent.com/chrysb/openclaw-railway-template/main/package.json",
+        )
+      ) {
+        return createFetchResponse({
+          body: {
+            dependencies: {
+              "@chrysb/alphaclaw": "0.9.2",
+            },
+          },
+        });
+      }
+
+      expect(url).toBe("https://registry.npmjs.org/@chrysb%2falphaclaw");
+      return createFetchResponse({
+        body: {
+          "dist-tags": { latest: "0.9.6" },
+          versions: {
+            "0.9.2": {
+              dependencies: {
+                openclaw: "2026.4.11",
+              },
+            },
+            "0.9.6": {
+              dependencies: {
+                openclaw: "2026.4.14",
+              },
+            },
+          },
+        },
+      });
+    });
+    const { service } = createService({
+      env: { RAILWAY_ENVIRONMENT: "production" },
+      readOpenclawVersion: () => "2026.4.5",
+      fetchMock,
+    });
+
+    const status = await service.getVersionStatus(true);
+
+    expect(status).toEqual(
+      expect.objectContaining({
+        ok: true,
+        latestVersion: "0.9.2",
+        latestOpenclawVersion: "2026.4.11",
+      }),
+    );
+  });
+
   it("includes a direct Railway dashboard link when project metadata is available", async () => {
     const fetchMock = vi.fn(async () =>
       createFetchResponse({


### PR DESCRIPTION
Fixes #67

## Summary
- resolve fallback OpenClaw metadata using the template-pinned `@chrysb/alphaclaw` version when a managed template omits a direct `openclaw` pin
- add regression coverage for templates that only pin `@chrysb/alphaclaw`
- keep self-hosted npm-latest resolution unchanged

## Why
This follows up on the template-only-pin direction from #65.

The current fallback still does:
- template `latestVersion` from the managed template
- `latestOpenclawVersion` from npm `dist-tags.latest`

That can produce a mixed result such as:
- `latestVersion = 0.9.2`
- `latestOpenclawVersion = 2026.4.14`

when the template-pinned `0.9.2` package actually depends on `openclaw 2026.4.11`.

This change keeps the resolver aligned with the same pinned AlphaClaw version the template already selected.

## Testing
- `node --check lib/server/alphaclaw-version.js`
- `node --check tests/server/alphaclaw-version.test.js`
- added regression coverage for the template-fallback mismatch case
- validated the fallback/latest/direct-pin paths with mocked fetch responses locally

## Scope
- no template repo changes
- no behavior change for self-hosted npm-latest checks
- only affects the managed-template fallback path when direct `openclaw` pin is absent
