### PR TITLE
fix(sidebar): prevent agent emoji shortcodes from overlapping name

### DIFF
--- a/lib/public/css/explorer.css
+++ b/lib/public/css/explorer.css
@@ -189,10 +189,12 @@
 
 .sidebar-agent-emoji {
   flex: 0 0 auto;
-  width: 14px;
+  min-width: 14px;
+  max-width: 1.5em;
   line-height: 1;
   font-size: 14px;
   text-align: center;
+  overflow: hidden;
 }
 
 .sidebar-agent-name {

--- a/lib/public/js/components/agents-tab/agent-identity-section.js
+++ b/lib/public/js/components/agents-tab/agent-identity-section.js
@@ -116,8 +116,11 @@ export const AgentIdentitySection = ({
                   value=${form.emoji}
                   onInput=${(event) => updateField("emoji", event.target.value)}
                   class="w-full bg-field border border-border rounded-lg px-3 py-2 text-sm text-body outline-none focus:border-fg-muted"
-                  placeholder="Optional emoji"
+                  placeholder="Single emoji, e.g. ✨"
                 />
+                <span class="text-xs text-fg-muted">
+                  Shortcodes like <code>:sparkles:</code> aren't supported — paste the glyph itself.
+                </span>
               </label>
               <label class="block space-y-1">
                 <span class="text-xs text-fg-muted">Avatar</span>

--- a/lib/public/js/components/sidebar.js
+++ b/lib/public/js/components/sidebar.js
@@ -33,6 +33,7 @@ import {
   getSessionDisplayLabel,
   getSessionRowKey,
 } from "../lib/session-keys.js";
+import { sanitizeAgentEmoji } from "../lib/agent-identity.js";
 import { ThemeToggle } from "./theme-toggle.js";
 
 const html = htm.bind(h);
@@ -91,7 +92,7 @@ const renderNavItem = ({ item, selectedNavId, onSelectNavItem }) => {
   `;
 };
 
-const getAgentIdentityEmoji = (agent) => String(agent?.identity?.emoji || "").trim();
+const getAgentIdentityEmoji = (agent) => sanitizeAgentEmoji(agent?.identity?.emoji);
 
 export const AppSidebar = ({
   mobileSidebarOpen = false,

--- a/lib/public/js/lib/agent-identity.js
+++ b/lib/public/js/lib/agent-identity.js
@@ -1,0 +1,8 @@
+const kNonEmojiPattern = /[A-Za-z0-9:]/;
+
+export const sanitizeAgentEmoji = (rawEmoji) => {
+  const trimmed = String(rawEmoji ?? "").trim();
+  if (!trimmed) return "";
+  if (kNonEmojiPattern.test(trimmed)) return "";
+  return trimmed;
+};

--- a/tests/frontend/agent-identity.test.js
+++ b/tests/frontend/agent-identity.test.js
@@ -1,0 +1,31 @@
+import { sanitizeAgentEmoji } from "../../lib/public/js/lib/agent-identity.js";
+
+describe("frontend/agent-identity", () => {
+  describe("sanitizeAgentEmoji", () => {
+    it("returns the trimmed glyph for a single emoji", () => {
+      expect(sanitizeAgentEmoji("✨")).toBe("✨");
+      expect(sanitizeAgentEmoji("  🌙  ")).toBe("🌙");
+    });
+
+    it("accepts ZWJ sequences", () => {
+      expect(sanitizeAgentEmoji("👨‍👩‍👧‍👦")).toBe("👨‍👩‍👧‍👦");
+    });
+
+    it("rejects shortcode strings like :sparkles:", () => {
+      expect(sanitizeAgentEmoji(":sparkles:")).toBe("");
+      expect(sanitizeAgentEmoji(":crescent_moon:")).toBe("");
+    });
+
+    it("rejects plain ASCII text", () => {
+      expect(sanitizeAgentEmoji("abc")).toBe("");
+      expect(sanitizeAgentEmoji("Vee")).toBe("");
+    });
+
+    it("returns an empty string for nullish or empty input", () => {
+      expect(sanitizeAgentEmoji(null)).toBe("");
+      expect(sanitizeAgentEmoji(undefined)).toBe("");
+      expect(sanitizeAgentEmoji("")).toBe("");
+      expect(sanitizeAgentEmoji("   ")).toBe("");
+    });
+  });
+});


### PR DESCRIPTION
Fixes #53.

## Summary

When an agent's `identity.emoji` is set to a Slack/Discord-style shortcode (e.g. `:sparkles:`, `:crescent_moon:`), the sidebar renders the literal text. The `.sidebar-agent-emoji` slot was hard-fixed at `width: 14px` with no overflow control, so longer values bled out and visually overlapped the adjacent `.sidebar-agent-name` column. Result is the rendering shown in #53 where channel/agent names appear stacked on top of `:sparkles:` text.

## Changes

- **CSS containment** (`lib/public/css/explorer.css`): `.sidebar-agent-emoji` now uses `min-width: 14px; max-width: 1.5em; overflow: hidden;` so any non-glyph value clips inside its slot instead of overflowing onto the name.
- **Renderer guard** (`lib/public/js/components/sidebar.js` + new `lib/public/js/lib/agent-identity.js`): extracted `sanitizeAgentEmoji` that rejects values containing ASCII letters/digits/colons. The sidebar falls back to the existing robot icon for shortcodes or free-form text. Existing data is untouched on disk; only the rendered output changes.
- **Form UX** (`lib/public/js/components/agents-tab/agent-identity-section.js`): placeholder is now `Single emoji, e.g. ✨` with a small helper note that shortcodes aren't supported, to prevent recurrence.
- **Tests** (`tests/frontend/agent-identity.test.js`): unit coverage for `sanitizeAgentEmoji` — single emoji, ZWJ sequences, shortcodes, plain text, and nullish/empty input.

## Test plan

- [x] `npm test` → `tests/frontend/` passes (95/95, +5 new). Pre-existing `tests/server/` failures on this branch are unrelated (`node:sqlite` not available on local Node 22.12; CI on Node 22 latest is unaffected).
- [x] `npm run build:ui` succeeds with the new helper module bundled.
- [ ] Maintainer to verify in the running UI: an agent with `identity.emoji = ":sparkles:"` now shows the robot icon instead of the overlapping shortcode; an agent with `identity.emoji = "✨"` still renders the glyph.

## Notes

- This is intentionally a conservative fix — the alternative would be a shortcode → glyph lookup table (`:sparkles:` → ✨ etc.), which is more user-friendly but adds either a runtime dependency or a maintenance surface. Happy to follow up with that as a separate change if you'd prefer.
- Diagnosis in the issue's screenshot incorrectly attributed the bug to the wrong field being used as the label; the renderer was already using `agent.name`. The actual root cause is the missing overflow control plus the lack of input sanitization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)