### PR TITLE
docs: link UTM-on-macOS install walkthrough from Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ EXPOSE 3000
 CMD ["alphaclaw", "start"]
 ```
 
+### UTM (macOS virtual machine)
+
+To run AlphaClaw inside a full virtual machine on a Mac (for maximum isolation from the host filesystem), use [UTM](https://mac.getutm.app) with Ubuntu Server. A community walkthrough covers the full flow, from UTM install to Apple Silicon vs Intel ISO selection to recommended VM resources (8 GB RAM, 4 CPU, 30 GB disk): [AlphaClaw in UTM on Mac](https://github.com/mayurjobanputra/AlphaClaw-in-UTM-on-Mac).
+
+Once the Ubuntu VM is up, the Local / Docker steps above apply unchanged inside the guest.
+
 ## Setup UI
 
 | Tab           | What it manages                                                                                                          |


### PR DESCRIPTION
Closes #36.

Adds a short `UTM (macOS virtual machine)` subsection under Quick Start that points users toward the community-maintained walkthrough at [mayurjobanputra/AlphaClaw-in-UTM-on-Mac](https://github.com/mayurjobanputra/AlphaClaw-in-UTM-on-Mac). That guide already covers UTM install, Apple Silicon vs Intel ISO selection, UTM VM configuration (8 GB RAM, 4 CPU, 30 GB disk), and the Ubuntu guest install steps, so the new README section keeps the footprint tiny: one linked paragraph, plus a note that once the VM is up the Local / Docker steps above apply unchanged inside the guest.

This is the smallest docs touch that addresses the issue - a reader following the Quick Start now finds the UTM path without having to search outside the README, and the external walkthrough remains the source of truth for the VM setup details so the README doesn't duplicate (or diverge from) them over time.