### PR TITLE
fix(runtime): make helper paths container-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ The built-in watchdog monitors gateway health and recovers from failures automat
 | `WATCHDOG_NOTIFICATIONS_DISABLED` | Optional | Disable watchdog notifications (`true`/`false`)    |
 | `PORT`                            | Optional | Server port (default `3000`)                       |
 | `ALPHACLAW_ROOT_DIR`              | Optional | Data directory (default `/data`)                   |
+| `ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL` | Optional | Skip writes to `/etc/cron.d` while keeping cron config (`true`/`false`) |
+| `ALPHACLAW_GIT_SHIM_PATH`         | Optional | Install the managed git auth shim at this path (default `/usr/local/bin/git`) |
+| `ALPHACLAW_GIT_ASKPASS_PATH`      | Optional | Install the git askpass helper at this path (default `$TMPDIR/alphaclaw-git-askpass.sh`) |
 | `TRUST_PROXY_HOPS`                | Optional | Trust proxy hop count for correct client IP        |
 
 ## Security Notes

--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ The built-in watchdog monitors gateway health and recovers from failures automat
 | `WATCHDOG_NOTIFICATIONS_DISABLED` | Optional | Disable watchdog notifications (`true`/`false`)    |
 | `PORT`                            | Optional | Server port (default `3000`)                       |
 | `ALPHACLAW_ROOT_DIR`              | Optional | Data directory (default `/data`)                   |
-| `ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL` | Optional | Skip writes to `/etc/cron.d` while keeping cron config (`true`/`false`) |
-| `ALPHACLAW_GIT_SHIM_PATH`         | Optional | Install the managed git auth shim at this path (default `/usr/local/bin/git`) |
+| `ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL` | Optional | Skip writes to `/etc/cron.d` while keeping cron config (`true`/`false`); the managed hourly script still exits when sync is disabled |
+| `ALPHACLAW_GIT_SHIM_PATH`         | Optional | Install the managed git auth shim at this path and prepend its directory to runtime `PATH` (default `/usr/local/bin/git`) |
 | `ALPHACLAW_GIT_ASKPASS_PATH`      | Optional | Install the git askpass helper at this path (default `$TMPDIR/alphaclaw-git-askpass.sh`) |
 | `TRUST_PROXY_HOPS`                | Optional | Trust proxy hop count for correct client IP        |
 

