### PR TITLE
Add Thinking default and Dreaming toggles to General menu

### DIFF
--- a/lib/public/js/components/general/agent-defaults.js
+++ b/lib/public/js/components/general/agent-defaults.js
@@ -2,12 +2,15 @@ import { h } from "preact";
 import { useEffect, useState } from "preact/hooks";
 import htm from "htm";
 import { fetchAgentDefaults, updateAgentDefaults } from "../../lib/api.js";
+import { setCached } from "../../lib/api-cache.js";
+import { useCachedFetch } from "../../hooks/use-cached-fetch.js";
 import { ChevronDownIcon } from "../icons.js";
 import { ToggleSwitch } from "../toggle-switch.js";
 import { showToast } from "../toast.js";
 
 const html = htm.bind(h);
 
+const kAgentDefaultsCacheKey = "/api/agent-defaults";
 const kThinkingOptions = [
   { value: "off", label: "Off" },
   { value: "low", label: "Low" },
@@ -15,47 +18,40 @@ const kThinkingOptions = [
   { value: "high", label: "High" },
 ];
 
-export const AgentDefaults = ({ onRestartRequired = () => {} }) => {
-  const [loading, setLoading] = useState(true);
+export const AgentDefaults = () => {
+  const { data, loading } = useCachedFetch(
+    kAgentDefaultsCacheKey,
+    fetchAgentDefaults,
+    { maxAgeMs: 30000 },
+  );
+  const serverDefaults = data?.agentDefaults || null;
   const [savingKey, setSavingKey] = useState("");
   const [thinking, setThinking] = useState("medium");
   const [dreaming, setDreaming] = useState(false);
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const data = await fetchAgentDefaults();
-        if (cancelled) return;
-        const next = data.agentDefaults || {};
-        if (typeof next.thinking === "string") setThinking(next.thinking);
-        if (typeof next.dreaming === "boolean") setDreaming(next.dreaming);
-      } catch (err) {
-        if (!cancelled) {
-          showToast(err.message || "Could not load agent defaults", "error");
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    if (!serverDefaults) return;
+    if (typeof serverDefaults.thinking === "string") {
+      setThinking(serverDefaults.thinking);
+    }
+    if (typeof serverDefaults.dreaming === "boolean") {
+      setDreaming(serverDefaults.dreaming);
+    }
+  }, [serverDefaults?.thinking, serverDefaults?.dreaming]);
 
   const save = async (key, payload, optimistic) => {
     const previous = key === "thinking" ? thinking : dreaming;
     optimistic();
     setSavingKey(key);
     try {
-      const data = await updateAgentDefaults(payload);
-      if (!data.ok) {
-        throw new Error(data.error || "Could not save agent defaults");
+      const response = await updateAgentDefaults(payload);
+      if (!response.ok) {
+        throw new Error(response.error || "Could not save agent defaults");
       }
-      const next = data.agentDefaults || {};
+      const next = response.agentDefaults || {};
       if (typeof next.thinking === "string") setThinking(next.thinking);
       if (typeof next.dreaming === "boolean") setDreaming(next.dreaming);
-      if (data.restartRequired) onRestartRequired(true);
+      setCached(kAgentDefaultsCacheKey, { ...(data || {}), ...response });
       showToast("Agent defaults saved", "success");
     } catch (err) {
       if (key === "thinking") setThinking(previous);
@@ -75,6 +71,8 @@ export const AgentDefaults = ({ onRestartRequired = () => {} }) => {
     save("dreaming", { dreaming: nextDreaming }, () => setDreaming(nextDreaming));
   };
 
+  const disabled = loading && !serverDefaults;
+
   return html`
     <div class="bg-surface border border-border rounded-xl p-4">
       <h2 class="card-label mb-3">Agent Defaults</h2>
@@ -88,8 +86,8 @@ export const AgentDefaults = ({ onRestartRequired = () => {} }) => {
             <select
               value=${thinking}
               onchange=${handleThinkingChange}
-              disabled=${loading || savingKey === "thinking"}
-              class="appearance-none bg-field border border-border rounded-lg pl-2.5 pr-9 py-1.5 text-xs text-body ${loading ||
+              disabled=${disabled || savingKey === "thinking"}
+              class="appearance-none bg-field border border-border rounded-lg pl-2.5 pr-9 py-1.5 text-xs text-body ${disabled ||
               savingKey === "thinking"
                 ? "opacity-50 cursor-not-allowed"
                 : ""}"
@@ -112,7 +110,7 @@ export const AgentDefaults = ({ onRestartRequired = () => {} }) => {
           </div>
           <${ToggleSwitch}
             checked=${dreaming}
-            disabled=${loading || savingKey === "dreaming"}
+            disabled=${disabled || savingKey === "dreaming"}
             onChange=${handleDreamingChange}
             label=${dreaming ? "On" : "Off"}
           />

--- a/lib/public/js/components/general/agent-defaults.js
+++ b/lib/public/js/components/general/agent-defaults.js
@@ -55,7 +55,7 @@ export const AgentDefaults = ({ onRestartRequired = () => {} }) => {
       const next = data.agentDefaults || {};
       if (typeof next.thinking === "string") setThinking(next.thinking);
       if (typeof next.dreaming === "boolean") setDreaming(next.dreaming);
-      if (data.restartRequired) onRestartRequired();
+      if (data.restartRequired) onRestartRequired(true);
       showToast("Agent defaults saved", "success");
     } catch (err) {
       if (key === "thinking") setThinking(previous);

--- a/lib/public/js/components/general/agent-defaults.js
+++ b/lib/public/js/components/general/agent-defaults.js
@@ -1,0 +1,123 @@
+import { h } from "preact";
+import { useEffect, useState } from "preact/hooks";
+import htm from "htm";
+import { fetchAgentDefaults, updateAgentDefaults } from "../../lib/api.js";
+import { ChevronDownIcon } from "../icons.js";
+import { ToggleSwitch } from "../toggle-switch.js";
+import { showToast } from "../toast.js";
+
+const html = htm.bind(h);
+
+const kThinkingOptions = [
+  { value: "off", label: "Off" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+];
+
+export const AgentDefaults = ({ onRestartRequired = () => {} }) => {
+  const [loading, setLoading] = useState(true);
+  const [savingKey, setSavingKey] = useState("");
+  const [thinking, setThinking] = useState("medium");
+  const [dreaming, setDreaming] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchAgentDefaults();
+        if (cancelled) return;
+        const next = data.agentDefaults || {};
+        if (typeof next.thinking === "string") setThinking(next.thinking);
+        if (typeof next.dreaming === "boolean") setDreaming(next.dreaming);
+      } catch (err) {
+        if (!cancelled) {
+          showToast(err.message || "Could not load agent defaults", "error");
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const save = async (key, payload, optimistic) => {
+    const previous = key === "thinking" ? thinking : dreaming;
+    optimistic();
+    setSavingKey(key);
+    try {
+      const data = await updateAgentDefaults(payload);
+      if (!data.ok) {
+        throw new Error(data.error || "Could not save agent defaults");
+      }
+      const next = data.agentDefaults || {};
+      if (typeof next.thinking === "string") setThinking(next.thinking);
+      if (typeof next.dreaming === "boolean") setDreaming(next.dreaming);
+      if (data.restartRequired) onRestartRequired();
+      showToast("Agent defaults saved", "success");
+    } catch (err) {
+      if (key === "thinking") setThinking(previous);
+      else setDreaming(previous);
+      showToast(err.message || "Could not save agent defaults", "error");
+    } finally {
+      setSavingKey("");
+    }
+  };
+
+  const handleThinkingChange = (event) => {
+    const nextThinking = String(event.target.value || "");
+    save("thinking", { thinking: nextThinking }, () => setThinking(nextThinking));
+  };
+
+  const handleDreamingChange = (nextDreaming) => {
+    save("dreaming", { dreaming: nextDreaming }, () => setDreaming(nextDreaming));
+  };
+
+  return html`
+    <div class="bg-surface border border-border rounded-xl p-4">
+      <h2 class="card-label mb-3">Agent Defaults</h2>
+      <div class="space-y-3">
+        <div class="flex items-center justify-between gap-3">
+          <div class="min-w-0">
+            <p class="text-sm text-body">Thinking default</p>
+            <p class="text-xs text-fg-muted">Default reasoning depth for agent calls.</p>
+          </div>
+          <div class="relative shrink-0">
+            <select
+              value=${thinking}
+              onchange=${handleThinkingChange}
+              disabled=${loading || savingKey === "thinking"}
+              class="appearance-none bg-field border border-border rounded-lg pl-2.5 pr-9 py-1.5 text-xs text-body ${loading ||
+              savingKey === "thinking"
+                ? "opacity-50 cursor-not-allowed"
+                : ""}"
+            >
+              ${kThinkingOptions.map(
+                (option) => html`
+                  <option value=${option.value}>${option.label}</option>
+                `,
+              )}
+            </select>
+            <${ChevronDownIcon}
+              className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-fg-muted"
+            />
+          </div>
+        </div>
+        <div class="flex items-center justify-between gap-3">
+          <div class="min-w-0">
+            <p class="text-sm text-body">Dreaming</p>
+            <p class="text-xs text-fg-muted">Allow the agent to run background ideation between turns.</p>
+          </div>
+          <${ToggleSwitch}
+            checked=${dreaming}
+            disabled=${loading || savingKey === "dreaming"}
+            onChange=${handleDreamingChange}
+            label=${dreaming ? "On" : "Off"}
+          />
+        </div>
+      </div>
+    </div>
+  `;
+};

--- a/lib/public/js/components/general/index.js
+++ b/lib/public/js/components/general/index.js
@@ -132,7 +132,7 @@ export const GeneralTab = ({
         `}
       />
       <${Features} onSwitchTab=${onSwitchTab} />
-      <${AgentDefaults} onRestartRequired=${onRestartRequired} />
+      <${AgentDefaults} />
       <${Google}
         gatewayStatus=${state.gatewayStatus}
         onRestartRequired=${onRestartRequired}

--- a/lib/public/js/components/general/index.js
+++ b/lib/public/js/components/general/index.js
@@ -11,6 +11,7 @@ import { Features } from "../features.js";
 import { GeneralDoctorWarning } from "../doctor/general-warning.js";
 import { ChevronDownIcon } from "../icons.js";
 import { UpdateActionButton } from "../update-action-button.js";
+import { AgentDefaults } from "./agent-defaults.js";
 import { useGeneralTab } from "./use-general-tab.js";
 
 const html = htm.bind(h);
@@ -131,6 +132,7 @@ export const GeneralTab = ({
         `}
       />
       <${Features} onSwitchTab=${onSwitchTab} />
+      <${AgentDefaults} onRestartRequired=${onRestartRequired} />
       <${Google}
         gatewayStatus=${state.gatewayStatus}
         onRestartRequired=${onRestartRequired}

--- a/lib/public/js/lib/api.js
+++ b/lib/public/js/lib/api.js
@@ -516,6 +516,40 @@ export async function updateAlphaclaw() {
   return res.json();
 }
 
+export async function fetchAgentDefaults() {
+  const res = await authFetch("/api/agent-defaults");
+  const text = await res.text();
+  let data;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(text || "Could not parse agent defaults response");
+  }
+  if (!res.ok) {
+    throw new Error(data.error || text || `HTTP ${res.status}`);
+  }
+  return data;
+}
+
+export async function updateAgentDefaults(payload) {
+  const res = await authFetch("/api/agent-defaults", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const text = await res.text();
+  let data;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(text || "Could not parse agent defaults response");
+  }
+  if (!res.ok) {
+    throw new Error(data.error || text || `HTTP ${res.status}`);
+  }
+  return data;
+}
+
 export async function fetchSyncCron() {
   const res = await authFetch("/api/sync-cron");
   const text = await res.text();

--- a/lib/server/agent-defaults-config.js
+++ b/lib/server/agent-defaults-config.js
@@ -1,8 +1,18 @@
 const fs = require("fs");
 const {
   readOpenclawConfig,
+  resolveOpenclawConfigPath,
   writeOpenclawConfig,
 } = require("./openclaw-config");
+
+class MalformedOpenclawConfigError extends Error {
+  constructor(configPath) {
+    super(
+      `Refusing to overwrite ${configPath}: file exists but could not be parsed as JSON. Inspect or restore it before changing agent defaults.`,
+    );
+    this.code = "MALFORMED_OPENCLAW_CONFIG";
+  }
+}
 
 const kThinkingLevels = Object.freeze(["off", "low", "medium", "high"]);
 const kDefaultThinkingLevel = "medium";
@@ -43,11 +53,19 @@ const writeAgentDefaults = ({
   thinking,
   dreaming,
 } = {}) => {
+  const configPath = resolveOpenclawConfigPath({ openclawDir });
+  const exists =
+    typeof fsModule.existsSync === "function"
+      ? fsModule.existsSync(configPath)
+      : null;
   const config = readOpenclawConfig({
     fsModule,
     openclawDir,
-    fallback: {},
+    fallback: exists === true ? null : {},
   });
+  if (exists === true && config === null) {
+    throw new MalformedOpenclawConfigError(configPath);
+  }
   const safeConfig =
     config && typeof config === "object" && !Array.isArray(config) ? config : {};
   const before = JSON.stringify(safeConfig.agentDefaults || null);
@@ -78,6 +96,7 @@ const writeAgentDefaults = ({
 };
 
 module.exports = {
+  MalformedOpenclawConfigError,
   kThinkingLevels,
   kDefaultThinkingLevel,
   kDefaultDreamingEnabled,

--- a/lib/server/agent-defaults-config.js
+++ b/lib/server/agent-defaults-config.js
@@ -1,0 +1,88 @@
+const fs = require("fs");
+const {
+  readOpenclawConfig,
+  writeOpenclawConfig,
+} = require("./openclaw-config");
+
+const kThinkingLevels = Object.freeze(["off", "low", "medium", "high"]);
+const kDefaultThinkingLevel = "medium";
+const kDefaultDreamingEnabled = false;
+
+const isThinkingLevel = (value) =>
+  typeof value === "string" && kThinkingLevels.includes(value);
+
+const normalizeAgentDefaults = (rawConfig = {}) => {
+  const config =
+    rawConfig && typeof rawConfig === "object" && !Array.isArray(rawConfig)
+      ? rawConfig
+      : {};
+  const raw =
+    config.agentDefaults &&
+    typeof config.agentDefaults === "object" &&
+    !Array.isArray(config.agentDefaults)
+      ? config.agentDefaults
+      : {};
+  return {
+    thinking: isThinkingLevel(raw.thinking) ? raw.thinking : kDefaultThinkingLevel,
+    dreaming: typeof raw.dreaming === "boolean" ? raw.dreaming : kDefaultDreamingEnabled,
+  };
+};
+
+const readAgentDefaults = ({ fsModule = fs, openclawDir } = {}) => {
+  const config = readOpenclawConfig({
+    fsModule,
+    openclawDir,
+    fallback: {},
+  });
+  return normalizeAgentDefaults(config);
+};
+
+const writeAgentDefaults = ({
+  fsModule = fs,
+  openclawDir,
+  thinking,
+  dreaming,
+} = {}) => {
+  const config = readOpenclawConfig({
+    fsModule,
+    openclawDir,
+    fallback: {},
+  });
+  const safeConfig =
+    config && typeof config === "object" && !Array.isArray(config) ? config : {};
+  const before = JSON.stringify(safeConfig.agentDefaults || null);
+  const next = normalizeAgentDefaults(safeConfig);
+  if (typeof thinking === "string") {
+    if (!isThinkingLevel(thinking)) {
+      throw new Error(
+        `thinking must be one of: ${kThinkingLevels.join(", ")}`,
+      );
+    }
+    next.thinking = thinking;
+  }
+  if (typeof dreaming === "boolean") {
+    next.dreaming = dreaming;
+  }
+  safeConfig.agentDefaults = next;
+  const after = JSON.stringify(safeConfig.agentDefaults);
+  const changed = before !== after;
+  if (changed) {
+    writeOpenclawConfig({
+      fsModule,
+      openclawDir,
+      config: safeConfig,
+      spacing: 2,
+    });
+  }
+  return { changed, agentDefaults: next };
+};
+
+module.exports = {
+  kThinkingLevels,
+  kDefaultThinkingLevel,
+  kDefaultDreamingEnabled,
+  isThinkingLevel,
+  normalizeAgentDefaults,
+  readAgentDefaults,
+  writeAgentDefaults,
+};

--- a/lib/server/constants.js
+++ b/lib/server/constants.js
@@ -408,6 +408,7 @@ const SETUP_API_PREFIXES = [
   "/api/channels",
   "/api/operations",
   "/api/nodes",
+  "/api/agent-defaults",
 ];
 
 module.exports = {

--- a/lib/server/doctor/service.js
+++ b/lib/server/doctor/service.js
@@ -15,6 +15,7 @@ const {
   kDoctorRunTimeoutMs,
   kDoctorStaleThresholdMs,
 } = require("./constants");
+const { readAgentDefaults } = require("../agent-defaults-config");
 
 const kMaxSnippetLines = 20;
 
@@ -214,12 +215,13 @@ const createDoctorService = ({
         promptVersion: kDoctorPromptVersion,
       });
       const gatewayTimeoutMs = kDoctorRunTimeoutMs + 30000;
+      const { thinking } = readAgentDefaults({ openclawDir: managedRoot });
       const gatewayParams = {
         agentId: "main",
         idempotencyKey: buildDoctorIdempotencyKey(runId),
         message: prompt,
         sessionKey: buildDoctorSessionKey(runId),
-        thinking: "medium",
+        thinking,
         timeout: Math.round(kDoctorRunTimeoutMs / 1000),
       };
       const result = await clawCmd(

--- a/lib/server/routes/system.js
+++ b/lib/server/routes/system.js
@@ -1,5 +1,11 @@
 const { buildManagedPaths } = require("../internal-files-migration");
 const { readOpenclawConfig } = require("../openclaw-config");
+const {
+  kThinkingLevels,
+  isThinkingLevel,
+  readAgentDefaults,
+  writeAgentDefaults,
+} = require("../agent-defaults-config");
 const https = require("https");
 
 const registerSystemRoutes = ({
@@ -574,6 +580,60 @@ const registerSystemRoutes = ({
     };
     const status = applySystemCronConfig(nextConfig);
     res.json({ ok: true, syncCron: status });
+  });
+
+  app.get("/api/agent-defaults", (req, res) => {
+    try {
+      const agentDefaults = readAgentDefaults({
+        fsModule: fs,
+        openclawDir: OPENCLAW_DIR,
+      });
+      res.json({ ok: true, agentDefaults, thinkingLevels: kThinkingLevels });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
+  });
+
+  app.put("/api/agent-defaults", (req, res) => {
+    const { thinking, dreaming } = req.body || {};
+    if (thinking !== undefined && !isThinkingLevel(thinking)) {
+      return res.status(400).json({
+        ok: false,
+        error: `thinking must be one of: ${kThinkingLevels.join(", ")}`,
+      });
+    }
+    if (dreaming !== undefined && typeof dreaming !== "boolean") {
+      return res
+        .status(400)
+        .json({ ok: false, error: "dreaming must be a boolean" });
+    }
+    if (thinking === undefined && dreaming === undefined) {
+      return res.status(400).json({
+        ok: false,
+        error: "At least one of thinking or dreaming must be provided",
+      });
+    }
+    try {
+      const result = writeAgentDefaults({
+        fsModule: fs,
+        openclawDir: OPENCLAW_DIR,
+        thinking,
+        dreaming,
+      });
+      let restartRequired = false;
+      if (result.changed && isOnboarded()) {
+        restartRequiredState.markRequired();
+        restartRequired = true;
+      }
+      res.json({
+        ok: true,
+        changed: result.changed,
+        agentDefaults: result.agentDefaults,
+        restartRequired,
+      });
+    } catch (err) {
+      res.status(500).json({ ok: false, error: err.message });
+    }
   });
 
   app.get("/api/alphaclaw/version", async (req, res) => {

--- a/lib/server/routes/system.js
+++ b/lib/server/routes/system.js
@@ -1,6 +1,7 @@
 const { buildManagedPaths } = require("../internal-files-migration");
 const { readOpenclawConfig } = require("../openclaw-config");
 const {
+  MalformedOpenclawConfigError,
   kThinkingLevels,
   isThinkingLevel,
   readAgentDefaults,
@@ -620,18 +621,15 @@ const registerSystemRoutes = ({
         thinking,
         dreaming,
       });
-      let restartRequired = false;
-      if (result.changed && isOnboarded()) {
-        restartRequiredState.markRequired();
-        restartRequired = true;
-      }
       res.json({
         ok: true,
         changed: result.changed,
         agentDefaults: result.agentDefaults,
-        restartRequired,
       });
     } catch (err) {
+      if (err instanceof MalformedOpenclawConfigError) {
+        return res.status(409).json({ ok: false, error: err.message });
+      }
       res.status(500).json({ ok: false, error: err.message });
     }
   });

--- a/tests/server/agent-defaults-config.test.js
+++ b/tests/server/agent-defaults-config.test.js
@@ -1,0 +1,108 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  kThinkingLevels,
+  kDefaultThinkingLevel,
+  kDefaultDreamingEnabled,
+  normalizeAgentDefaults,
+  readAgentDefaults,
+  writeAgentDefaults,
+} = require("../../lib/server/agent-defaults-config");
+
+const createTempOpenclawDir = () =>
+  fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-agent-defaults-test-"));
+
+describe("server/agent-defaults-config", () => {
+  it("falls back to safe defaults when openclaw.json is missing or empty", () => {
+    const openclawDir = createTempOpenclawDir();
+
+    expect(readAgentDefaults({ fsModule: fs, openclawDir })).toEqual({
+      thinking: kDefaultThinkingLevel,
+      dreaming: kDefaultDreamingEnabled,
+    });
+  });
+
+  it("normalizes invalid stored values to safe defaults", () => {
+    expect(
+      normalizeAgentDefaults({
+        agentDefaults: { thinking: "ultra", dreaming: "yes" },
+      }),
+    ).toEqual({
+      thinking: kDefaultThinkingLevel,
+      dreaming: kDefaultDreamingEnabled,
+    });
+  });
+
+  it("reads stored values verbatim when valid", () => {
+    const openclawDir = createTempOpenclawDir();
+    fs.writeFileSync(
+      path.join(openclawDir, "openclaw.json"),
+      JSON.stringify({
+        agentDefaults: { thinking: "high", dreaming: true },
+      }),
+    );
+
+    expect(readAgentDefaults({ fsModule: fs, openclawDir })).toEqual({
+      thinking: "high",
+      dreaming: true,
+    });
+  });
+
+  it("writes only the keys provided and preserves existing siblings", () => {
+    const openclawDir = createTempOpenclawDir();
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        tools: { profile: "full" },
+        agentDefaults: { thinking: "low", dreaming: true },
+      }),
+    );
+
+    const result = writeAgentDefaults({
+      fsModule: fs,
+      openclawDir,
+      thinking: "high",
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.agentDefaults).toEqual({ thinking: "high", dreaming: true });
+    const stored = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(stored).toEqual({
+      tools: { profile: "full" },
+      agentDefaults: { thinking: "high", dreaming: true },
+    });
+  });
+
+  it("reports changed=false when the write is a no-op", () => {
+    const openclawDir = createTempOpenclawDir();
+    fs.writeFileSync(
+      path.join(openclawDir, "openclaw.json"),
+      JSON.stringify({
+        agentDefaults: { thinking: "medium", dreaming: false },
+      }),
+    );
+
+    const result = writeAgentDefaults({
+      fsModule: fs,
+      openclawDir,
+      thinking: "medium",
+      dreaming: false,
+    });
+
+    expect(result.changed).toBe(false);
+  });
+
+  it("rejects invalid thinking values", () => {
+    const openclawDir = createTempOpenclawDir();
+    expect(() =>
+      writeAgentDefaults({ fsModule: fs, openclawDir, thinking: "max" }),
+    ).toThrow(/thinking must be one of/);
+  });
+
+  it("exposes the canonical thinking level list", () => {
+    expect(kThinkingLevels).toEqual(["off", "low", "medium", "high"]);
+  });
+});

--- a/tests/server/agent-defaults-config.test.js
+++ b/tests/server/agent-defaults-config.test.js
@@ -3,6 +3,7 @@ const os = require("os");
 const path = require("path");
 
 const {
+  MalformedOpenclawConfigError,
   kThinkingLevels,
   kDefaultThinkingLevel,
   kDefaultDreamingEnabled,
@@ -104,5 +105,34 @@ describe("server/agent-defaults-config", () => {
 
   it("exposes the canonical thinking level list", () => {
     expect(kThinkingLevels).toEqual(["off", "low", "medium", "high"]);
+  });
+
+  it("refuses to overwrite when openclaw.json exists but is malformed", () => {
+    const openclawDir = createTempOpenclawDir();
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.writeFileSync(configPath, "{ malformed:");
+
+    expect(() =>
+      writeAgentDefaults({ fsModule: fs, openclawDir, thinking: "high" }),
+    ).toThrow(MalformedOpenclawConfigError);
+
+    expect(fs.readFileSync(configPath, "utf8")).toBe("{ malformed:");
+  });
+
+  it("creates openclaw.json from scratch when absent", () => {
+    const openclawDir = createTempOpenclawDir();
+    const configPath = path.join(openclawDir, "openclaw.json");
+
+    const result = writeAgentDefaults({
+      fsModule: fs,
+      openclawDir,
+      thinking: "high",
+      dreaming: true,
+    });
+
+    expect(result.changed).toBe(true);
+    expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).toEqual({
+      agentDefaults: { thinking: "high", dreaming: true },
+    });
   });
 });

--- a/tests/server/routes-system.test.js
+++ b/tests/server/routes-system.test.js
@@ -728,7 +728,6 @@ describe("server/routes/system", () => {
       expect(res.status).toBe(400);
       expect(res.body.ok).toBe(false);
       expect(res.body.error).toContain("thinking must be one of");
-      expect(deps.restartRequiredState.markRequired).not.toHaveBeenCalled();
     });
 
     it("rejects non-boolean dreaming values on PUT", async () => {
@@ -753,11 +752,10 @@ describe("server/routes/system", () => {
       expect(res.body.error).toContain("At least one of thinking or dreaming");
     });
 
-    it("persists changes and signals restart-required when onboarded", async () => {
+    it("persists changes and preserves unrelated config keys", async () => {
       const { deps, stored } = buildAgentDefaultsDeps({
         tools: { profile: "full" },
       });
-      deps.isOnboarded.mockReturnValue(true);
       const app = createApp(deps);
 
       const res = await request(app)
@@ -769,21 +767,18 @@ describe("server/routes/system", () => {
         ok: true,
         changed: true,
         agentDefaults: { thinking: "high", dreaming: true },
-        restartRequired: true,
       });
       expect(stored.value.agentDefaults).toEqual({
         thinking: "high",
         dreaming: true,
       });
       expect(stored.value.tools).toEqual({ profile: "full" });
-      expect(deps.restartRequiredState.markRequired).toHaveBeenCalledTimes(1);
     });
 
-    it("does not signal restart-required for no-op writes", async () => {
+    it("reports no change for no-op writes", async () => {
       const { deps } = buildAgentDefaultsDeps({
         agentDefaults: { thinking: "medium", dreaming: false },
       });
-      deps.isOnboarded.mockReturnValue(true);
       const app = createApp(deps);
 
       const res = await request(app)
@@ -792,8 +787,23 @@ describe("server/routes/system", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.changed).toBe(false);
-      expect(res.body.restartRequired).toBe(false);
-      expect(deps.restartRequiredState.markRequired).not.toHaveBeenCalled();
+    });
+
+    it("refuses to overwrite when openclaw.json exists but cannot be parsed", async () => {
+      const { deps } = buildAgentDefaultsDeps(null);
+      deps.fs.existsSync = vi.fn(() => true);
+      deps.fs.readFileSync = vi.fn(() => "{ this is not json");
+      const writeSpy = vi.spyOn(deps.fs, "writeFileSync");
+      const app = createApp(deps);
+
+      const res = await request(app)
+        .put("/api/agent-defaults")
+        .send({ thinking: "high" });
+
+      expect(res.status).toBe(409);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toMatch(/could not be parsed/i);
+      expect(writeSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/server/routes-system.test.js
+++ b/tests/server/routes-system.test.js
@@ -78,6 +78,7 @@ const createSystemDeps = () => {
         restartInProgress: false,
         gatewayRunning: true,
       })),
+      markRequired: vi.fn(),
       markRestartInProgress: vi.fn(),
       clearRequired: vi.fn(),
       markRestartComplete: vi.fn(),
@@ -665,5 +666,134 @@ describe("server/routes/system", () => {
         replyTo: "-1003709908795:4011",
       },
     ]);
+  });
+
+  describe("/api/agent-defaults", () => {
+    const buildAgentDefaultsDeps = (storedConfig) => {
+      const deps = createSystemDeps();
+      const stored = { value: storedConfig ? { ...storedConfig } : null };
+      deps.fs.readFileSync = vi.fn((filePath) => {
+        if (
+          typeof filePath === "string" &&
+          filePath.endsWith("openclaw.json") &&
+          stored.value
+        ) {
+          return JSON.stringify(stored.value);
+        }
+        throw new Error("ENOENT");
+      });
+      deps.fs.writeFileSync = vi.fn((filePath, content) => {
+        if (typeof filePath === "string" && filePath.endsWith("openclaw.json")) {
+          stored.value = JSON.parse(content);
+        }
+      });
+      deps.fs.mkdirSync = vi.fn();
+      return { deps, stored };
+    };
+
+    it("returns defaults when openclaw.json is missing", async () => {
+      const { deps } = buildAgentDefaultsDeps(null);
+      const app = createApp(deps);
+
+      const res = await request(app).get("/api/agent-defaults");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        ok: true,
+        agentDefaults: { thinking: "medium", dreaming: false },
+        thinkingLevels: ["off", "low", "medium", "high"],
+      });
+    });
+
+    it("returns stored agent defaults", async () => {
+      const { deps } = buildAgentDefaultsDeps({
+        agentDefaults: { thinking: "high", dreaming: true },
+      });
+      const app = createApp(deps);
+
+      const res = await request(app).get("/api/agent-defaults");
+
+      expect(res.status).toBe(200);
+      expect(res.body.agentDefaults).toEqual({ thinking: "high", dreaming: true });
+    });
+
+    it("rejects invalid thinking values on PUT", async () => {
+      const { deps } = buildAgentDefaultsDeps(null);
+      const app = createApp(deps);
+
+      const res = await request(app)
+        .put("/api/agent-defaults")
+        .send({ thinking: "max" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toContain("thinking must be one of");
+      expect(deps.restartRequiredState.markRequired).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-boolean dreaming values on PUT", async () => {
+      const { deps } = buildAgentDefaultsDeps(null);
+      const app = createApp(deps);
+
+      const res = await request(app)
+        .put("/api/agent-defaults")
+        .send({ dreaming: "yes" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("dreaming must be a boolean");
+    });
+
+    it("rejects empty payloads on PUT", async () => {
+      const { deps } = buildAgentDefaultsDeps(null);
+      const app = createApp(deps);
+
+      const res = await request(app).put("/api/agent-defaults").send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("At least one of thinking or dreaming");
+    });
+
+    it("persists changes and signals restart-required when onboarded", async () => {
+      const { deps, stored } = buildAgentDefaultsDeps({
+        tools: { profile: "full" },
+      });
+      deps.isOnboarded.mockReturnValue(true);
+      const app = createApp(deps);
+
+      const res = await request(app)
+        .put("/api/agent-defaults")
+        .send({ thinking: "high", dreaming: true });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        ok: true,
+        changed: true,
+        agentDefaults: { thinking: "high", dreaming: true },
+        restartRequired: true,
+      });
+      expect(stored.value.agentDefaults).toEqual({
+        thinking: "high",
+        dreaming: true,
+      });
+      expect(stored.value.tools).toEqual({ profile: "full" });
+      expect(deps.restartRequiredState.markRequired).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not signal restart-required for no-op writes", async () => {
+      const { deps } = buildAgentDefaultsDeps({
+        agentDefaults: { thinking: "medium", dreaming: false },
+      });
+      deps.isOnboarded.mockReturnValue(true);
+      const app = createApp(deps);
+
+      const res = await request(app)
+        .put("/api/agent-defaults")
+        .send({ thinking: "medium", dreaming: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.changed).toBe(false);
+      expect(res.body.restartRequired).toBe(false);
+      expect(deps.restartRequiredState.markRequired).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Adds an **Agent Defaults** card to the Setup UI's General tab with two settings:

- **Thinking default** — `off` / `low` / `medium` / `high`. Already wired into `doctor/service.js` so it actually shapes agent calls (replaces the hard-coded `thinking: \"medium\"`).
- **Dreaming** — boolean toggle, persisted under `agentDefaults.dreaming` for OpenClaw to pick up when the gateway-side feature lands.

Backed by `GET/PUT /api/agent-defaults` writing to `openclaw.json` under `agentDefaults`.

## Why these shapes

- **Per-call read, no restart needed.** The doctor service reads `agentDefaults.thinking` at invocation time, so changing the default takes effect on the next agent call. The PUT handler does **not** mark restart-required — the prior version did, but the only consumer doesn't need a restart and signaling one would have been misleading.
- **Refuses to overwrite a corrupt `openclaw.json`.** `writeAgentDefaults` distinguishes ENOENT from parse failure: if the file exists but can't be parsed, the route returns `409` and the file stays untouched. Mirrors the `existsSync + fallback:null` pattern from `exec-defaults-config.js`.
- **`useCachedFetch` per AGENTS.md.** The component reads through the shared cache and writes through `setCached` after PUT, so other tabs reading the same key see fresh data without a refetch.

## What's not in this PR

- **OpenClaw-side `dreaming` consumer.** The value persists, but nothing reads it yet. Out of scope by design — AlphaClaw owns persistence; OpenClaw owns runtime.
- **Forward-compat for additional `agentDefaults` keys.** Today PUT rejects bodies with no recognized fields. Tracked locally under ticket 4 in the run artifact; trivial fix when a third key is needed.
- **Frontend component tests.** Existing pattern in `tests/frontend/api.test.js` would cover this; tracked in the same ticket file.

## Test plan

- [x] `npm test` — 585 pass (was 582; adds 3 new tests covering the malformed-`openclaw.json` refusal path and the from-scratch write path).
- [x] `npm run build:ui` — bundle rebuilds cleanly.
- [ ] Manual: change Thinking default in the UI, run a doctor scan, verify the gateway call uses the new value.
- [ ] Manual: toggle Dreaming on/off, verify the value round-trips in `openclaw.json`.
- [ ] Manual: corrupt `openclaw.json` (e.g., drop a closing brace), attempt a PUT, verify it returns 409 and the file is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)