### PR TITLE
Fix dashboard token fallback for newer OpenClaw

### DIFF
--- a/lib/server/routes/system.js
+++ b/lib/server/routes/system.js
@@ -92,6 +92,35 @@ const registerSystemRoutes = ({
     }
     return null;
   };
+  const getEnvFileValue = (key) =>
+    (typeof readEnvFile === "function" ? readEnvFile() : []).find(
+      (entry) => entry?.key === key,
+    )?.value;
+  const resolveEnvReference = (value) => {
+    const match = String(value || "").trim().match(/^\$\{([A-Z_][A-Z0-9_]*)\}$/);
+    if (!match) return "";
+    const envKey = match[1];
+    const envValue = process.env[envKey] || getEnvFileValue(envKey);
+    return typeof envValue === "string" && envValue.trim() ? envValue.trim() : "";
+  };
+  const getDashboardTokenFromConfig = () => {
+    const config = readOpenclawConfig({
+      fsModule: fs,
+      openclawDir: OPENCLAW_DIR,
+      fallback: {},
+    });
+    const configuredToken = config?.gateway?.auth?.token;
+    if (typeof configuredToken === "string" && configuredToken.trim()) {
+      const trimmedToken = configuredToken.trim();
+      if (/^\$\{[A-Z_][A-Z0-9_]*\}$/.test(trimmedToken)) {
+        return resolveEnvReference(trimmedToken);
+      }
+      return trimmedToken;
+    }
+    const envToken =
+      process.env.OPENCLAW_GATEWAY_TOKEN || getEnvFileValue("OPENCLAW_GATEWAY_TOKEN");
+    return typeof envToken === "string" && envToken.trim() ? envToken.trim() : "";
+  };
   const getRawSessionKey = (sessionRow = {}) =>
     String(sessionRow?.key || sessionRow?.sessionKey || sessionRow?.id || "").trim();
   const getRawSessionsFromPayload = (payload) => {
@@ -699,7 +728,15 @@ const registerSystemRoutes = ({
         return res.json({ ok: true, url: `/openclaw/#token=${tokenMatch[1]}` });
       }
     }
-    res.json({ ok: true, url: "/openclaw" });
+    const token = getDashboardTokenFromConfig();
+    if (token) {
+      return res.json({
+        ok: true,
+        url: `/openclaw/#token=${encodeURIComponent(token)}`,
+        source: "config",
+      });
+    }
+    res.json({ ok: true, url: "/openclaw", needsAuth: true });
   });
 
   app.get("/api/restart-status", async (req, res) => {

--- a/tests/server/routes-system.test.js
+++ b/tests/server/routes-system.test.js
@@ -358,6 +358,162 @@ describe("server/routes/system", () => {
     );
   });
 
+  it("returns tokenized dashboard URL when OpenClaw CLI prints a token", async () => {
+    const deps = createSystemDeps();
+    deps.clawCmd.mockResolvedValueOnce({
+      ok: true,
+      stdout: "Dashboard URL: http://127.0.0.1:18789/#token=abc123",
+    });
+    const app = createApp(deps);
+
+    const res = await request(app).get("/api/gateway/dashboard");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, url: "/openclaw/#token=abc123" });
+  });
+
+  it("falls back to plain configured gateway token for dashboard URL", async () => {
+    const deps = createSystemDeps();
+    deps.clawCmd.mockResolvedValueOnce({
+      ok: true,
+      stdout: "Dashboard URL: http://127.0.0.1:18789/",
+    });
+    deps.fs.readFileSync.mockImplementation((filePath) => {
+      if (String(filePath).endsWith("openclaw.json")) {
+        return JSON.stringify({ gateway: { auth: { token: "cfg-token+value" } } });
+      }
+      throw new Error("unexpected file");
+    });
+    const app = createApp(deps);
+
+    const res = await request(app).get("/api/gateway/dashboard");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      url: "/openclaw/#token=cfg-token%2Bvalue",
+      source: "config",
+    });
+  });
+
+  it("falls back to OPENCLAW_GATEWAY_TOKEN from env file for dashboard URL", async () => {
+    const previousEnvToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    try {
+      const deps = createSystemDeps();
+      deps.clawCmd.mockResolvedValueOnce({
+        ok: true,
+        stdout: "Dashboard URL: http://127.0.0.1:18789/",
+      });
+      deps.readEnvFile.mockReturnValue([
+        { key: "OPENCLAW_GATEWAY_TOKEN", value: "env-token" },
+      ]);
+      const app = createApp(deps);
+
+      const res = await request(app).get("/api/gateway/dashboard");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        ok: true,
+        url: "/openclaw/#token=env-token",
+        source: "config",
+      });
+    } finally {
+      if (previousEnvToken === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      else process.env.OPENCLAW_GATEWAY_TOKEN = previousEnvToken;
+    }
+  });
+
+  it("resolves configured OPENCLAW_GATEWAY_TOKEN env refs for dashboard URL", async () => {
+    const previousEnvToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    process.env.OPENCLAW_GATEWAY_TOKEN = "real-env-token+value";
+    try {
+      const deps = createSystemDeps();
+      deps.clawCmd.mockResolvedValueOnce({
+        ok: true,
+        stdout: "Dashboard URL: http://127.0.0.1:18789/",
+      });
+      deps.fs.readFileSync.mockImplementation((filePath) => {
+        if (String(filePath).endsWith("openclaw.json")) {
+          return JSON.stringify({
+            gateway: { auth: { token: "${OPENCLAW_GATEWAY_TOKEN}" } },
+          });
+        }
+        throw new Error("unexpected file");
+      });
+      const app = createApp(deps);
+
+      const res = await request(app).get("/api/gateway/dashboard");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        ok: true,
+        url: "/openclaw/#token=real-env-token%2Bvalue",
+        source: "config",
+      });
+    } finally {
+      if (previousEnvToken === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      else process.env.OPENCLAW_GATEWAY_TOKEN = previousEnvToken;
+    }
+  });
+
+  it("resolves configured OPENCLAW_GATEWAY_TOKEN env refs from env file for dashboard URL", async () => {
+    const previousEnvToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    try {
+      const deps = createSystemDeps();
+      deps.clawCmd.mockResolvedValueOnce({
+        ok: true,
+        stdout: "Dashboard URL: http://127.0.0.1:18789/",
+      });
+      deps.fs.readFileSync.mockImplementation((filePath) => {
+        if (String(filePath).endsWith("openclaw.json")) {
+          return JSON.stringify({
+            gateway: { auth: { token: "${OPENCLAW_GATEWAY_TOKEN}" } },
+          });
+        }
+        throw new Error("unexpected file");
+      });
+      deps.readEnvFile.mockReturnValue([
+        { key: "OPENCLAW_GATEWAY_TOKEN", value: "env-file-token" },
+      ]);
+      const app = createApp(deps);
+
+      const res = await request(app).get("/api/gateway/dashboard");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        ok: true,
+        url: "/openclaw/#token=env-file-token",
+        source: "config",
+      });
+    } finally {
+      if (previousEnvToken === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      else process.env.OPENCLAW_GATEWAY_TOKEN = previousEnvToken;
+    }
+  });
+
+  it("marks dashboard URL as needing auth when no token can be resolved", async () => {
+    const previousEnvToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    try {
+      const deps = createSystemDeps();
+      deps.clawCmd.mockResolvedValueOnce({
+        ok: true,
+        stdout: "Dashboard URL: http://127.0.0.1:18789/",
+      });
+      const app = createApp(deps);
+
+      const res = await request(app).get("/api/gateway/dashboard");
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, url: "/openclaw", needsAuth: true });
+    } finally {
+      if (previousEnvToken === undefined) delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      else process.env.OPENCLAW_GATEWAY_TOKEN = previousEnvToken;
+    }
+  });
+
   it("returns sync cron status on GET /api/sync-cron", async () => {
     const deps = createSystemDeps();
     deps.fs.readFileSync.mockReturnValueOnce(


### PR DESCRIPTION
## Summary

Fixes the AlphaClaw “OpenClaw Gateway Dashboard” button when running against newer OpenClaw versions that intentionally no longer print tokenized dashboard URLs from `openclaw dashboard --no-open`.

Previously `/api/gateway/dashboard` only scraped `#token=...` from the CLI output. With OpenClaw 2026.4.24, the CLI still prepares token auto-auth for browser/clipboard paths, but `--no-open` prints a clean non-tokenized URL for safety. AlphaClaw therefore fell back to `/openclaw`, opened the proxied Control UI without a token, and the UI hit a websocket auth/token error.

This change keeps the old scraping behavior for compatibility, then falls back to resolving the plain gateway shared-secret token from:

1. `gateway.auth.token` in `openclaw.json`
2. `OPENCLAW_GATEWAY_TOKEN` from process env or AlphaClaw’s env file

If no token can be resolved, the route now returns `needsAuth: true` instead of silently returning an indistinguishable unauthenticated URL.

## Validation

- Reproduced locally before the patch: authenticated `GET /api/gateway/dashboard` returned `{ ok: true, url: "/openclaw" }`, which opened the Control UI without auth and triggered the token error.
- Patched the local installed AlphaClaw package and restarted `alphaclaw.service`.
- Verified after restart: authenticated `GET /api/gateway/dashboard` now returns a tokenized `/openclaw/#token=...` URL with `source: "config"`.
- Verified `/openclaw` still serves the proxied OpenClaw Control UI HTML through AlphaClaw auth.

## Tests

- `npm test -- tests/server/routes-system.test.js` ✅ 24 passed
- `npm test` ⚠️ existing unrelated failures observed:
  - `tests/server/gateway.test.js`: 2 WhatsApp pairing/status expectation failures
  - `tests/server/watchdog-notify.test.js`: 2 WhatsApp watchdog notification expectation failures

The targeted system-route coverage added here passes and covers:

- legacy CLI stdout token scraping
- fallback to configured `gateway.auth.token`
- fallback to env-file `OPENCLAW_GATEWAY_TOKEN`
- explicit `needsAuth: true` when no token is available