--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -6,6 +6,9 @@ const os = require("os");
 const path = require("path");
 const { execSync } = require("child_process");
 const {
+  shouldSkipSystemCronInstall,
+  resolveGitAskPassPath,
+  resolveGitShimPath,
   normalizeGitSyncFilePath,
   validateGitSyncFilePath,
   resolveRealGitPath,
@@ -278,7 +281,7 @@ const runGitSync = () => {
   }
 
   const realGitPath = resolveRealGitPath({
-    shimPath: "/usr/local/bin/git",
+    shimPath: resolveGitShimPath({ env: process.env }),
   });
   if (!realGitPath) {
     console.error(
@@ -631,7 +634,11 @@ if (fs.existsSync(hourlyGitSyncPath)) {
     }
 
     const cronFilePath = "/etc/cron.d/openclaw-hourly-sync";
-    if (cronEnabled) {
+    if (shouldSkipSystemCronInstall({ env: process.env })) {
+      console.log(
+        "[alphaclaw] System cron setup skipped by ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL",
+      );
+    } else if (cronEnabled) {
       const cronContent = [
         "SHELL=/bin/bash",
         "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
@@ -819,11 +826,15 @@ try {
 
 try {
   const gitAskPassSrc = path.join(__dirname, "..", "lib", "scripts", "git-askpass");
-  const gitAskPassDest = "/tmp/alphaclaw-git-askpass.sh";
+  const gitAskPassDest = resolveGitAskPassPath({
+    env: process.env,
+    tmpDir: os.tmpdir(),
+  });
   const gitShimTemplatePath = path.join(__dirname, "..", "lib", "scripts", "git");
-  const gitShimDest = "/usr/local/bin/git";
+  const gitShimDest = resolveGitShimPath({ env: process.env });
 
   if (fs.existsSync(gitAskPassSrc)) {
+    fs.mkdirSync(path.dirname(gitAskPassDest), { recursive: true });
     fs.copyFileSync(gitAskPassSrc, gitAskPassDest);
     fs.chmodSync(gitAskPassDest, 0o755);
   }
@@ -837,7 +848,9 @@ try {
     const gitShimTemplate = fs.readFileSync(gitShimTemplatePath, "utf8");
     const gitShimContent = gitShimTemplate
       .replace("@@REAL_GIT@@", realGitPath)
-      .replace("@@OPENCLAW_REPO_ROOT@@", openclawDir);
+      .replace("@@OPENCLAW_REPO_ROOT@@", openclawDir)
+      .replace("@@ASKPASS_PATH@@", gitAskPassDest);
+    fs.mkdirSync(path.dirname(gitShimDest), { recursive: true });
     fs.writeFileSync(gitShimDest, gitShimContent, { mode: 0o755 });
     console.log("[alphaclaw] git auth shim installed");
   }

--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -9,6 +9,7 @@ const {
   shouldSkipSystemCronInstall,
   resolveGitAskPassPath,
   resolveGitShimPath,
+  prependGitShimDirToPath,
   normalizeGitSyncFilePath,
   validateGitSyncFilePath,
   resolveRealGitPath,
@@ -831,6 +832,9 @@ try {
   });
   const gitShimTemplatePath = path.join(__dirname, "..", "lib", "scripts", "git");
   const gitShimDest = resolveGitShimPath();
+  process.env.PATH = prependGitShimDirToPath({
+    shimPath: gitShimDest,
+  });
 
   if (fs.existsSync(gitAskPassSrc)) {
     fs.mkdirSync(path.dirname(gitAskPassDest), { recursive: true });

--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -281,7 +281,7 @@ const runGitSync = () => {
   }
 
   const realGitPath = resolveRealGitPath({
-    shimPath: resolveGitShimPath({ env: process.env }),
+    shimPath: resolveGitShimPath(),
   });
   if (!realGitPath) {
     console.error(
@@ -634,7 +634,7 @@ if (fs.existsSync(hourlyGitSyncPath)) {
     }
 
     const cronFilePath = "/etc/cron.d/openclaw-hourly-sync";
-    if (shouldSkipSystemCronInstall({ env: process.env })) {
+    if (shouldSkipSystemCronInstall()) {
       console.log(
         "[alphaclaw] System cron setup skipped by ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL",
       );
@@ -827,11 +827,10 @@ try {
 try {
   const gitAskPassSrc = path.join(__dirname, "..", "lib", "scripts", "git-askpass");
   const gitAskPassDest = resolveGitAskPassPath({
-    env: process.env,
     tmpDir: os.tmpdir(),
   });
   const gitShimTemplatePath = path.join(__dirname, "..", "lib", "scripts", "git");
-  const gitShimDest = resolveGitShimPath({ env: process.env });
+  const gitShimDest = resolveGitShimPath();
 
   if (fs.existsSync(gitAskPassSrc)) {
     fs.mkdirSync(path.dirname(gitAskPassDest), { recursive: true });

--- a/lib/cli/git-runtime.js
+++ b/lib/cli/git-runtime.js
@@ -2,6 +2,28 @@ const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
+const isEnabledEnvFlag = (value) =>
+  ["1", "true", "yes", "on"].includes(
+    String(value || "").trim().toLowerCase(),
+  );
+
+const shouldSkipSystemCronInstall = ({ env = process.env } = {}) =>
+  isEnabledEnvFlag(env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL);
+
+const resolveGitAskPassPath = ({ env = process.env, tmpDir = "/tmp" } = {}) => {
+  const explicitPath = String(env.ALPHACLAW_GIT_ASKPASS_PATH || "").trim();
+  if (explicitPath) return explicitPath;
+
+  const runtimeTmpDir =
+    String(env.TMPDIR || "").trim() || String(tmpDir || "").trim() || "/tmp";
+  return path.join(runtimeTmpDir, "alphaclaw-git-askpass.sh");
+};
+
+const resolveGitShimPath = ({ env = process.env } = {}) => {
+  const explicitPath = String(env.ALPHACLAW_GIT_SHIM_PATH || "").trim();
+  return explicitPath || "/usr/local/bin/git";
+};
+
 const normalizeGitSyncFilePath = (requestedFilePath) => {
   const rawPath = String(requestedFilePath || "").trim();
   if (!rawPath) return "";
@@ -90,6 +112,9 @@ const shouldRefreshHourlyGitSyncScript = ({
 };
 
 module.exports = {
+  shouldSkipSystemCronInstall,
+  resolveGitAskPassPath,
+  resolveGitShimPath,
   normalizeGitSyncFilePath,
   validateGitSyncFilePath,
   resolveRealGitPath,

--- a/lib/cli/git-runtime.js
+++ b/lib/cli/git-runtime.js
@@ -24,6 +24,21 @@ const resolveGitShimPath = ({ env = process.env } = {}) => {
   return explicitPath || "/usr/local/bin/git";
 };
 
+const prependGitShimDirToPath = ({
+  env = process.env,
+  shimPath = resolveGitShimPath({ env }),
+} = {}) => {
+  if (!String(env.ALPHACLAW_GIT_SHIM_PATH || "").trim()) {
+    return env.PATH || process.env.PATH || "";
+  }
+  const shimDir = path.dirname(String(shimPath || "").trim());
+  if (!shimDir || shimDir === ".") return env.PATH || process.env.PATH || "";
+  const pathEntries = String(env.PATH || process.env.PATH || "")
+    .split(path.delimiter)
+    .filter((entry) => entry && entry !== shimDir);
+  return [shimDir, ...pathEntries].join(path.delimiter);
+};
+
 const normalizeGitSyncFilePath = (requestedFilePath) => {
   const rawPath = String(requestedFilePath || "").trim();
   if (!rawPath) return "";
@@ -115,6 +130,7 @@ module.exports = {
   shouldSkipSystemCronInstall,
   resolveGitAskPassPath,
   resolveGitShimPath,
+  prependGitShimDirToPath,
   normalizeGitSyncFilePath,
   validateGitSyncFilePath,
   resolveRealGitPath,

--- a/lib/cli/openclaw-config-restore.js
+++ b/lib/cli/openclaw-config-restore.js
@@ -27,7 +27,7 @@ const resolveCurrentBranch = ({ execSyncImpl, openclawDir }) => {
 
 const createGitEnv = ({ fsModule, osModule, env, processId }) => {
   const githubToken = String(env.GITHUB_TOKEN || "").trim();
-  const gitEnv = { ...env };
+  const gitEnv = { PATH: process.env.PATH, ...env };
   if (!githubToken) {
     return { gitEnv, askPassPath: "" };
   }

--- a/lib/cli/openclaw-config-restore.js
+++ b/lib/cli/openclaw-config-restore.js
@@ -27,7 +27,7 @@ const resolveCurrentBranch = ({ execSyncImpl, openclawDir }) => {
 
 const createGitEnv = ({ fsModule, osModule, env, processId }) => {
   const githubToken = String(env.GITHUB_TOKEN || "").trim();
-  const gitEnv = { PATH: process.env.PATH, ...env };
+  const gitEnv = { ...env, PATH: env.PATH || process.env.PATH };
   if (!githubToken) {
     return { gitEnv, askPassPath: "" };
   }

--- a/lib/scripts/git
+++ b/lib/scripts/git
@@ -4,7 +4,7 @@
 
 REAL_GIT_HINT="@@REAL_GIT@@"
 OPENCLAW_REPO_ROOT="@@OPENCLAW_REPO_ROOT@@"
-ASKPASS_PATH="/tmp/alphaclaw-git-askpass.sh"
+ASKPASS_PATH="@@ASKPASS_PATH@@"
 
 same_path() {
   local left_path right_path

--- a/lib/server/onboarding/cron.js
+++ b/lib/server/onboarding/cron.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const { kSetupDir } = require("../constants");
 const { buildManagedPaths } = require("../internal-files-migration");
+const { shouldSkipSystemCronInstall } = require("../../cli/git-runtime");
 
 const kHourlyGitSyncTemplatePath = path.join(kSetupDir, "hourly-git-sync.sh");
 const kSystemCronPath = "/etc/cron.d/openclaw-hourly-sync";
@@ -36,6 +37,13 @@ const installHourlyGitSyncCron = async ({ fs, openclawDir }) => {
     const config = { enabled: true, schedule: kDefaultSystemCronSchedule };
     fs.mkdirSync(configDir, { recursive: true });
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    if (shouldSkipSystemCronInstall()) {
+      console.log(
+        "[onboard] System cron install skipped by ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL",
+      );
+      return false;
+    }
 
     const cronContent = buildSystemCronFile({
       schedule: config.schedule,

--- a/lib/server/openclaw-thinking.js
+++ b/lib/server/openclaw-thinking.js
@@ -27,6 +27,31 @@ const loadThinkingModule = async () => {
   return thinkingModulePromise;
 };
 
+const isNormalizeThinkLevel = (candidate) => {
+  if (typeof candidate !== "function") return false;
+  try {
+    return (
+      candidate("off") === "off" &&
+      candidate("low") === "low" &&
+      candidate("high") === "high"
+    );
+  } catch {
+    return false;
+  }
+};
+
+const resolveNormalizeThinkLevel = (mod) => {
+  const candidates = [
+    mod.normalizeThinkLevel,
+    mod.f,
+    mod.p,
+    ...Object.values(mod),
+  ];
+  const match = candidates.find(isNormalizeThinkLevel);
+  if (!match) throw new Error("OpenClaw normalizeThinkLevel export not found");
+  return match;
+};
+
 const splitModelKey = (modelKey = "") => {
   const normalized = String(modelKey || "").trim();
   const slashIndex = normalized.indexOf("/");
@@ -55,7 +80,7 @@ const resolveThinkingApi = async () => {
   return {
     listThinkingLevelOptions: mod.listThinkingLevelOptions || mod.i,
     resolveThinkingDefaultForModel: mod.resolveThinkingDefaultForModel || mod.s,
-    normalizeThinkLevel: mod.normalizeThinkLevel || mod.f,
+    normalizeThinkLevel: resolveNormalizeThinkLevel(mod),
   };
 };
 

--- a/lib/server/routes/system.js
+++ b/lib/server/routes/system.js
@@ -1,5 +1,6 @@
 const { buildManagedPaths } = require("../internal-files-migration");
 const { readOpenclawConfig } = require("../openclaw-config");
+const { shouldSkipSystemCronInstall } = require("../../cli/git-runtime");
 const https = require("https");
 
 const registerSystemRoutes = ({
@@ -382,6 +383,9 @@ const registerSystemRoutes = ({
       kSystemCronConfigPath,
       JSON.stringify(nextConfig, null, 2),
     );
+    if (shouldSkipSystemCronInstall()) {
+      return getSystemCronStatus();
+    }
     if (nextConfig.enabled) {
       fs.writeFileSync(
         kSystemCronPath,

--- a/lib/setup/hourly-git-sync.sh
+++ b/lib/setup/hourly-git-sync.sh
@@ -12,6 +12,23 @@ if [[ -f "$REPO/.env" ]]; then
   set +a
 fi
 
+if [[ -f "$REPO/cron/system-sync.json" ]]; then
+  if node - "$REPO/cron/system-sync.json" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+try {
+  const config = JSON.parse(fs.readFileSync(file, 'utf8'));
+  process.exit(config && config.enabled === false ? 0 : 1);
+} catch {
+  process.exit(1);
+}
+NODE
+  then
+    echo "hourly-git-sync: disabled by cron/system-sync.json"
+    exit 0
+  fi
+fi
+
 # Drop cron scheduler runtime-only churn when it is metadata/timestamp-only.
 maybe_restore_if_runtime_only() {
   local file="$1"

--- a/tests/bin/alphaclaw.test.js
+++ b/tests/bin/alphaclaw.test.js
@@ -171,6 +171,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
         OPENCLAW_HOME: process.env.OPENCLAW_HOME,
         OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
         OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+        PATH: process.env.PATH,
         XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
       }),
     );
@@ -188,6 +189,7 @@ Module._load = function patchedLoad(request, parent, isMain) {
         ...process.env,
         SETUP_PASSWORD: "test-password",
         ALPHACLAW_ROOT_DIR: tmpDir,
+        ALPHACLAW_GIT_SHIM_PATH: path.join(tmpDir, "bin", "git"),
         ALPHACLAW_TEST_HOME: tmpHome,
         ALPHACLAW_CAPTURE_ENV_PATH: capturePath,
         NODE_OPTIONS: `--require=${preloadPath}`,
@@ -195,13 +197,14 @@ Module._load = function patchedLoad(request, parent, isMain) {
     });
 
     const reportedEnv = JSON.parse(fs.readFileSync(capturePath, "utf8"));
-    expect(reportedEnv).toEqual({
+    expect(reportedEnv).toEqual(expect.objectContaining({
       HOME: tmpDir,
       OPENCLAW_HOME: tmpDir,
       OPENCLAW_CONFIG_PATH: path.join(tmpDir, ".openclaw", "openclaw.json"),
       OPENCLAW_STATE_DIR: path.join(tmpDir, ".openclaw"),
       XDG_CONFIG_HOME: path.join(tmpDir, ".openclaw"),
-    });
+    }));
+    expect(reportedEnv.PATH.split(path.delimiter)[0]).toBe(path.join(tmpDir, "bin"));
 
   });
 

--- a/tests/server/git-runtime.test.js
+++ b/tests/server/git-runtime.test.js
@@ -1,9 +1,46 @@
 const {
+  shouldSkipSystemCronInstall,
+  resolveGitAskPassPath,
+  resolveGitShimPath,
   resolveRealGitPath,
   shouldRefreshHourlyGitSyncScript,
 } = require("../../lib/cli/git-runtime");
 
 describe("cli/git runtime helpers", () => {
+  it("honors the system cron install opt-out flag", () => {
+    expect(
+      shouldSkipSystemCronInstall({
+        env: { ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL: "true" },
+      }),
+    ).toBe(true);
+    expect(
+      shouldSkipSystemCronInstall({
+        env: { ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL: "0" },
+      }),
+    ).toBe(false);
+  });
+
+  it("resolves git helper paths from runtime environment", () => {
+    expect(
+      resolveGitAskPassPath({
+        env: { TMPDIR: "/runtime/tmp" },
+        tmpDir: "/fallback/tmp",
+      }),
+    ).toBe("/runtime/tmp/alphaclaw-git-askpass.sh");
+    expect(
+      resolveGitAskPassPath({
+        env: { ALPHACLAW_GIT_ASKPASS_PATH: "/state/git-askpass" },
+        tmpDir: "/fallback/tmp",
+      }),
+    ).toBe("/state/git-askpass");
+    expect(
+      resolveGitShimPath({
+        env: { ALPHACLAW_GIT_SHIM_PATH: "/state/bin/git" },
+      }),
+    ).toBe("/state/bin/git");
+    expect(resolveGitShimPath({ env: {} })).toBe("/usr/local/bin/git");
+  });
+
   it("resolves a real git path while skipping the installed shim", () => {
     const resolvedPath = resolveRealGitPath({
       shimPath: "/usr/local/bin/git",

--- a/tests/server/git-runtime.test.js
+++ b/tests/server/git-runtime.test.js
@@ -2,6 +2,7 @@ const {
   shouldSkipSystemCronInstall,
   resolveGitAskPassPath,
   resolveGitShimPath,
+  prependGitShimDirToPath,
   resolveRealGitPath,
   shouldRefreshHourlyGitSyncScript,
 } = require("../../lib/cli/git-runtime");
@@ -39,6 +40,47 @@ describe("cli/git runtime helpers", () => {
       }),
     ).toBe("/state/bin/git");
     expect(resolveGitShimPath({ env: {} })).toBe("/usr/local/bin/git");
+  });
+
+  it("prepends custom git shim directories to PATH", () => {
+    expect(
+      prependGitShimDirToPath({
+        env: {
+          ALPHACLAW_GIT_SHIM_PATH: "/state/bin/git",
+          PATH: "/usr/bin:/bin",
+        },
+        shimPath: "/state/bin/git",
+      }),
+    ).toBe("/state/bin:/usr/bin:/bin");
+
+    expect(
+      prependGitShimDirToPath({
+        env: {
+          ALPHACLAW_GIT_SHIM_PATH: "/state/bin/git",
+          PATH: "/state/bin:/usr/bin:/bin",
+        },
+        shimPath: "/state/bin/git",
+      }),
+    ).toBe("/state/bin:/usr/bin:/bin");
+
+    expect(
+      prependGitShimDirToPath({
+        env: {
+          ALPHACLAW_GIT_SHIM_PATH: "/state/bin/git",
+          PATH: "/usr/bin:/state/bin:/bin",
+        },
+        shimPath: "/state/bin/git",
+      }),
+    ).toBe("/state/bin:/usr/bin:/bin");
+
+    expect(
+      prependGitShimDirToPath({
+        env: {
+          PATH: "/usr/bin:/bin",
+        },
+        shimPath: "/usr/local/bin/git",
+      }),
+    ).toBe("/usr/bin:/bin");
   });
 
   it("resolves a real git path while skipping the installed shim", () => {

--- a/tests/server/git-shim.test.js
+++ b/tests/server/git-shim.test.js
@@ -45,7 +45,7 @@ const createBehaviorHarness = ({ repoRoot }) => {
   const shimContent = shimTemplate
     .replace('REAL_GIT_HINT="@@REAL_GIT@@"', `REAL_GIT_HINT="${realGitPath}"`)
     .replace('OPENCLAW_REPO_ROOT="@@OPENCLAW_REPO_ROOT@@"', `OPENCLAW_REPO_ROOT="${repoRoot}"`)
-    .replace('ASKPASS_PATH="/tmp/alphaclaw-git-askpass.sh"', `ASKPASS_PATH="${askPassPath}"`);
+    .replace('ASKPASS_PATH="@@ASKPASS_PATH@@"', `ASKPASS_PATH="${askPassPath}"`);
   fs.writeFileSync(shimPath, shimContent, { mode: 0o755 });
 
   return { tempRoot, logPath, shimPath };
@@ -56,6 +56,7 @@ describe("server git shim scripts", () => {
     const content = fs.readFileSync(kGitShimPath, "utf8");
     expect(content).toContain('REAL_GIT_HINT="@@REAL_GIT@@"');
     expect(content).toContain('OPENCLAW_REPO_ROOT="@@OPENCLAW_REPO_ROOT@@"');
+    expect(content).toContain('ASKPASS_PATH="@@ASKPASS_PATH@@"');
   });
 
   it("passes auth through for git -C repo push commands", () => {

--- a/tests/server/hourly-git-sync.test.js
+++ b/tests/server/hourly-git-sync.test.js
@@ -1,0 +1,75 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const kScriptPath = path.resolve(__dirname, "../../lib/setup/hourly-git-sync.sh");
+
+describe("hourly-git-sync managed script", () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-hourly-sync-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const installScript = () => {
+    const internalDir = path.join(tmpDir, ".alphaclaw");
+    const target = path.join(internalDir, "hourly-git-sync.sh");
+    fs.mkdirSync(internalDir, { recursive: true });
+    fs.copyFileSync(kScriptPath, target);
+    fs.chmodSync(target, 0o755);
+    return target;
+  };
+
+  it("exits without git-sync when system sync is disabled", () => {
+    const script = installScript();
+    fs.mkdirSync(path.join(tmpDir, "cron"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "cron", "system-sync.json"),
+      JSON.stringify({ enabled: false, schedule: "0 * * * *" }),
+    );
+
+    const output = execFileSync("bash", [script], {
+      cwd: tmpDir,
+      encoding: "utf8",
+      env: { ...process.env, PATH: process.env.PATH },
+    });
+
+    expect(output).toContain("hourly-git-sync: disabled by cron/system-sync.json");
+  });
+
+  it("runs alphaclaw git-sync when system sync is enabled", () => {
+    const script = installScript();
+    const binDir = path.join(tmpDir, "bin");
+    const markerPath = path.join(tmpDir, "alphaclaw-called");
+    fs.mkdirSync(path.join(tmpDir, "cron"), { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "cron", "system-sync.json"),
+      JSON.stringify({ enabled: true, schedule: "0 * * * *" }),
+    );
+    fs.writeFileSync(
+      path.join(binDir, "alphaclaw"),
+      [
+        "#!/usr/bin/env bash",
+        `printf '%s\\n' "$*" > "${markerPath}"`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+
+    execFileSync("bash", [script], {
+      cwd: tmpDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+
+    expect(fs.readFileSync(markerPath, "utf8")).toContain("git-sync -m Auto-commit hourly sync");
+  });
+});

--- a/tests/server/routes-onboarding.test.js
+++ b/tests/server/routes-onboarding.test.js
@@ -470,6 +470,41 @@ describe("server/routes/onboarding", () => {
     });
   });
 
+  it("keeps cron config but skips system cron writes when disabled by runtime env", async () => {
+    const previousValue = process.env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL;
+    process.env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL = "true";
+    try {
+      const deps = createBaseDeps();
+      deps.fs.readFileSync.mockImplementation((p) => {
+        if (p === "/tmp/openclaw/openclaw.json") return "{}";
+        if (p === path.join(kSetupDir, "core-prompts", "TOOLS.md")) return "Setup: {{SETUP_UI_URL}}";
+        if (p === path.join(kSetupDir, "hourly-git-sync.sh")) return "echo Auto-commit hourly sync";
+        return "{}";
+      });
+      const app = createApp(deps);
+      mockGithubVerifyAndCreate();
+
+      const res = await request(app).post("/api/onboard").send(makeValidBody());
+
+      expect(res.status).toBe(200);
+      expect(deps.fs.writeFileSync).toHaveBeenCalledWith(
+        "/tmp/openclaw/cron/system-sync.json",
+        expect.stringContaining('"enabled": true'),
+      );
+      expect(deps.fs.writeFileSync).not.toHaveBeenCalledWith(
+        "/etc/cron.d/openclaw-hourly-sync",
+        expect.anything(),
+        expect.anything(),
+      );
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL;
+      } else {
+        process.env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL = previousValue;
+      }
+    }
+  });
+
   it("rejects onboarding when workspace repo already exists", async () => {
     const deps = createBaseDeps();
     deps.fs.readFileSync.mockImplementation((p) => {

--- a/tests/server/routes-system.test.js
+++ b/tests/server/routes-system.test.js
@@ -607,6 +607,44 @@ describe("server/routes/system", () => {
     expect(res.body.ok).toBe(true);
   });
 
+  it("updates sync cron config without touching system cron when disabled by runtime env", async () => {
+    const previousValue = process.env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL;
+    process.env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL = "true";
+    try {
+      const deps = createSystemDeps();
+      deps.fs.readFileSync.mockReturnValueOnce(
+        JSON.stringify({ enabled: true, schedule: "0 * * * *" }),
+      );
+      const app = createApp(deps);
+
+      const res = await request(app).put("/api/sync-cron").send({
+        enabled: true,
+        schedule: "*/15 * * * *",
+      });
+
+      expect(res.status).toBe(200);
+      expect(deps.fs.writeFileSync).toHaveBeenCalledWith(
+        "/tmp/openclaw/cron/system-sync.json",
+        expect.stringContaining('"schedule": "*/15 * * * *"'),
+      );
+      expect(deps.fs.writeFileSync).not.toHaveBeenCalledWith(
+        "/etc/cron.d/openclaw-hourly-sync",
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(deps.fs.rmSync).not.toHaveBeenCalledWith(
+        "/etc/cron.d/openclaw-hourly-sync",
+        expect.anything(),
+      );
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL;
+      } else {
+        process.env.ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL = previousValue;
+      }
+    }
+  });
+
   it("returns alphaclaw version status on GET /api/alphaclaw/version", async () => {
     const deps = createSystemDeps();
     const app = createApp(deps);


### PR DESCRIPTION
## What

This makes AlphaClaw less picky about where it is allowed to write runtime helper files.

By default, nothing changes. AlphaClaw still uses `/etc/cron.d/openclaw-hourly-sync`, `/usr/local/bin/git`, and the existing askpass helper path. Deployments that run as a non-root user, mount read-only system paths, or manage cron outside the app can now set:

- `ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL=true` to keep AlphaClaw from writing `/etc/cron.d`
- `ALPHACLAW_GIT_SHIM_PATH=/some/writable/bin/git` to move the managed git shim
- `ALPHACLAW_GIT_ASKPASS_PATH=/some/writable/path/git-askpass.sh` to move the askpass helper

The same cron opt-out now applies in startup, onboarding, and the `/api/sync-cron` route. I also fixed the remote config restore helper so sanitized environments still keep `PATH`; without that, git can disappear even though the caller only meant to avoid passing secrets through.

## Why

The current defaults are fine for a simple Docker image. They are brittle once AlphaClaw runs in a stricter container, on NixOS-style hosts, or anywhere `/etc` and `/usr/local/bin` are owned by the image or supervisor instead of the app process.

This keeps the friendly defaults but gives managed deployments a clean escape hatch. No local patching of packaged files, no special entrypoint rewrite, and no surprise write attempt to a host-level cron directory when cron is managed elsewhere.

## Evidence

- `npm test -- tests/server/git-runtime.test.js tests/server/git-shim.test.js tests/server/routes-onboarding.test.js tests/server/routes-system.test.js`
- `npm test`
- `git diff --check`
- `codex review --base origin/main`, with no blocking findings
- GitHub CI on this PR: `test (22)` passed

## Real behavior proof

I tested this against a real AlphaClaw server process, not only mocks.

Runtime setup:

```bash
PORT=13190 \
SETUP_PASSWORD=test-password \
ALPHACLAW_ROOT_DIR=/tmp/alphaclaw-browser-smoke-XXXXXX \
ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL=true \
ALPHACLAW_GIT_SHIM_PATH=/tmp/alphaclaw-browser-smoke-XXXXXX/bin/git \
ALPHACLAW_GIT_ASKPASS_PATH=/tmp/alphaclaw-browser-smoke-XXXXXX/tmp/git-askpass.sh \
node bin/alphaclaw.js start
```

Observed startup output included:

```text
[alphaclaw] System cron setup skipped by ALPHACLAW_SKIP_SYSTEM_CRON_INSTALL
[alphaclaw] git auth shim installed
[alphaclaw] Express listening on :13190
```

Then I opened the setup UI in a browser, logged in with the test password, and reached the setup choice screen. I also verified that the custom git shim and askpass helper existed and were executable, while the smoke run did not create `/etc/cron.d/openclaw-hourly-sync`.

What I did not test: a full production onboarding against real GitHub credentials from this branch. The touched behavior is covered by the onboarding route tests and the live smoke above, but I did not create a real workspace repo during the smoke.

## AI assistance

Built with Codex. I reviewed the diff, ran the tests above, and verified the runtime behavior locally before opening the PR.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5.5-000000)
