### PR TITLE
fix(test): resolve flaky usage-db timeout via vitest singleFork

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,5 +7,11 @@ export default defineConfig({
     include: ["tests/**/*.test.js"],
     restoreMocks: true,
     clearMocks: true,
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

- `tests/server/usage-db.test.js` intermittently times out (63s) when the full suite runs in parallel
- Root cause: multiple test files open concurrent `DatabaseSync` (`node:sqlite`) connections to WAL-mode SQLite databases; vitest's default parallel worker pool causes WAL write-lock contention that exceeds the 5000ms `busy_timeout`
- Fix: set `pool: "forks"` + `singleFork: true` in `vitest.config.js` so all test files share one process and SQLite connections are serialized

## Test plan

- [x] `npm test` — 551 tests pass, no timeouts, suite completes in ~7s (was ~64s when flaking)
- [x] Verified the failing test passes in isolation before and after the fix
- [x] No test logic changes — config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)