### PR TITLE
browse: cap admin file tree depth

### DIFF
--- a/lib/public/js/components/file-tree.js
+++ b/lib/public/js/components/file-tree.js
@@ -76,6 +76,16 @@ const collectFolderPaths = (node, folderPaths) => {
   );
 };
 
+const collectTruncatedExpandedFolderPaths = (node, expandedPaths, folderPaths) => {
+  if (!node || node.type !== "folder") return;
+  if (node.truncated && expandedPaths.has(node.path || "")) {
+    folderPaths.push(node.path || "");
+  }
+  (node.children || []).forEach((childNode) =>
+    collectTruncatedExpandedFolderPaths(childNode, expandedPaths, folderPaths),
+  );
+};
+
 const collectFilePaths = (node, filePaths) => {
   if (!node) return;
   if (node.type === "file") {
@@ -98,6 +108,19 @@ const removeTreePath = (node, targetPath) => {
     .map((childNode) => removeTreePath(childNode, safeTargetPath))
     .filter(Boolean);
   if (nextChildren.length === (node.children || []).length) return node;
+  return {
+    ...node,
+    children: nextChildren,
+  };
+};
+
+const replaceTreeNode = (node, nextNode) => {
+  if (!node || !nextNode) return node;
+  if (String(node.path || "") === String(nextNode.path || "")) return nextNode;
+  if (node.type !== "folder") return node;
+  const nextChildren = (node.children || []).map((childNode) =>
+    replaceTreeNode(childNode, nextNode),
+  );
   return {
     ...node,
     children: nextChildren,
@@ -410,6 +433,7 @@ const TreeNode = ({
   onCreationConfirm,
   onCreationCancel,
   dragSourcePath = "",
+  loadingFolderPaths = new Set(),
 }) => {
   if (!node) return null;
   if (node.type === "file") {
@@ -471,6 +495,7 @@ const TreeNode = ({
 
   const folderPath = node.path || "";
   const isCollapsed = isSearchActive ? false : !expandedPaths.has(folderPath);
+  const isLoadingFolder = loadingFolderPaths.has(folderPath);
   const isFolderActive = selectedPath === folderPath;
   const isFolderLocked = folderPath && matchesBrowsePolicyPath(
     kLockedBrowsePaths,
@@ -484,7 +509,7 @@ const TreeNode = ({
         class=${`tree-folder ${isCollapsed ? "collapsed" : ""} ${isFolderActive ? "active" : ""} ${isDropTarget ? "is-drop-target" : ""}`.trim()}
         onclick=${() => {
           if (!folderPath) return;
-          onSetFolderExpanded(folderPath, isCollapsed);
+          onSetFolderExpanded(folderPath, isCollapsed, node);
           onSelectFolder(folderPath);
         }}
         oncontextmenu=${(e) => {
@@ -540,8 +565,9 @@ const TreeNode = ({
             event.preventDefault();
             event.stopPropagation();
             if (!folderPath) return;
-            onSetFolderExpanded(folderPath, isCollapsed);
+            onSetFolderExpanded(folderPath, isCollapsed, node);
           }}
+          disabled=${isLoadingFolder}
         >
           <span class="arrow">▼</span>
         </button>
@@ -587,6 +613,7 @@ const TreeNode = ({
               onCreationConfirm=${onCreationConfirm}
               onCreationCancel=${onCreationCancel}
               dragSourcePath=${dragSourcePath}
+              loadingFolderPaths=${loadingFolderPaths}
             />
           `,
         )}
@@ -623,6 +650,7 @@ const TreeNode = ({
               onCreationConfirm=${onCreationConfirm}
               onCreationCancel=${onCreationCancel}
               dragSourcePath=${dragSourcePath}
+              loadingFolderPaths=${loadingFolderPaths}
             />
           `,
         )}
@@ -650,6 +678,7 @@ export const FileTree = ({
   const [creatingType, setCreatingType] = useState("");
   const [contextMenu, setContextMenu] = useState(null);
   const [dragSourcePath, setDragSourcePath] = useState("");
+  const [loadingFolderPaths, setLoadingFolderPaths] = useState(new Set());
   const [selectedFolder, setSelectedFolder] = useState("");
   const effectiveSelectedPath = selectedFolder || selectedPath;
   const searchInputRef = useRef(null);
@@ -661,10 +690,31 @@ export const FileTree = ({
     try {
       const data = await fetchBrowseTree();
       const nextRoot = data.root || null;
-      const nextSignature = JSON.stringify(nextRoot || {});
+      const nextExpandedPaths =
+        expandedPaths instanceof Set ? expandedPaths : new Set();
+      let hydratedRoot = nextRoot;
+      const hydratedPaths = new Set();
+      while (true) {
+        const truncatedExpandedPaths = [];
+        collectTruncatedExpandedFolderPaths(
+          hydratedRoot,
+          nextExpandedPaths,
+          truncatedExpandedPaths,
+        );
+        const nextFolderPath = truncatedExpandedPaths.find(
+          (folderPath) => !hydratedPaths.has(folderPath),
+        );
+        if (!nextFolderPath) break;
+        hydratedPaths.add(nextFolderPath);
+        const subtreeData = await fetchBrowseTree({ path: nextFolderPath });
+        if (subtreeData.root) {
+          hydratedRoot = replaceTreeNode(hydratedRoot, subtreeData.root);
+        }
+      }
+      const nextSignature = JSON.stringify(hydratedRoot || {});
       if (treeSignatureRef.current !== nextSignature) {
         treeSignatureRef.current = nextSignature;
-        setTreeRoot(nextRoot);
+        setTreeRoot(hydratedRoot);
       }
       setExpandedPaths((previousPaths) =>
         previousPaths instanceof Set ? previousPaths : new Set(),
@@ -677,7 +727,7 @@ export const FileTree = ({
     } finally {
       if (showLoading) setLoading(false);
     }
-  }, []);
+  }, [expandedPaths]);
 
   useEffect(() => {
     loadTree({ showLoading: true });
@@ -834,7 +884,31 @@ export const FileTree = ({
     onPreviewFile("");
   }, [isSearchActive, filteredFilePaths, searchActivePath, onPreviewFile]);
 
-  const setFolderExpanded = (folderPath, nextExpanded) => {
+  const setFolderExpanded = async (folderPath, nextExpanded, node = null) => {
+    if (nextExpanded === true && node?.truncated) {
+      setLoadingFolderPaths((previousPaths) => {
+        const nextPaths =
+          previousPaths instanceof Set ? new Set(previousPaths) : new Set();
+        nextPaths.add(folderPath);
+        return nextPaths;
+      });
+      try {
+        const data = await fetchBrowseTree({ path: folderPath });
+        if (data.root) {
+          setTreeRoot((previousRoot) => replaceTreeNode(previousRoot, data.root));
+        }
+      } catch (loadError) {
+        showToast(loadError.message || "Could not load folder", "error");
+        return;
+      } finally {
+        setLoadingFolderPaths((previousPaths) => {
+          const nextPaths =
+            previousPaths instanceof Set ? new Set(previousPaths) : new Set();
+          nextPaths.delete(folderPath);
+          return nextPaths;
+        });
+      }
+    }
     setExpandedPaths((previousPaths) => {
       const nextPaths =
         previousPaths instanceof Set ? new Set(previousPaths) : new Set();
@@ -1210,6 +1284,7 @@ export const FileTree = ({
               onCreationConfirm=${confirmCreate}
               onCreationCancel=${cancelCreate}
               dragSourcePath=${dragSourcePath}
+              loadingFolderPaths=${loadingFolderPaths}
             />
           `,
         )}
@@ -1245,6 +1320,7 @@ export const FileTree = ({
               onCreationConfirm=${confirmCreate}
               onCreationCancel=${cancelCreate}
               dragSourcePath=${dragSourcePath}
+              loadingFolderPaths=${loadingFolderPaths}
             />
           `,
         )}

--- a/lib/public/js/lib/api.js
+++ b/lib/public/js/lib/api.js
@@ -1245,8 +1245,11 @@ export async function fetchWebhookRequest(name, id) {
   return parseJsonOrThrow(res, "Could not load webhook request");
 }
 
-export const fetchBrowseTree = async (depth = 3) => {
+export const fetchBrowseTree = async (options = {}) => {
+  const { depth = 3, path = "" } =
+    typeof options === "number" ? { depth: options, path: "" } : options;
   const params = new URLSearchParams({ depth: String(depth) });
+  if (path) params.set("path", String(path));
   const res = await authFetch(`/api/browse/tree?${params.toString()}`);
   return parseJsonOrThrow(res, "Could not load file tree");
 };

--- a/lib/public/js/lib/api.js
+++ b/lib/public/js/lib/api.js
@@ -1245,7 +1245,7 @@ export async function fetchWebhookRequest(name, id) {
   return parseJsonOrThrow(res, "Could not load webhook request");
 }
 
-export const fetchBrowseTree = async (depth = 10) => {
+export const fetchBrowseTree = async (depth = 3) => {
   const params = new URLSearchParams({ depth: String(depth) });
   const res = await authFetch(`/api/browse/tree?${params.toString()}`);
   return parseJsonOrThrow(res, "Could not load file tree");

--- a/lib/server/routes/browse/constants.js
+++ b/lib/server/routes/browse/constants.js
@@ -1,4 +1,5 @@
-const kDefaultTreeDepth = 10;
+const kDefaultTreeDepth = 3;
+const kMaxTreeDepth = 3;
 const kIgnoredDirectoryNames = new Set([
   ".git",
   ".alphaclaw",
@@ -42,6 +43,7 @@ const kSqliteTablePageSize = 50;
 
 module.exports = {
   kDefaultTreeDepth,
+  kMaxTreeDepth,
   kIgnoredDirectoryNames,
   kImageMimeTypeByExtension,
   kCommitHistoryLimit,

--- a/lib/server/routes/browse/index.js
+++ b/lib/server/routes/browse/index.js
@@ -2,6 +2,7 @@ const path = require("path");
 const { kLockedBrowsePaths, kProtectedBrowsePaths } = require("../../constants");
 const {
   kDefaultTreeDepth,
+  kMaxTreeDepth,
   kIgnoredDirectoryNames,
   kCommitHistoryLimit,
 } = require("./constants");
@@ -70,10 +71,11 @@ const registerBrowseRoutes = ({ app, fs, kRootDir }) => {
 
   app.get("/api/browse/tree", (req, res) => {
     const depthValue = Number.parseInt(String(req.query.depth || ""), 10);
-    const depth =
+    const requestedDepth =
       Number.isFinite(depthValue) && depthValue > 0
         ? depthValue
         : kDefaultTreeDepth;
+    const depth = Math.min(requestedDepth, kMaxTreeDepth);
     try {
       const tree = buildTreeNode(kRootResolved, depth);
       return res.json({ ok: true, root: tree });

--- a/lib/server/routes/browse/index.js
+++ b/lib/server/routes/browse/index.js
@@ -35,6 +35,16 @@ const registerBrowseRoutes = ({ app, fs, kRootDir }) => {
     fs.mkdirSync(kRootResolved, { recursive: true });
   }
 
+  const readVisibleDirectoryEntries = (absolutePath) =>
+    fs
+      .readdirSync(absolutePath, { withFileTypes: true })
+      .filter((entry) => {
+        if (entry.isDirectory() && kIgnoredDirectoryNames.has(entry.name)) {
+          return false;
+        }
+        return entry.isDirectory() || entry.isFile();
+      });
+
   const buildTreeNode = (absolutePath, depthRemaining) => {
     const stats = fs.statSync(absolutePath);
     const nodeName = path.basename(absolutePath);
@@ -45,17 +55,17 @@ const registerBrowseRoutes = ({ app, fs, kRootDir }) => {
     }
 
     if (depthRemaining <= 0) {
-      return { type: "folder", name: nodeName, path: nodePath, children: [] };
+      const hasMoreChildren = readVisibleDirectoryEntries(absolutePath).length > 0;
+      return {
+        type: "folder",
+        name: nodeName,
+        path: nodePath,
+        children: [],
+        truncated: hasMoreChildren,
+      };
     }
 
-    const children = fs
-      .readdirSync(absolutePath, { withFileTypes: true })
-      .filter((entry) => {
-        if (entry.isDirectory() && kIgnoredDirectoryNames.has(entry.name)) {
-          return false;
-        }
-        return entry.isDirectory() || entry.isFile();
-      })
+    const children = readVisibleDirectoryEntries(absolutePath)
       .map((entry) =>
         buildTreeNode(path.join(absolutePath, entry.name), depthRemaining - 1),
       )
@@ -76,8 +86,24 @@ const registerBrowseRoutes = ({ app, fs, kRootDir }) => {
         ? depthValue
         : kDefaultTreeDepth;
     const depth = Math.min(requestedDepth, kMaxTreeDepth);
+    const requestedPath = String(req.query.path || "").trim();
     try {
-      const tree = buildTreeNode(kRootResolved, depth);
+      const resolvedPath = requestedPath
+        ? resolveSafePath(
+            requestedPath,
+            kRootResolved,
+            kRootWithSep,
+            kRootDisplayName,
+          )
+        : { ok: true, absolutePath: kRootResolved };
+      if (!resolvedPath.ok) {
+        return res.status(400).json({ ok: false, error: resolvedPath.error });
+      }
+      const stats = fs.statSync(resolvedPath.absolutePath);
+      if (!stats.isDirectory()) {
+        return res.status(400).json({ ok: false, error: "Path is not a folder" });
+      }
+      const tree = buildTreeNode(resolvedPath.absolutePath, depth);
       return res.json({ ok: true, root: tree });
     } catch (error) {
       return res.status(500).json({

--- a/tests/frontend/api.test.js
+++ b/tests/frontend/api.test.js
@@ -439,6 +439,19 @@ describe("frontend/api", () => {
     expect(result).toEqual({ ok: true, committed: true });
   });
 
+  it("fetchBrowseTree defaults to a bounded tree depth", async () => {
+    global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: true, tree: [] }));
+    const api = await loadApiModule();
+
+    const result = await api.fetchBrowseTree();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/browse/tree?depth=3",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    expect(result).toEqual({ ok: true, tree: [] });
+  });
+
   it("fetchBrowseFileDiff calls git diff endpoint with encoded path", async () => {
     global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: true, content: "diff --git" }));
     const api = await loadApiModule();

--- a/tests/frontend/api.test.js
+++ b/tests/frontend/api.test.js
@@ -452,6 +452,34 @@ describe("frontend/api", () => {
     expect(result).toEqual({ ok: true, tree: [] });
   });
 
+  it("fetchBrowseTree requests a folder subtree by path", async () => {
+    global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: true, root: {} }));
+    const api = await loadApiModule();
+
+    const result = await api.fetchBrowseTree({
+      path: "workspace/hooks/bootstrap",
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/browse/tree?depth=3&path=workspace%2Fhooks%2Fbootstrap",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    expect(result).toEqual({ ok: true, root: {} });
+  });
+
+  it("fetchBrowseTree preserves numeric depth calls", async () => {
+    global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: true, root: {} }));
+    const api = await loadApiModule();
+
+    const result = await api.fetchBrowseTree(2);
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/browse/tree?depth=2",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    expect(result).toEqual({ ok: true, root: {} });
+  });
+
   it("fetchBrowseFileDiff calls git diff endpoint with encoded path", async () => {
     global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: true, content: "diff --git" }));
     const api = await loadApiModule();

--- a/tests/server/routes-browse.test.js
+++ b/tests/server/routes-browse.test.js
@@ -98,7 +98,37 @@ describe("server/routes/browse", () => {
     const level1 = res.body.root.children.find((entry) => entry.name === "level-1");
     const level2 = level1.children.find((entry) => entry.name === "level-2");
     const level3 = level2.children.find((entry) => entry.name === "level-3");
+    expect(level3.truncated).toBe(true);
     expect(level3.children).toEqual([]);
+  });
+
+  it("loads capped folder subtrees by path", async () => {
+    const rootDir = createTestRoot();
+    fs.mkdirSync(path.join(rootDir, "level-1", "level-2", "level-3", "level-4"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(rootDir, "level-1", "level-2", "level-3", "level-4", "deep.txt"),
+      "visible after expansion\n",
+      "utf8",
+    );
+    const app = createApp(rootDir);
+
+    const res = await request(app)
+      .get("/api/browse/tree")
+      .query({ depth: 10, path: "level-1/level-2/level-3" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.root.path).toBe("level-1/level-2/level-3");
+    const level4 = res.body.root.children.find((entry) => entry.name === "level-4");
+    expect(level4.children).toEqual([
+      expect.objectContaining({
+        type: "file",
+        name: "deep.txt",
+        path: "level-1/level-2/level-3/level-4/deep.txt",
+      }),
+    ]);
   });
 
   it("honors explicit shallow browse tree depth below the cap", async () => {

--- a/tests/server/routes-browse.test.js
+++ b/tests/server/routes-browse.test.js
@@ -79,6 +79,46 @@ describe("server/routes/browse", () => {
     ).toBe(false);
   });
 
+  it("caps requested browse tree depth", async () => {
+    const rootDir = createTestRoot();
+    fs.mkdirSync(path.join(rootDir, "level-1", "level-2", "level-3", "level-4"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(rootDir, "level-1", "level-2", "level-3", "level-4", "too-deep.txt"),
+      "hidden\n",
+      "utf8",
+    );
+    const app = createApp(rootDir);
+
+    const res = await request(app).get("/api/browse/tree").query({ depth: 10 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    const level1 = res.body.root.children.find((entry) => entry.name === "level-1");
+    const level2 = level1.children.find((entry) => entry.name === "level-2");
+    const level3 = level2.children.find((entry) => entry.name === "level-3");
+    expect(level3.children).toEqual([]);
+  });
+
+  it("honors explicit shallow browse tree depth below the cap", async () => {
+    const rootDir = createTestRoot();
+    fs.mkdirSync(path.join(rootDir, "level-1", "level-2"), { recursive: true });
+    fs.writeFileSync(
+      path.join(rootDir, "level-1", "level-2", "nested.txt"),
+      "hidden\n",
+      "utf8",
+    );
+    const app = createApp(rootDir);
+
+    const res = await request(app).get("/api/browse/tree").query({ depth: 1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    const level1 = res.body.root.children.find((entry) => entry.name === "level-1");
+    expect(level1.children).toEqual([]);
+  });
+
   it("rejects path traversal on read", async () => {
     const rootDir = createTestRoot();
     const app = createApp(rootDir);


### PR DESCRIPTION
## What

- Reduce the admin browse tree default depth from 10 to 3.
- Add a server-side maximum browse tree depth so older clients or manual API calls cannot request an arbitrarily deep recursive tree.
- Mark capped folders as truncated and lazy-load their subtrees when expanded, including recursive hydration across refreshes/remounts for already-expanded deep folders.
- Add frontend API and server route coverage for bounded tree behavior, subtree loading, and numeric-depth compatibility.

## Why

Large imported OpenClaw workspaces can make the admin panel extremely slow when the file browser eagerly requests a deep tree. Capping the initial recursive tree keeps the panel responsive, while lazy subtree loading preserves access to files below the initial depth cap.

## Tests

- `npm run build:ui`
- `npm test -- tests/frontend/api.test.js tests/server/routes-browse.test.js`
- `codex review --base origin/main` after fixes: no actionable introduced issues found.
- Protected API smoke: logged into a local AlphaClaw server and confirmed `/api/browse/tree?depth=10` returned a capped tree for a nested workspace fixture.
- `npm test` currently fails locally in `tests/bin/openclaw-config-restore.test.js` with two unrelated failures where branch detection returns `master` and `git ls-remote --heads origin 'master'` exits 127. The changed browse/API tests pass.

## AI Assistance

Implemented with AI assistance. I inspected the repository contribution guidance first, kept the patch narrowly scoped, ran local AI review, addressed the reported P1/P2 browse regressions, and signed off the commits for DCO.
