### PR TITLE
Harden setup login throttling

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -65,6 +65,10 @@ const {
   getDoctorCard,
   updateDoctorCardStatus,
 } = require("./server/db/doctor");
+const {
+  initAuthDb,
+  createLoginThrottleStore,
+} = require("./server/db/auth");
 const { createWebhookMiddleware } = require("./server/webhook-middleware");
 const {
   readEnvFile,
@@ -186,7 +190,10 @@ const agentsService = createAgentsService({
   restartGateway: () => restartGatewayWithReload(reloadEnv),
   clawCmd,
 });
-const loginThrottle = { ...createLoginThrottle(), getClientKey };
+const loginThrottle = {
+  ...createLoginThrottle({ store: createLoginThrottleStore() }),
+  getClientKey,
+};
 const resolveSetupUrl = () =>
   resolveSetupUiUrl(
     process.env.ALPHACLAW_SETUP_URL ||
@@ -219,6 +226,7 @@ const cronService = createCronService({
 app.use(express.static(path.join(__dirname, "public")));
 initializeServerDatabases({
   constants,
+  initAuthDb,
   initWebhooksDb,
   initWatchdogDb,
   initUsageDb,

--- a/lib/server/constants.js
+++ b/lib/server/constants.js
@@ -54,6 +54,22 @@ const kLoginMaxLockMs = parsePositiveInt(
   process.env.LOGIN_RATE_MAX_LOCK_MS,
   15 * 60 * 1000,
 );
+const kLoginGlobalWindowMs = parsePositiveInt(
+  process.env.LOGIN_RATE_GLOBAL_WINDOW_MS,
+  kLoginWindowMs,
+);
+const kLoginGlobalMaxAttempts = parsePositiveInt(
+  process.env.LOGIN_RATE_GLOBAL_MAX_ATTEMPTS,
+  Math.max(kLoginMaxAttempts * 5, 25),
+);
+const kLoginGlobalBaseLockMs = parsePositiveInt(
+  process.env.LOGIN_RATE_GLOBAL_BASE_LOCK_MS,
+  kLoginBaseLockMs,
+);
+const kLoginGlobalMaxLockMs = parsePositiveInt(
+  process.env.LOGIN_RATE_GLOBAL_MAX_LOCK_MS,
+  kLoginMaxLockMs,
+);
 const kLoginCleanupIntervalMs = parsePositiveInt(
   process.env.LOGIN_RATE_CLEANUP_INTERVAL_MS,
   60 * 1000,
@@ -445,6 +461,10 @@ module.exports = {
   kLoginMaxAttempts,
   kLoginBaseLockMs,
   kLoginMaxLockMs,
+  kLoginGlobalWindowMs,
+  kLoginGlobalMaxAttempts,
+  kLoginGlobalBaseLockMs,
+  kLoginGlobalMaxLockMs,
   kLoginCleanupIntervalMs,
   kLoginStateTtlMs,
   kOnboardingModelProviders,

--- a/lib/server/db/auth/index.js
+++ b/lib/server/db/auth/index.js
@@ -1,0 +1,147 @@
+const fs = require("fs");
+const path = require("path");
+const { DatabaseSync } = require("node:sqlite");
+const { createSchema } = require("./schema");
+
+let db = null;
+
+const ensureDb = () => {
+  if (!db) throw new Error("Auth DB not initialized");
+  return db;
+};
+
+const closeAuthDb = () => {
+  if (!db) return;
+  const database = db;
+  db = null;
+  database.close();
+};
+
+const initAuthDb = ({ rootDir }) => {
+  closeAuthDb();
+  const dbDir = path.join(rootDir, "db");
+  fs.mkdirSync(dbDir, { recursive: true });
+  const dbPath = path.join(dbDir, "auth.db");
+  db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA busy_timeout = 5000");
+  createSchema(db);
+  return { path: dbPath };
+};
+
+const toStateModel = (row) => {
+  if (!row) return null;
+  return {
+    attempts: Number(row.attempts || 0),
+    windowStart: Number(row.window_start || 0),
+    lockUntil: Number(row.lock_until || 0),
+    failStreak: Number(row.fail_streak || 0),
+    lastSeenAt: Number(row.last_seen_at || 0),
+  };
+};
+
+const createLoginThrottleStore = () => ({
+  get: (stateKey) => {
+    const row = ensureDb()
+      .prepare(
+        `
+          SELECT
+            attempts,
+            window_start,
+            lock_until,
+            fail_streak,
+            last_seen_at
+          FROM login_throttle_states
+          WHERE state_key = $state_key
+          LIMIT 1
+        `,
+      )
+      .get({ $state_key: String(stateKey || "") });
+    return toStateModel(row);
+  },
+
+  set: (stateKey, state) => {
+    ensureDb()
+      .prepare(
+        `
+          INSERT INTO login_throttle_states (
+            state_key,
+            attempts,
+            window_start,
+            lock_until,
+            fail_streak,
+            last_seen_at
+          ) VALUES (
+            $state_key,
+            $attempts,
+            $window_start,
+            $lock_until,
+            $fail_streak,
+            $last_seen_at
+          )
+          ON CONFLICT(state_key) DO UPDATE SET
+            attempts = excluded.attempts,
+            window_start = excluded.window_start,
+            lock_until = excluded.lock_until,
+            fail_streak = excluded.fail_streak,
+            last_seen_at = excluded.last_seen_at
+        `,
+      )
+      .run({
+        $state_key: String(stateKey || ""),
+        $attempts: Number(state?.attempts || 0),
+        $window_start: Number(state?.windowStart || 0),
+        $lock_until: Number(state?.lockUntil || 0),
+        $fail_streak: Number(state?.failStreak || 0),
+        $last_seen_at: Number(state?.lastSeenAt || 0),
+      });
+  },
+
+  delete: (stateKey) => {
+    ensureDb()
+      .prepare(
+        `
+          DELETE FROM login_throttle_states
+          WHERE state_key = $state_key
+        `,
+      )
+      .run({ $state_key: String(stateKey || "") });
+  },
+
+  entries: () =>
+    ensureDb()
+      .prepare(
+        `
+          SELECT
+            state_key,
+            attempts,
+            window_start,
+            lock_until,
+            fail_streak,
+            last_seen_at
+          FROM login_throttle_states
+        `,
+      )
+      .all()
+      .map((row) => [String(row.state_key || ""), toStateModel(row)]),
+
+  runExclusive: (callback) => {
+    const database = ensureDb();
+    database.exec("BEGIN IMMEDIATE");
+    try {
+      const result = callback();
+      database.exec("COMMIT");
+      return result;
+    } catch (err) {
+      try {
+        database.exec("ROLLBACK");
+      } catch {}
+      throw err;
+    }
+  },
+});
+
+module.exports = {
+  initAuthDb,
+  closeAuthDb,
+  createLoginThrottleStore,
+};

--- a/lib/server/db/auth/schema.js
+++ b/lib/server/db/auth/schema.js
@@ -1,0 +1,17 @@
+const createSchema = (db) => {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS login_throttle_states (
+      state_key TEXT PRIMARY KEY,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      window_start INTEGER NOT NULL,
+      lock_until INTEGER NOT NULL DEFAULT 0,
+      fail_streak INTEGER NOT NULL DEFAULT 0,
+      last_seen_at INTEGER NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_login_throttle_states_last_seen
+      ON login_throttle_states(last_seen_at);
+  `);
+};
+
+module.exports = { createSchema };

--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -60,9 +60,7 @@ const isDebugEnabled = () =>
   isTruthyEnvFlag(process.env.DEBUG);
 
 const getClientKey = (req) =>
-  normalizeIp(
-    req.ip || req.headers["x-forwarded-for"] || req.socket?.remoteAddress || "",
-  ) || "unknown";
+  normalizeIp(req.ip || req.socket?.remoteAddress || "") || "unknown";
 
 const resolveGithubRepoUrl = (repoInput) => {
   const cleaned = String(repoInput || "")

--- a/lib/server/init/runtime-init.js
+++ b/lib/server/init/runtime-init.js
@@ -19,11 +19,15 @@ const initializeServerRuntime = ({
 
 const initializeServerDatabases = ({
   constants,
+  initAuthDb,
   initWebhooksDb,
   initWatchdogDb,
   initUsageDb,
   initDoctorDb,
 }) => {
+  initAuthDb({
+    rootDir: constants.kRootDir,
+  });
   initWebhooksDb({
     rootDir: constants.kRootDir,
     pruneDays: constants.kWebhookPruneDays,

--- a/lib/server/login-throttle.js
+++ b/lib/server/login-throttle.js
@@ -1,77 +1,255 @@
-const { kLoginWindowMs, kLoginMaxAttempts, kLoginBaseLockMs, kLoginMaxLockMs, kLoginStateTtlMs } = require("./constants");
+const {
+  kLoginWindowMs,
+  kLoginMaxAttempts,
+  kLoginBaseLockMs,
+  kLoginMaxLockMs,
+  kLoginGlobalWindowMs,
+  kLoginGlobalMaxAttempts,
+  kLoginGlobalBaseLockMs,
+  kLoginGlobalMaxLockMs,
+  kLoginStateTtlMs,
+} = require("./constants");
 
-const createLoginThrottle = () => {
-  const kLoginAttemptStates = new Map();
+const kGlobalStateKey = "global:login";
 
-  const getOrCreateLoginAttemptState = (clientKey, now) => {
-    const existing = kLoginAttemptStates.get(clientKey);
-    if (existing) {
-      existing.lastSeenAt = now;
-      return existing;
-    }
-    const next = {
-      attempts: 0,
-      windowStart: now,
-      lockUntil: 0,
-      failStreak: 0,
-      lastSeenAt: now,
-    };
-    kLoginAttemptStates.set(clientKey, next);
-    return next;
+const createLoginAttemptState = (now) => ({
+  attempts: 0,
+  windowStart: now,
+  lockUntil: 0,
+  failStreak: 0,
+  lastSeenAt: now,
+});
+
+const normalizeState = (state, now) => ({
+  attempts: Number.parseInt(String(state?.attempts ?? 0), 10) || 0,
+  windowStart: Number.parseInt(String(state?.windowStart ?? now), 10) || now,
+  lockUntil: Number.parseInt(String(state?.lockUntil ?? 0), 10) || 0,
+  failStreak: Number.parseInt(String(state?.failStreak ?? 0), 10) || 0,
+  lastSeenAt: Number.parseInt(String(state?.lastSeenAt ?? now), 10) || now,
+});
+
+const createMemoryLoginThrottleStore = () => {
+  const states = new Map();
+
+  return {
+    get: (stateKey) => states.get(stateKey) || null,
+    set: (stateKey, state) => {
+      states.set(stateKey, { ...state });
+    },
+    delete: (stateKey) => {
+      states.delete(stateKey);
+    },
+    entries: () =>
+      Array.from(states.entries()).map(([stateKey, state]) => [
+        stateKey,
+        { ...state },
+      ]),
+    runExclusive: (callback) => callback(),
   };
+};
 
-  const evaluateLoginThrottle = (state, now) => {
-    if (!state) return { blocked: false, retryAfterSec: 0 };
-    if (state.lockUntil > now) {
-      return {
-        blocked: true,
-        retryAfterSec: Math.max(1, Math.ceil((state.lockUntil - now) / 1000)),
-      };
-    }
-    if (now - state.windowStart >= kLoginWindowMs) {
-      state.attempts = 0;
-      state.windowStart = now;
-    }
-    return { blocked: false, retryAfterSec: 0 };
-  };
+const getClientStateKey = (clientKey) =>
+  `client:${String(clientKey || "unknown")}`;
 
-  const recordLoginFailure = (state, now) => {
-    if (!state) return { lockMs: 0, locked: false };
-    if (now - state.windowStart >= kLoginWindowMs) {
-      state.attempts = 0;
-      state.windowStart = now;
-    }
-    state.attempts += 1;
+const getOrCreateState = (store, stateKey, now) => {
+  const existing = store.get(stateKey);
+  if (existing) {
+    const state = normalizeState(existing, now);
     state.lastSeenAt = now;
-    if (state.attempts < kLoginMaxAttempts) {
-      return { lockMs: 0, locked: false };
-    }
-    state.failStreak += 1;
+    store.set(stateKey, state);
+    return state;
+  }
+  const next = createLoginAttemptState(now);
+  store.set(stateKey, next);
+  return next;
+};
+
+const evaluateState = ({ store, stateKey, now, windowMs }) => {
+  const state = getOrCreateState(store, stateKey, now);
+  if (state.lockUntil > now) {
+    return {
+      state,
+      blocked: true,
+      retryAfterSec: Math.max(1, Math.ceil((state.lockUntil - now) / 1000)),
+    };
+  }
+  if (now - state.windowStart >= windowMs) {
     state.attempts = 0;
     state.windowStart = now;
-    const lockMultiplier = Math.max(1, 2 ** (state.failStreak - 1));
-    const lockMs = Math.min(kLoginBaseLockMs * lockMultiplier, kLoginMaxLockMs);
-    state.lockUntil = now + lockMs;
-    return { lockMs, locked: true };
+    store.set(stateKey, state);
+  }
+  return { state, blocked: false, retryAfterSec: 0 };
+};
+
+const recordStateFailure = ({
+  store,
+  stateKey,
+  now,
+  windowMs,
+  maxAttempts,
+  baseLockMs,
+  maxLockMs,
+}) => {
+  const state = getOrCreateState(store, stateKey, now);
+  if (state.lockUntil > now) {
+    return {
+      state,
+      lockMs: state.lockUntil - now,
+      locked: true,
+      retryAfterSec: Math.max(1, Math.ceil((state.lockUntil - now) / 1000)),
+    };
+  }
+  if (now - state.windowStart >= windowMs) {
+    state.attempts = 0;
+    state.windowStart = now;
+  }
+  state.attempts += 1;
+  state.lastSeenAt = now;
+  if (state.attempts < maxAttempts) {
+    store.set(stateKey, state);
+    return { state, lockMs: 0, locked: false, retryAfterSec: 0 };
+  }
+  state.failStreak += 1;
+  state.attempts = 0;
+  state.windowStart = now;
+  const lockMultiplier = Math.max(1, 2 ** (state.failStreak - 1));
+  const lockMs = Math.min(baseLockMs * lockMultiplier, maxLockMs);
+  state.lockUntil = now + lockMs;
+  store.set(stateKey, state);
+  return {
+    state,
+    lockMs,
+    locked: true,
+    retryAfterSec: Math.max(1, Math.ceil(lockMs / 1000)),
   };
+};
+
+const chooseThrottleResult = (...results) => {
+  const blockedResults = results.filter((result) => result.blocked);
+  if (blockedResults.length === 0) {
+    return { blocked: false, retryAfterSec: 0 };
+  }
+  return {
+    blocked: true,
+    retryAfterSec: Math.max(
+      ...blockedResults.map((result) => result.retryAfterSec || 0),
+    ),
+  };
+};
+
+const chooseFailureResult = (...results) => {
+  const lockedResults = results.filter((result) => result.locked);
+  if (lockedResults.length === 0) {
+    return { lockMs: 0, locked: false, retryAfterSec: 0 };
+  }
+  return {
+    lockMs: Math.max(...lockedResults.map((result) => result.lockMs || 0)),
+    locked: true,
+    retryAfterSec: Math.max(
+      ...lockedResults.map((result) => result.retryAfterSec || 0),
+    ),
+  };
+};
+
+const createLoginThrottle = ({
+  store = createMemoryLoginThrottleStore(),
+} = {}) => {
+  const runExclusive =
+    typeof store.runExclusive === "function"
+      ? (callback) => store.runExclusive(callback)
+      : (callback) => callback();
+
+  const getOrCreateLoginAttemptState = (clientKey, now) =>
+    runExclusive(() => {
+      const clientStateKey = getClientStateKey(clientKey);
+      return {
+        clientKey,
+        clientStateKey,
+        globalStateKey: kGlobalStateKey,
+        client: getOrCreateState(store, clientStateKey, now),
+        global: getOrCreateState(store, kGlobalStateKey, now),
+      };
+    });
+
+  const evaluateLoginThrottle = (stateBundle, now) =>
+    runExclusive(() => {
+      const clientStateKey =
+        stateBundle?.clientStateKey ||
+        getClientStateKey(stateBundle?.clientKey);
+      const globalStateKey = stateBundle?.globalStateKey || kGlobalStateKey;
+      const clientResult = evaluateState({
+        store,
+        stateKey: clientStateKey,
+        now,
+        windowMs: kLoginWindowMs,
+      });
+      const globalResult = evaluateState({
+        store,
+        stateKey: globalStateKey,
+        now,
+        windowMs: kLoginGlobalWindowMs,
+      });
+      if (stateBundle) {
+        stateBundle.client = clientResult.state;
+        stateBundle.global = globalResult.state;
+      }
+      return chooseThrottleResult(clientResult, globalResult);
+    });
+
+  const recordLoginFailure = (stateBundle, now) =>
+    runExclusive(() => {
+      const clientStateKey =
+        stateBundle?.clientStateKey ||
+        getClientStateKey(stateBundle?.clientKey);
+      const globalStateKey = stateBundle?.globalStateKey || kGlobalStateKey;
+      const clientResult = recordStateFailure({
+        store,
+        stateKey: clientStateKey,
+        now,
+        windowMs: kLoginWindowMs,
+        maxAttempts: kLoginMaxAttempts,
+        baseLockMs: kLoginBaseLockMs,
+        maxLockMs: kLoginMaxLockMs,
+      });
+      const globalResult = recordStateFailure({
+        store,
+        stateKey: globalStateKey,
+        now,
+        windowMs: kLoginGlobalWindowMs,
+        maxAttempts: kLoginGlobalMaxAttempts,
+        baseLockMs: kLoginGlobalBaseLockMs,
+        maxLockMs: kLoginGlobalMaxLockMs,
+      });
+      if (stateBundle) {
+        stateBundle.client = clientResult.state;
+        stateBundle.global = globalResult.state;
+      }
+      return chooseFailureResult(clientResult, globalResult);
+    });
 
   const recordLoginSuccess = (clientKey) => {
     if (!clientKey) return;
-    kLoginAttemptStates.delete(clientKey);
+    runExclusive(() => {
+      store.delete(getClientStateKey(clientKey));
+      store.delete(kGlobalStateKey);
+    });
   };
 
   const cleanupLoginAttemptStates = () => {
     const now = Date.now();
-    for (const [key, state] of kLoginAttemptStates.entries()) {
-      if (!state) {
-        kLoginAttemptStates.delete(key);
-        continue;
+    runExclusive(() => {
+      for (const [stateKey, rawState] of store.entries()) {
+        if (!rawState) {
+          store.delete(stateKey);
+          continue;
+        }
+        const state = normalizeState(rawState, now);
+        if (state.lockUntil > now) continue;
+        if (now - state.lastSeenAt > kLoginStateTtlMs) {
+          store.delete(stateKey);
+        }
       }
-      if (state.lockUntil > now) continue;
-      if (now - state.lastSeenAt > kLoginStateTtlMs) {
-        kLoginAttemptStates.delete(key);
-      }
-    }
+    });
   };
 
   return {
@@ -83,4 +261,8 @@ const createLoginThrottle = () => {
   };
 };
 
-module.exports = { createLoginThrottle };
+module.exports = {
+  createLoginThrottle,
+  createMemoryLoginThrottleStore,
+  kGlobalStateKey,
+};

--- a/tests/server/auth-db.test.js
+++ b/tests/server/auth-db.test.js
@@ -1,0 +1,74 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { createLoginThrottle } = require("../../lib/server/login-throttle");
+const { kLoginMaxAttempts } = require("../../lib/server/constants");
+
+const loadAuthDb = () => {
+  const modulePath = require.resolve("../../lib/server/db/auth");
+  delete require.cache[modulePath];
+  return require(modulePath);
+};
+
+let currentAuthDb = null;
+let currentRootDir = "";
+
+const createAuthDbContext = (prefix) => {
+  currentRootDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  currentAuthDb = loadAuthDb();
+  const dbResult = currentAuthDb.initAuthDb({ rootDir: currentRootDir });
+  return {
+    ...currentAuthDb,
+    ...dbResult,
+    rootDir: currentRootDir,
+  };
+};
+
+describe("server/auth-db", () => {
+  afterEach(() => {
+    if (currentAuthDb?.closeAuthDb) {
+      currentAuthDb.closeAuthDb();
+      currentAuthDb = null;
+    }
+    if (currentRootDir) {
+      fs.rmSync(currentRootDir, { recursive: true, force: true });
+      currentRootDir = "";
+    }
+  });
+
+  it("initializes auth.db under root db directory", () => {
+    const result = createAuthDbContext("auth-db-init-");
+
+    expect(result.path).toBe(path.join(result.rootDir, "db", "auth.db"));
+    expect(fs.existsSync(result.path)).toBe(true);
+  });
+
+  it("persists login throttle failures across throttle instances", () => {
+    const { createLoginThrottleStore } = createAuthDbContext("auth-db-throttle-");
+    const firstThrottle = createLoginThrottle({
+      store: createLoginThrottleStore(),
+    });
+    const now = 1_000;
+    const firstState = firstThrottle.getOrCreateLoginAttemptState(
+      "client-1",
+      now,
+    );
+
+    for (let i = 0; i < kLoginMaxAttempts - 1; i += 1) {
+      const result = firstThrottle.recordLoginFailure(firstState, now + i);
+      expect(result.locked).toBe(false);
+    }
+
+    const secondThrottle = createLoginThrottle({
+      store: createLoginThrottleStore(),
+    });
+    const secondState = secondThrottle.getOrCreateLoginAttemptState(
+      "client-1",
+      now + 100,
+    );
+    const lockResult = secondThrottle.recordLoginFailure(secondState, now + 100);
+
+    expect(lockResult.locked).toBe(true);
+  });
+});

--- a/tests/server/helpers.test.js
+++ b/tests/server/helpers.test.js
@@ -2,6 +2,7 @@ const {
   parseJsonFromNoisyOutput,
   parseJwtPayload,
   getCodexAccountId,
+  getClientKey,
   resolveGithubRepoUrl,
   normalizeOnboardingModels,
 } = require("../../lib/server/helpers");
@@ -52,6 +53,15 @@ describe("server/helpers", () => {
   it("returns null for invalid JWT payloads", () => {
     expect(parseJwtPayload("bad.token")).toBeNull();
     expect(getCodexAccountId("bad.token.value")).toBeNull();
+  });
+
+  it("does not use raw x-forwarded-for as the client key fallback", () => {
+    const key = getClientKey({
+      headers: { "x-forwarded-for": "203.0.113.10" },
+      socket: { remoteAddress: "::ffff:127.0.0.1" },
+    });
+
+    expect(key).toBe("127.0.0.1");
   });
 
   it("normalizes onboarding models by filtering, deduping, and sorting", () => {

--- a/tests/server/login-throttle.test.js
+++ b/tests/server/login-throttle.test.js
@@ -4,6 +4,7 @@ const {
   kLoginMaxAttempts,
   kLoginBaseLockMs,
   kLoginMaxLockMs,
+  kLoginGlobalMaxAttempts,
   kLoginStateTtlMs,
 } = require("../../lib/server/constants");
 
@@ -14,10 +15,12 @@ describe("server/login-throttle", () => {
     const state = throttle.getOrCreateLoginAttemptState("client-1", now);
 
     for (let i = 0; i < kLoginMaxAttempts - 1; i += 1) {
-      expect(throttle.recordLoginFailure(state, now + i)).toEqual({
-        lockMs: 0,
-        locked: false,
-      });
+      expect(throttle.recordLoginFailure(state, now + i)).toEqual(
+        expect.objectContaining({
+          lockMs: 0,
+          locked: false,
+        }),
+      );
     }
 
     const lockResult = throttle.recordLoginFailure(state, now + 100);
@@ -57,8 +60,44 @@ describe("server/login-throttle", () => {
     throttle.recordLoginSuccess("client-3");
 
     const state = throttle.getOrCreateLoginAttemptState("client-3", now + 1);
-    expect(state.attempts).toBe(0);
-    expect(state.failStreak).toBe(0);
+    expect(state.client.attempts).toBe(0);
+    expect(state.client.failStreak).toBe(0);
+    expect(state.global.attempts).toBe(0);
+    expect(state.global.failStreak).toBe(0);
+  });
+
+  it("locks globally even when failures rotate across client keys", () => {
+    const throttle = createLoginThrottle();
+    const now = 15_000;
+
+    for (let i = 0; i < kLoginGlobalMaxAttempts - 1; i += 1) {
+      const state = throttle.getOrCreateLoginAttemptState(
+        `client-${i}`,
+        now + i,
+      );
+      const result = throttle.recordLoginFailure(state, now + i);
+      expect(result.locked).toBe(false);
+    }
+
+    const finalState = throttle.getOrCreateLoginAttemptState(
+      "fresh-client",
+      now + kLoginGlobalMaxAttempts,
+    );
+    const lockResult = throttle.recordLoginFailure(
+      finalState,
+      now + kLoginGlobalMaxAttempts,
+    );
+    expect(lockResult.locked).toBe(true);
+
+    const blockedState = throttle.getOrCreateLoginAttemptState(
+      "another-fresh-client",
+      now + kLoginGlobalMaxAttempts + 1,
+    );
+    const blocked = throttle.evaluateLoginThrottle(
+      blockedState,
+      now + kLoginGlobalMaxAttempts + 1,
+    );
+    expect(blocked.blocked).toBe(true);
   });
 
   it("cleans up stale states past TTL", () => {
@@ -73,6 +112,6 @@ describe("server/login-throttle", () => {
       "client-4",
       oldNow + kLoginStateTtlMs + 2,
     );
-    expect(fresh.windowStart).toBe(oldNow + kLoginStateTtlMs + 2);
+    expect(fresh.client.windowStart).toBe(oldNow + kLoginStateTtlMs + 2);
   });
 });

--- a/tests/server/routes-auth.test.js
+++ b/tests/server/routes-auth.test.js
@@ -1,5 +1,8 @@
 const express = require("express");
 const request = require("supertest");
+const { createLoginThrottle } = require("../../lib/server/login-throttle");
+const { kLoginGlobalMaxAttempts } = require("../../lib/server/constants");
+const { getClientKey } = require("../../lib/server/helpers");
 
 const loadAuthRoutes = () => {
   vi.resetModules();
@@ -17,7 +20,10 @@ const createLoginThrottleMock = () => ({
   cleanupLoginAttemptStates: vi.fn(),
 });
 
-const createTestApp = ({ setupPassword, loginThrottle } = {}) => {
+const getTestIp = (index) =>
+  `203.0.${Math.floor(index / 250)}.${(index % 250) + 1}`;
+
+const createTestApp = ({ setupPassword, loginThrottle, trustProxy } = {}) => {
   if (typeof setupPassword === "string") {
     process.env.SETUP_PASSWORD = setupPassword;
   } else {
@@ -26,6 +32,7 @@ const createTestApp = ({ setupPassword, loginThrottle } = {}) => {
 
   const { registerAuthRoutes } = loadAuthRoutes();
   const app = express();
+  if (trustProxy !== undefined) app.set("trust proxy", trustProxy);
   app.use(express.json());
   const throttle = loginThrottle || createLoginThrottleMock();
   registerAuthRoutes({ app, loginThrottle: throttle });
@@ -76,6 +83,30 @@ describe("server/routes/auth", () => {
     expect(res.status).toBe(401);
     expect(res.body).toEqual({ ok: false, error: "Invalid credentials" });
     expect(throttle.recordLoginFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies global throttling when proxy-derived client keys rotate", async () => {
+    const { app } = createTestApp({
+      setupPassword: "secret",
+      trustProxy: 1,
+      loginThrottle: { ...createLoginThrottle(), getClientKey },
+    });
+
+    for (let i = 0; i < kLoginGlobalMaxAttempts - 1; i += 1) {
+      const res = await request(app)
+        .post("/api/auth/login")
+        .set("X-Forwarded-For", getTestIp(i))
+        .send({ password: "wrong" });
+      expect(res.status).toBe(401);
+    }
+
+    const res = await request(app)
+      .post("/api/auth/login")
+      .set("X-Forwarded-For", getTestIp(kLoginGlobalMaxAttempts))
+      .send({ password: "wrong" });
+
+    expect(res.status).toBe(429);
+    expect(res.headers["retry-after"]).toBeTruthy();
   });
 
   it("sets auth cookie on success and allows protected API by cookie", async () => {


### PR DESCRIPTION
## Summary
- persist setup login throttle state in a new SQLite-backed auth DB
- add a global login failure bucket so rotated client keys still hit lockout
- stop using raw X-Forwarded-For as the fallback client key
- add focused coverage for restart persistence, global throttling, and client key fallback behavior

## Tests
- npm test -- tests/server/login-throttle.test.js tests/server/auth-db.test.js tests/server/routes-auth.test.js tests/server/helpers.test.js
- npm test -- tests/server
