### PR TITLE
feat: OpenAI-compat /v1 proxy + managed remote MCP server entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ The built-in watchdog monitors gateway health and recovers from failures automat
 | `PORT`                            | Optional | Server port (default `3000`)                       |
 | `ALPHACLAW_ROOT_DIR`              | Optional | Data directory (default `/data`)                   |
 | `TRUST_PROXY_HOPS`                | Optional | Trust proxy hop count for correct client IP        |
+| `REMOTE_MCP_URL`                  | Optional | Upstream remote MCP server URL. When set together with `REMOTE_MCP_API_TOKEN`, AlphaClaw writes a managed `mcp.servers.<name>` entry to `openclaw.json` on every gateway start. |
+| `REMOTE_MCP_API_TOKEN`            | Optional | Bearer token for the remote MCP server. Persisted in `openclaw.json` as the `${REMOTE_MCP_API_TOKEN}` reference, never as plaintext. |
+| `REMOTE_MCP_NAME`                 | Optional | Key under `mcp.servers.<name>`. Defaults to `remote`. Set it to label the entry (e.g. `sure`, `notion`). |
+| `REMOTE_MCP_PROXY_URL`            | Optional | When set, OpenClaw connects here instead of `REMOTE_MCP_URL`. Intended for a same-host scanning proxy (e.g. `pipelock mcp proxy --listen <REMOTE_MCP_PROXY_URL> --upstream <REMOTE_MCP_URL>`). Implementation is proxy-agnostic. |
+
+## OpenAI-compatible `/v1` proxy
+
+AlphaClaw exposes an OpenAI-compatible API surface on the same public port as the Setup UI:
+
+| Path                            | Method  | Notes                                                              |
+| ------------------------------- | ------- | ------------------------------------------------------------------ |
+| `/v1/chat/completions`          | POST    | Streams when `stream: true`. Use `model: "openclaw/default"` or `openclaw/<agentId>`. |
+| `/v1/responses`                 | POST    | OpenClaw's `/v1/responses` surface (enabled together with chat completions). |
+| `/v1/embeddings`                | POST    | Routes to OpenClaw's embeddings endpoint.                          |
+| `/v1/models`, `/v1/models/<id>` | GET     | Lists OpenClaw agent targets.                                      |
+
+The proxy forwards requests to the loopback OpenClaw gateway. AlphaClaw checks that an `Authorization: Bearer ...` header is present; the actual token is validated by OpenClaw's gateway auth (`OPENCLAW_GATEWAY_TOKEN`). The setup-UI cookie is stripped before forwarding and hop-by-hop response headers are not passed through.
+
+**Security boundary (important).** OpenClaw treats `/v1/chat/completions` as a full operator-access surface. A caller with a valid `OPENCLAW_GATEWAY_TOKEN` can run any tool the configured agent profile allows. Treat this token like an owner credential:
+
+- Use this surface only for trusted server-to-server callers (for example, a self-hosted app that needs OpenClaw as its external assistant).
+- Do not hand the gateway token to end-user clients.
+- If your front door is public (Render, Fly, fly-style PaaS), make sure `SETUP_PASSWORD` is strong and that the gateway token is held by exactly one trusted backend.
+
+When `REMOTE_MCP_URL` + `REMOTE_MCP_API_TOKEN` are set, AlphaClaw also registers an `mcp.servers.<REMOTE_MCP_NAME>` block (default key `remote`) in `openclaw.json` so the agent can call back into that remote MCP server. Set `REMOTE_MCP_PROXY_URL` to route those callbacks through a same-host scanning proxy (for example a Pipelock MCP reverse proxy running in the same container).
 
 ## Security Notes
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The built-in watchdog monitors gateway health and recovers from failures automat
 
 ## OpenAI-compatible `/v1` proxy
 
-AlphaClaw exposes an OpenAI-compatible API surface on the same public port as the Setup UI:
+AlphaClaw can expose an OpenAI-compatible API surface on the same public port as the Setup UI. It is disabled by default. Enable it from the Setup UI under General -> Features -> API; the setting is persisted in `alphaclaw.json` in the OpenClaw repo so workspace sync can commit the change.
 
 | Path                            | Method  | Notes                                                              |
 | ------------------------------- | ------- | ------------------------------------------------------------------ |
@@ -174,7 +174,7 @@ AlphaClaw exposes an OpenAI-compatible API surface on the same public port as th
 | `/v1/embeddings`                | POST    | Routes to OpenClaw's embeddings endpoint.                          |
 | `/v1/models`, `/v1/models/<id>` | GET     | Lists OpenClaw agent targets.                                      |
 
-The proxy forwards requests to the loopback OpenClaw gateway. AlphaClaw requires `Authorization: Bearer <OPENCLAW_GATEWAY_TOKEN>` and rejects requests when the gateway token is missing or does not match before forwarding to OpenClaw. The setup-UI cookie is stripped before forwarding, hop-by-hop response headers are not passed through, and `/v1` JSON request bodies are accepted up to 50 MB.
+When enabled, the proxy forwards requests to the loopback OpenClaw gateway. AlphaClaw requires `Authorization: Bearer <OPENCLAW_GATEWAY_TOKEN>` and rejects requests when the gateway token is missing or does not match before forwarding to OpenClaw. The setup-UI cookie is stripped before forwarding, hop-by-hop response headers are not passed through, and `/v1` JSON request bodies are accepted up to 50 MB. When disabled or missing from `alphaclaw.json`, `/v1` requests return 404.
 
 **Security boundary (important).** OpenClaw treats `/v1/chat/completions` as a full operator-access surface. A caller with a valid `OPENCLAW_GATEWAY_TOKEN` can run any tool the configured agent profile allows. Treat this token like an owner credential:
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ AlphaClaw exposes an OpenAI-compatible API surface on the same public port as th
 | `/v1/embeddings`                | POST    | Routes to OpenClaw's embeddings endpoint.                          |
 | `/v1/models`, `/v1/models/<id>` | GET     | Lists OpenClaw agent targets.                                      |
 
-The proxy forwards requests to the loopback OpenClaw gateway. AlphaClaw checks that an `Authorization: Bearer ...` header is present; the actual token is validated by OpenClaw's gateway auth (`OPENCLAW_GATEWAY_TOKEN`). The setup-UI cookie is stripped before forwarding and hop-by-hop response headers are not passed through.
+The proxy forwards requests to the loopback OpenClaw gateway. AlphaClaw requires `Authorization: Bearer <OPENCLAW_GATEWAY_TOKEN>` and rejects requests when the gateway token is missing or does not match before forwarding to OpenClaw. The setup-UI cookie is stripped before forwarding, hop-by-hop response headers are not passed through, and `/v1` JSON request bodies are accepted up to 50 MB.
 
 **Security boundary (important).** OpenClaw treats `/v1/chat/completions` as a full operator-access surface. A caller with a valid `OPENCLAW_GATEWAY_TOKEN` can run any tool the configured agent profile allows. Treat this token like an owner credential:
 

--- a/lib/public/js/components/features.js
+++ b/lib/public/js/components/features.js
@@ -3,6 +3,7 @@ import htm from "htm";
 import { fetchEnvVars } from "../lib/api.js";
 import { useCachedFetch } from "../hooks/use-cached-fetch.js";
 import { Badge } from "./badge.js";
+import { ToggleSwitch } from "./toggle-switch.js";
 import {
   kFeatureDefs,
   kProviderAuthFields,
@@ -22,12 +23,18 @@ const resolveFeatureStatus = (feature, envVars) => {
   return { active: false, provider: null };
 };
 
-export const Features = ({ onSwitchTab }) => {
+export const Features = ({
+  onSwitchTab,
+  openAiCompatApi = { enabled: false },
+  savingOpenAiCompatApi = false,
+  onToggleOpenAiCompatApi = () => {},
+}) => {
   const { data, loading } = useCachedFetch("/api/env", fetchEnvVars, {
     maxAgeMs: 30000,
   });
   const envVars = Array.isArray(data?.vars) ? data.vars : [];
   const loaded = !loading;
+  const apiEnabled = openAiCompatApi?.enabled === true;
 
   if (!loaded) return null;
 
@@ -35,6 +42,18 @@ export const Features = ({ onSwitchTab }) => {
     <div class="bg-surface border border-border rounded-xl p-4">
       <h2 class="card-label mb-3">Features</h2>
       <div class="space-y-2">
+        <div class="flex flex-col gap-2 py-1.5 sm:flex-row sm:items-center sm:justify-between">
+          <div class="min-w-0">
+            <div class="text-sm text-body">API</div>
+            <div class="text-xs text-fg-muted">OpenAI-compatible /v1 proxy</div>
+          </div>
+          <${ToggleSwitch}
+            checked=${apiEnabled}
+            disabled=${savingOpenAiCompatApi}
+            label=${savingOpenAiCompatApi ? "Saving..." : apiEnabled ? "Enabled" : "Disabled"}
+            onChange=${onToggleOpenAiCompatApi}
+          />
+        </div>
         ${kFeatureDefs.map((feature) => {
           const status = resolveFeatureStatus(feature, envVars);
           return html`

--- a/lib/public/js/components/general/index.js
+++ b/lib/public/js/components/general/index.js
@@ -130,7 +130,12 @@ export const GeneralTab = ({
               `}
         `}
       />
-      <${Features} onSwitchTab=${onSwitchTab} />
+      <${Features}
+        onSwitchTab=${onSwitchTab}
+        openAiCompatApi=${state.openAiCompatApi}
+        savingOpenAiCompatApi=${state.savingOpenAiCompatApi}
+        onToggleOpenAiCompatApi=${actions.handleOpenAiCompatApiToggle}
+      />
       <${Google}
         gatewayStatus=${state.gatewayStatus}
         onRestartRequired=${onRestartRequired}

--- a/lib/public/js/components/general/use-general-tab.js
+++ b/lib/public/js/components/general/use-general-tab.js
@@ -8,6 +8,7 @@ import {
   rejectDevice,
   rejectPairing,
   triggerWatchdogRepair,
+  updateOpenAiCompatApiFeature,
   updateSyncCron,
 } from "../../lib/api.js";
 import { usePolling } from "../../hooks/usePolling.js";
@@ -30,6 +31,8 @@ export const useGeneralTab = ({
   const [syncCronSchedule, setSyncCronSchedule] = useState(kDefaultSyncCronSchedule);
   const [savingSyncCron, setSavingSyncCron] = useState(false);
   const [syncCronChoice, setSyncCronChoice] = useState(kDefaultSyncCronSchedule);
+  const [openAiCompatApiEnabled, setOpenAiCompatApiEnabled] = useState(false);
+  const [savingOpenAiCompatApi, setSavingOpenAiCompatApi] = useState(false);
   const [pairingStatusRefreshing, setPairingStatusRefreshing] = useState(false);
   const [devicePollingEnabled, setDevicePollingEnabled] = useState(false);
   const [cliAutoApproveComplete, setCliAutoApproveComplete] = useState(false);
@@ -42,6 +45,7 @@ export const useGeneralTab = ({
   const channels = status?.channels ?? null;
   const repo = status?.repo || null;
   const syncCron = status?.syncCron || null;
+  const openAiCompatApi = status?.alphaclaw?.features?.openaiCompatApi || null;
   const openclawVersion = status?.openclawVersion || null;
 
   const hasUnpaired = ALL_CHANNELS.some((channel) => {
@@ -134,6 +138,10 @@ export const useGeneralTab = ({
     );
   }, [syncCron?.enabled, syncCron?.schedule]);
 
+  useEffect(() => {
+    setOpenAiCompatApiEnabled(openAiCompatApi?.enabled === true);
+  }, [openAiCompatApi?.enabled]);
+
   useEffect(
     () => () => {
       if (pairingRefreshTimerRef.current) {
@@ -194,6 +202,26 @@ export const useGeneralTab = ({
       enabled: nextEnabled,
       schedule: nextSchedule,
     });
+  };
+
+  const handleOpenAiCompatApiToggle = async (enabled) => {
+    if (savingOpenAiCompatApi) return;
+    const previousEnabled = openAiCompatApiEnabled;
+    setOpenAiCompatApiEnabled(enabled);
+    setSavingOpenAiCompatApi(true);
+    try {
+      const data = await updateOpenAiCompatApiFeature(enabled);
+      if (!data.ok) {
+        throw new Error(data.error || "Could not save API setting");
+      }
+      showToast(`API ${enabled ? "enabled" : "disabled"}`, "success");
+      onRefreshStatuses();
+    } catch (err) {
+      setOpenAiCompatApiEnabled(previousEnabled);
+      showToast(err.message || "Could not save API setting", "error");
+    } finally {
+      setSavingOpenAiCompatApi(false);
+    }
   };
 
   const handleApprove = async (id, channel, accountId = "") => {
@@ -288,12 +316,17 @@ export const useGeneralTab = ({
       gatewayStatus,
       hasUnpaired,
       openclawVersion,
+      openAiCompatApi: {
+        ...(openAiCompatApi || {}),
+        enabled: openAiCompatApiEnabled,
+      },
       pending,
       pairingsPolling: pairingsPoll.isPolling,
       pairingStatusRefreshing,
       repairingWatchdog,
       repo,
       savingSyncCron,
+      savingOpenAiCompatApi,
       syncCron,
       syncCronChoice,
       syncCronEnabled,
@@ -306,6 +339,7 @@ export const useGeneralTab = ({
       handleDeviceApprove,
       handleDeviceReject,
       handleOpenDashboard,
+      handleOpenAiCompatApiToggle,
       handleReject,
       handleSyncCronChoiceChange,
       handleWatchdogRepair,

--- a/lib/public/js/lib/api.js
+++ b/lib/public/js/lib/api.js
@@ -550,6 +550,25 @@ export async function updateSyncCron(payload) {
   return data;
 }
 
+export async function updateOpenAiCompatApiFeature(enabled) {
+  const res = await authFetch("/api/alphaclaw/config/features/openai-compat-api", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enabled }),
+  });
+  const text = await res.text();
+  let data;
+  try {
+    data = text ? JSON.parse(text) : {};
+  } catch {
+    throw new Error(text || "Could not parse AlphaClaw config response");
+  }
+  if (!res.ok) {
+    throw new Error(data.error || text || `HTTP ${res.status}`);
+  }
+  return data;
+}
+
 export async function fetchCronJobs({ sortBy = "nextRunAtMs", sortDir = "asc" } = {}) {
   const params = new URLSearchParams();
   if (sortBy) params.set("sortBy", String(sortBy));

--- a/lib/server.js
+++ b/lib/server.js
@@ -165,6 +165,7 @@ const app = express();
 app.set("trust proxy", kTrustProxyHops);
 app.use(["/webhook", "/hooks"], express.raw({ type: "*/*", limit: "5mb" }));
 app.use("/gmail-pubsub", express.raw({ type: "*/*", limit: "5mb" }));
+app.use("/v1", express.json({ limit: "50mb" }));
 app.use(express.json({ limit: "5mb" }));
 
 const proxy = httpProxy.createProxyServer({

--- a/lib/server.js
+++ b/lib/server.js
@@ -148,6 +148,9 @@ const {
 const {
   ensureOpenclawStartupEnv,
 } = require("./server/openclaw-runtime-env");
+const {
+  isOpenAiCompatApiEnabled,
+} = require("./server/alphaclaw-config");
 
 const { PORT, kTrustProxyHops, SETUP_API_PREFIXES } = constants;
 
@@ -165,7 +168,18 @@ const app = express();
 app.set("trust proxy", kTrustProxyHops);
 app.use(["/webhook", "/hooks"], express.raw({ type: "*/*", limit: "5mb" }));
 app.use("/gmail-pubsub", express.raw({ type: "*/*", limit: "5mb" }));
-app.use("/v1", express.json({ limit: "50mb" }));
+const openAiCompatJsonParser = express.json({ limit: "50mb" });
+const isOpenAiCompatApiCurrentlyEnabled = () =>
+  isOpenAiCompatApiEnabled({
+    fsModule: fs,
+    openclawDir: constants.OPENCLAW_DIR,
+  });
+app.use("/v1", (req, res, next) => {
+  if (!isOpenAiCompatApiCurrentlyEnabled()) {
+    return res.status(404).json({ error: "Not found" });
+  }
+  return openAiCompatJsonParser(req, res, next);
+});
 app.use(express.json({ limit: "5mb" }));
 
 const proxy = httpProxy.createProxyServer({
@@ -315,6 +329,7 @@ const { isAuthorizedRequest, gmailWatchService } = registerServerRoutes({
   resolveGithubRepoUrl,
   resolveModelProvider,
   ensureGatewayProxyConfig,
+  isOpenAiCompatApiEnabled: isOpenAiCompatApiCurrentlyEnabled,
   getBaseUrl,
   startGateway,
   syncChannelConfig,

--- a/lib/server/alphaclaw-config.js
+++ b/lib/server/alphaclaw-config.js
@@ -1,0 +1,99 @@
+const fs = require("fs");
+const path = require("path");
+
+const kConfigFileName = "alphaclaw.json";
+const kDefaultAlphaclawConfig = Object.freeze({
+  features: Object.freeze({
+    openaiCompatApi: Object.freeze({
+      enabled: false,
+    }),
+  }),
+});
+
+const resolveAlphaclawConfigPath = ({ openclawDir } = {}) =>
+  path.join(openclawDir || process.cwd(), kConfigFileName);
+
+const normalizeOpenAiCompatApiFeature = (feature = {}) => ({
+  ...(feature && typeof feature === "object" ? feature : {}),
+  enabled: feature?.enabled === true,
+});
+
+const normalizeAlphaclawConfig = (raw = {}) => {
+  const base = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+  const features =
+    base.features && typeof base.features === "object" && !Array.isArray(base.features)
+      ? base.features
+      : {};
+  return {
+    ...base,
+    features: {
+      ...features,
+      openaiCompatApi: normalizeOpenAiCompatApiFeature(features.openaiCompatApi),
+    },
+  };
+};
+
+const readAlphaclawConfig = ({
+  fsModule = fs,
+  openclawDir,
+  fallback = kDefaultAlphaclawConfig,
+} = {}) => {
+  try {
+    const configPath = resolveAlphaclawConfigPath({ openclawDir });
+    const raw = fsModule.readFileSync(configPath, "utf8");
+    return normalizeAlphaclawConfig(JSON.parse(raw));
+  } catch {
+    return normalizeAlphaclawConfig(fallback);
+  }
+};
+
+const writeAlphaclawConfig = ({
+  fsModule = fs,
+  openclawDir,
+  config,
+  spacing = 2,
+} = {}) => {
+  const configPath = resolveAlphaclawConfigPath({ openclawDir });
+  fsModule.mkdirSync(path.dirname(configPath), { recursive: true });
+  const normalized = normalizeAlphaclawConfig(config);
+  fsModule.writeFileSync(configPath, `${JSON.stringify(normalized, null, spacing)}\n`);
+  return normalized;
+};
+
+const isOpenAiCompatApiEnabled = (options = {}) =>
+  readAlphaclawConfig(options).features.openaiCompatApi.enabled === true;
+
+const updateOpenAiCompatApiFeature = ({
+  fsModule = fs,
+  openclawDir,
+  enabled,
+} = {}) => {
+  const current = readAlphaclawConfig({ fsModule, openclawDir });
+  const next = normalizeAlphaclawConfig({
+    ...current,
+    features: {
+      ...current.features,
+      openaiCompatApi: {
+        ...current.features.openaiCompatApi,
+        enabled: enabled === true,
+      },
+    },
+  });
+  const changed =
+    current.features.openaiCompatApi.enabled !== next.features.openaiCompatApi.enabled;
+  return {
+    config: writeAlphaclawConfig({ fsModule, openclawDir, config: next }),
+    changed,
+  };
+};
+
+module.exports = {
+  kConfigFileName,
+  kDefaultAlphaclawConfig,
+  isOpenAiCompatApiEnabled,
+  normalizeAlphaclawConfig,
+  readAlphaclawConfig,
+  resolveAlphaclawConfigPath,
+  updateOpenAiCompatApiFeature,
+  writeAlphaclawConfig,
+};

--- a/lib/server/gateway.js
+++ b/lib/server/gateway.js
@@ -364,7 +364,29 @@ const ensureGatewayProxyConfig = (origin) => {
     const configPath = `${OPENCLAW_DIR}/openclaw.json`;
     const cfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
     if (!cfg.gateway) cfg.gateway = {};
+    if (!cfg.gateway.http) cfg.gateway.http = {};
+    if (!cfg.gateway.http.endpoints) cfg.gateway.http.endpoints = {};
     let changed = false;
+
+    const chatCompletions = cfg.gateway.http.endpoints.chatCompletions || {};
+    if (chatCompletions.enabled !== true) {
+      cfg.gateway.http.endpoints.chatCompletions = {
+        ...chatCompletions,
+        enabled: true,
+      };
+      console.log("[alphaclaw] Enabled gateway OpenAI chat completions endpoint");
+      changed = true;
+    }
+
+    const responses = cfg.gateway.http.endpoints.responses || {};
+    if (responses.enabled !== true) {
+      cfg.gateway.http.endpoints.responses = {
+        ...responses,
+        enabled: true,
+      };
+      console.log("[alphaclaw] Enabled gateway OpenResponses endpoint");
+      changed = true;
+    }
 
     if (!Array.isArray(cfg.gateway.trustedProxies)) {
       cfg.gateway.trustedProxies = [];
@@ -387,8 +409,141 @@ const ensureGatewayProxyConfig = (origin) => {
       }
     }
 
+    // Managed remote MCP server entry. Env-driven so any AlphaClaw operator
+    // (Render, Fly, fly.io-style PaaS, plain VPS) can wire OpenClaw to a
+    // remote MCP server without hand-editing /data/.openclaw/openclaw.json.
+    //
+    //   REMOTE_MCP_URL         upstream MCP endpoint (streamable-http).
+    //   REMOTE_MCP_API_TOKEN   Bearer token the remote MCP expects. Persisted
+    //                          as the ${REMOTE_MCP_API_TOKEN} reference, not
+    //                          raw, so the openclaw.json that gets
+    //                          git-committed never holds the plaintext.
+    //   REMOTE_MCP_NAME        Key under mcp.servers.<name>. Default "remote".
+    //   REMOTE_MCP_PROXY_URL   When set, OpenClaw connects here instead of
+    //                          REMOTE_MCP_URL. Intended for a same-host
+    //                          scanning proxy (e.g. `pipelock mcp proxy
+    //                          --listen ... --upstream <REMOTE_MCP_URL>`),
+    //                          but the implementation is proxy-agnostic.
+    //                          The supervisor that starts that proxy is
+    //                          responsible for unsetting this env var when
+    //                          the proxy is not running, so AlphaClaw never
+    //                          points OpenClaw at a dead listener.
+    const remoteMcpUrl = String(process.env.REMOTE_MCP_URL || "").trim();
+    const remoteMcpToken = String(
+      process.env.REMOTE_MCP_API_TOKEN || "",
+    ).trim();
+    const remoteMcpProxyUrl = String(
+      process.env.REMOTE_MCP_PROXY_URL || "",
+    ).trim();
+    const remoteMcpNameRaw = String(process.env.REMOTE_MCP_NAME || "").trim();
+    // Constrain the managed key. OpenClaw sanitizes names later for tool
+    // prefixes, but the config-key itself must be safe to use as an object
+    // key and to read back in `openclaw mcp` CLI commands. Reject names
+    // with prototype-pollution shapes, spaces, or path-like names; fall
+    // back to "remote" with a warning so a typo doesn't silently misroute.
+    const kRemoteMcpNamePattern = /^[A-Za-z0-9_-]{1,64}$/;
+    const kReservedRemoteMcpNames = new Set([
+      "__proto__",
+      "constructor",
+      "prototype",
+    ]);
+    let remoteMcpName = "remote";
+    if (remoteMcpNameRaw) {
+      if (
+        kRemoteMcpNamePattern.test(remoteMcpNameRaw) &&
+        !kReservedRemoteMcpNames.has(remoteMcpNameRaw)
+      ) {
+        remoteMcpName = remoteMcpNameRaw;
+      } else {
+        console.warn(
+          `[alphaclaw] REMOTE_MCP_NAME=${JSON.stringify(remoteMcpNameRaw)} is invalid (must match ${kRemoteMcpNamePattern} and not be a reserved key); falling back to "remote"`,
+        );
+      }
+    }
+    const placeholderAuth = "Bearer ${REMOTE_MCP_API_TOKEN}";
+    const desiredAuth = `Bearer ${remoteMcpToken}`;
+    const kManagedMarker = "_alphaclawManaged";
+    let mcpChanged = false;
+
+    // Clean up any managed entries left over from a prior REMOTE_MCP_NAME
+    // value. Without this, renaming REMOTE_MCP_NAME from "sure" to "notion"
+    // would leave the old "sure" entry behind, duplicating MCP tools or
+    // routing callbacks to a stale target. The marker scopes the cleanup so
+    // user-managed entries (no marker) are never touched.
+    if (cfg.mcp?.servers) {
+      for (const [key, entry] of Object.entries(cfg.mcp.servers)) {
+        if (
+          entry &&
+          typeof entry === "object" &&
+          entry[kManagedMarker] === true &&
+          key !== remoteMcpName
+        ) {
+          delete cfg.mcp.servers[key];
+          mcpChanged = true;
+          console.log(
+            `[alphaclaw] Removed stale managed MCP server "${key}" (REMOTE_MCP_NAME is now "${remoteMcpName}")`,
+          );
+        }
+      }
+    }
+
+    if (remoteMcpUrl && remoteMcpToken) {
+      if (!cfg.mcp) cfg.mcp = {};
+      if (!cfg.mcp.servers) cfg.mcp.servers = {};
+      const existing = cfg.mcp.servers[remoteMcpName] || {};
+      const effectiveUrl = remoteMcpProxyUrl || remoteMcpUrl;
+      const existingHeaders = existing.headers || {};
+      const existingAuth = existingHeaders.Authorization;
+      // Only the placeholder counts as "already sanitized". A plaintext
+      // Bearer (even one that matches the current desiredAuth) must trigger a
+      // rewrite so the substitution loop below scrubs it back to the
+      // ${REMOTE_MCP_API_TOKEN} reference.
+      const authIsPlaceholder = existingAuth === placeholderAuth;
+      const hasManagedMarker = existing[kManagedMarker] === true;
+      if (
+        existing.url !== effectiveUrl ||
+        existing.transport !== "streamable-http" ||
+        !authIsPlaceholder ||
+        !hasManagedMarker
+      ) {
+        cfg.mcp.servers[remoteMcpName] = {
+          ...existing,
+          url: effectiveUrl,
+          transport: "streamable-http",
+          headers: {
+            ...existingHeaders,
+            Authorization: desiredAuth,
+          },
+          [kManagedMarker]: true,
+        };
+        mcpChanged = true;
+        console.log(
+          `[alphaclaw] Configured remote MCP server "${remoteMcpName}" (url=${effectiveUrl}, via_proxy=${Boolean(remoteMcpProxyUrl)})`,
+        );
+      }
+    } else if (cfg.mcp?.servers?.[remoteMcpName]) {
+      delete cfg.mcp.servers[remoteMcpName];
+      mcpChanged = true;
+      console.log(
+        `[alphaclaw] Removed remote MCP server "${remoteMcpName}" entry (REMOTE_MCP_URL / REMOTE_MCP_API_TOKEN unset)`,
+      );
+    }
+    if (cfg.mcp?.servers && Object.keys(cfg.mcp.servers).length === 0) {
+      delete cfg.mcp.servers;
+    }
+    if (cfg.mcp && Object.keys(cfg.mcp).length === 0) {
+      delete cfg.mcp;
+    }
+    if (mcpChanged) changed = true;
+
     if (changed) {
-      fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2));
+      let content = JSON.stringify(cfg, null, 2);
+      if (remoteMcpToken) {
+        const jsonValue = JSON.stringify(desiredAuth);
+        const jsonPlaceholder = JSON.stringify(placeholderAuth);
+        content = content.split(jsonValue).join(jsonPlaceholder);
+      }
+      fs.writeFileSync(configPath, content);
     }
     return changed;
   } catch (e) {

--- a/lib/server/gateway.js
+++ b/lib/server/gateway.js
@@ -12,6 +12,7 @@ const {
   kRootDir,
 } = require("./constants");
 const { withOpenclawStartupEnv } = require("./openclaw-runtime-env");
+const { isOpenAiCompatApiEnabled } = require("./alphaclaw-config");
 
 let gatewayChild = null;
 let gatewayExitHandler = null;
@@ -364,28 +365,31 @@ const ensureGatewayProxyConfig = (origin) => {
     const configPath = `${OPENCLAW_DIR}/openclaw.json`;
     const cfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
     if (!cfg.gateway) cfg.gateway = {};
-    if (!cfg.gateway.http) cfg.gateway.http = {};
-    if (!cfg.gateway.http.endpoints) cfg.gateway.http.endpoints = {};
     let changed = false;
 
-    const chatCompletions = cfg.gateway.http.endpoints.chatCompletions || {};
-    if (chatCompletions.enabled !== true) {
-      cfg.gateway.http.endpoints.chatCompletions = {
-        ...chatCompletions,
-        enabled: true,
-      };
-      console.log("[alphaclaw] Enabled gateway OpenAI chat completions endpoint");
-      changed = true;
-    }
+    if (isOpenAiCompatApiEnabled({ fsModule: fs, openclawDir: OPENCLAW_DIR })) {
+      if (!cfg.gateway.http) cfg.gateway.http = {};
+      if (!cfg.gateway.http.endpoints) cfg.gateway.http.endpoints = {};
 
-    const responses = cfg.gateway.http.endpoints.responses || {};
-    if (responses.enabled !== true) {
-      cfg.gateway.http.endpoints.responses = {
-        ...responses,
-        enabled: true,
-      };
-      console.log("[alphaclaw] Enabled gateway OpenResponses endpoint");
-      changed = true;
+      const chatCompletions = cfg.gateway.http.endpoints.chatCompletions || {};
+      if (chatCompletions.enabled !== true) {
+        cfg.gateway.http.endpoints.chatCompletions = {
+          ...chatCompletions,
+          enabled: true,
+        };
+        console.log("[alphaclaw] Enabled gateway OpenAI chat completions endpoint");
+        changed = true;
+      }
+
+      const responses = cfg.gateway.http.endpoints.responses || {};
+      if (responses.enabled !== true) {
+        cfg.gateway.http.endpoints.responses = {
+          ...responses,
+          enabled: true,
+        };
+        console.log("[alphaclaw] Enabled gateway OpenResponses endpoint");
+        changed = true;
+      }
     }
 
     if (!Array.isArray(cfg.gateway.trustedProxies)) {

--- a/lib/server/gateway.js
+++ b/lib/server/gateway.js
@@ -521,7 +521,10 @@ const ensureGatewayProxyConfig = (origin) => {
           `[alphaclaw] Configured remote MCP server "${remoteMcpName}" (url=${effectiveUrl}, via_proxy=${Boolean(remoteMcpProxyUrl)})`,
         );
       }
-    } else if (cfg.mcp?.servers?.[remoteMcpName]) {
+    } else if (
+      cfg.mcp?.servers?.[remoteMcpName] &&
+      cfg.mcp.servers[remoteMcpName][kManagedMarker] === true
+    ) {
       delete cfg.mcp.servers[remoteMcpName];
       mcpChanged = true;
       console.log(

--- a/lib/server/init/register-server-routes.js
+++ b/lib/server/init/register-server-routes.js
@@ -256,6 +256,8 @@ const registerServerRoutes = ({
     app,
     proxy,
     getGatewayUrl,
+    getGatewayToken: () =>
+      process.env.OPENCLAW_GATEWAY_TOKEN || constants.GATEWAY_TOKEN || "",
     SETUP_API_PREFIXES,
     requireAuth,
     oauthCallbackMiddleware,

--- a/lib/server/init/register-server-routes.js
+++ b/lib/server/init/register-server-routes.js
@@ -41,6 +41,7 @@ const registerServerRoutes = ({
   resolveGithubRepoUrl,
   resolveModelProvider,
   ensureGatewayProxyConfig,
+  isOpenAiCompatApiEnabled,
   getBaseUrl,
   startGateway,
   syncChannelConfig,
@@ -147,6 +148,8 @@ const registerServerRoutes = ({
     authProfiles,
     watchdog,
     doctorService,
+    ensureGatewayProxyConfig,
+    getBaseUrl,
   });
   registerBrowseRoutes({
     app,
@@ -258,6 +261,7 @@ const registerServerRoutes = ({
     getGatewayUrl,
     getGatewayToken: () =>
       process.env.OPENCLAW_GATEWAY_TOKEN || constants.GATEWAY_TOKEN || "",
+    isOpenAiCompatApiEnabled,
     SETUP_API_PREFIXES,
     requireAuth,
     oauthCallbackMiddleware,

--- a/lib/server/onboarding/openclaw.js
+++ b/lib/server/onboarding/openclaw.js
@@ -138,11 +138,22 @@ const ensureManagedConfigShell = (cfg) => {
   ensurePluginsShell(cfg);
   if (!cfg.commands) cfg.commands = {};
   if (!cfg.tools) cfg.tools = {};
+  if (!cfg.gateway) cfg.gateway = {};
+  if (!cfg.gateway.http) cfg.gateway.http = {};
+  if (!cfg.gateway.http.endpoints) cfg.gateway.http.endpoints = {};
   if (!cfg.hooks) cfg.hooks = {};
   if (!cfg.hooks.internal) cfg.hooks.internal = {};
   if (!cfg.hooks.internal.entries) cfg.hooks.internal.entries = {};
   cfg.commands.restart = true;
   cfg.tools.profile = kDefaultToolsProfile;
+  cfg.gateway.http.endpoints.chatCompletions = {
+    ...(cfg.gateway.http.endpoints.chatCompletions || {}),
+    enabled: true,
+  };
+  cfg.gateway.http.endpoints.responses = {
+    ...(cfg.gateway.http.endpoints.responses || {}),
+    enabled: true,
+  };
   cfg.hooks.internal.enabled = true;
   cfg.hooks.internal.entries["bootstrap-extra-files"] = {
     ...(cfg.hooks.internal.entries["bootstrap-extra-files"] || {}),

--- a/lib/server/onboarding/openclaw.js
+++ b/lib/server/onboarding/openclaw.js
@@ -4,6 +4,7 @@ const {
   ensurePluginAllowed,
   ensureUsageTrackerPluginEntry,
 } = require("../usage-tracker-config");
+const { isOpenAiCompatApiEnabled } = require("../alphaclaw-config");
 
 const kDefaultToolsProfile = "full";
 const kBootstrapExtraFiles = [
@@ -133,27 +134,29 @@ const buildOnboardArgs = ({
   return onboardArgs;
 };
 
-const ensureManagedConfigShell = (cfg) => {
+const ensureManagedConfigShell = (cfg, { openAiCompatApiEnabled = false } = {}) => {
   if (!cfg.channels) cfg.channels = {};
   ensurePluginsShell(cfg);
   if (!cfg.commands) cfg.commands = {};
   if (!cfg.tools) cfg.tools = {};
   if (!cfg.gateway) cfg.gateway = {};
-  if (!cfg.gateway.http) cfg.gateway.http = {};
-  if (!cfg.gateway.http.endpoints) cfg.gateway.http.endpoints = {};
   if (!cfg.hooks) cfg.hooks = {};
   if (!cfg.hooks.internal) cfg.hooks.internal = {};
   if (!cfg.hooks.internal.entries) cfg.hooks.internal.entries = {};
   cfg.commands.restart = true;
   cfg.tools.profile = kDefaultToolsProfile;
-  cfg.gateway.http.endpoints.chatCompletions = {
-    ...(cfg.gateway.http.endpoints.chatCompletions || {}),
-    enabled: true,
-  };
-  cfg.gateway.http.endpoints.responses = {
-    ...(cfg.gateway.http.endpoints.responses || {}),
-    enabled: true,
-  };
+  if (openAiCompatApiEnabled) {
+    if (!cfg.gateway.http) cfg.gateway.http = {};
+    if (!cfg.gateway.http.endpoints) cfg.gateway.http.endpoints = {};
+    cfg.gateway.http.endpoints.chatCompletions = {
+      ...(cfg.gateway.http.endpoints.chatCompletions || {}),
+      enabled: true,
+    };
+    cfg.gateway.http.endpoints.responses = {
+      ...(cfg.gateway.http.endpoints.responses || {}),
+      enabled: true,
+    };
+  }
   cfg.hooks.internal.enabled = true;
   cfg.hooks.internal.entries["bootstrap-extra-files"] = {
     ...(cfg.hooks.internal.entries["bootstrap-extra-files"] || {}),
@@ -235,7 +238,12 @@ const writeSanitizedOpenclawConfig = ({
 }) => {
   const configPath = `${openclawDir}/openclaw.json`;
   const cfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
-  ensureManagedConfigShell(cfg);
+  ensureManagedConfigShell(cfg, {
+    openAiCompatApiEnabled: isOpenAiCompatApiEnabled({
+      fsModule: fs,
+      openclawDir,
+    }),
+  });
   applyFreshOnboardingChannels({
     cfg,
     varMap,
@@ -267,7 +275,12 @@ const writeManagedImportOpenclawConfig = ({
 }) => {
   const configPath = `${openclawDir}/openclaw.json`;
   const cfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
-  ensureManagedConfigShell(cfg);
+  ensureManagedConfigShell(cfg, {
+    openAiCompatApiEnabled: isOpenAiCompatApiEnabled({
+      fsModule: fs,
+      openclawDir,
+    }),
+  });
 
   ensureUsageTrackerPluginEntry(cfg);
 

--- a/lib/server/routes/proxy.js
+++ b/lib/server/routes/proxy.js
@@ -1,3 +1,106 @@
+const http = require("http");
+const https = require("https");
+const { URL } = require("url");
+
+const kOpenAiCompatProxyPathPattern =
+  /^\/v1\/(?:chat\/completions|responses|embeddings|models(?:\/[^/?#]+)?)$/;
+const kHopByHopResponseHeaders = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+]);
+// Strip these even though they're not hop-by-hop: an OpenAI-compatible client
+// (e.g. Sure's external assistant) has no business receiving cookies from the
+// gateway, and a stray Set-Cookie crossing the AlphaClaw boundary would be a
+// real leak.
+const kAlwaysStrippedResponseHeaders = new Set(["set-cookie"]);
+
+const extractBodyBuffer = (req) => {
+  if (Buffer.isBuffer(req.body)) return req.body;
+  if (typeof req.body === "string") return Buffer.from(req.body, "utf8");
+  if (req.body && typeof req.body === "object") {
+    return Buffer.from(JSON.stringify(req.body), "utf8");
+  }
+  return Buffer.alloc(0);
+};
+
+const createGatewayProxyHeaders = ({ reqHeaders, bodyBuffer }) => {
+  const headers = { ...(reqHeaders || {}) };
+  delete headers.host;
+  delete headers.connection;
+  delete headers["content-length"];
+  delete headers["transfer-encoding"];
+  // Express has already parsed and (if gzip/deflate) inflated the body, so
+  // the bytes we reserialize are plain JSON. Forwarding the original
+  // Content-Encoding would tell the gateway to gunzip plain text and fail.
+  delete headers["content-encoding"];
+  delete headers.cookie;
+  if (bodyBuffer.length > 0) {
+    headers["content-length"] = String(bodyBuffer.length);
+    if (!headers["content-type"]) headers["content-type"] = "application/json";
+  }
+  return headers;
+};
+
+const proxyOpenAiCompatRequest = ({ req, res, getGatewayUrl }) => {
+  const authorization = String(req.headers.authorization || "").trim();
+  if (!authorization.toLowerCase().startsWith("bearer ")) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  let gateway;
+  try {
+    gateway = new URL(getGatewayUrl());
+  } catch {
+    return res.status(502).json({ error: "Gateway unavailable" });
+  }
+
+  const bodyBuffer = extractBodyBuffer(req);
+  const protocolClient = gateway.protocol === "https:" ? https : http;
+  const requestOptions = {
+    protocol: gateway.protocol,
+    hostname: gateway.hostname,
+    port: gateway.port,
+    method: req.method,
+    path: req.originalUrl || req.url,
+    headers: createGatewayProxyHeaders({
+      reqHeaders: req.headers,
+      bodyBuffer,
+    }),
+  };
+
+  const proxyReq = protocolClient.request(requestOptions, (proxyRes) => {
+    res.statusCode = proxyRes.statusCode || 502;
+    for (const [key, value] of Object.entries(proxyRes.headers || {})) {
+      if (value == null) continue;
+      const lowerKey = key.toLowerCase();
+      if (kHopByHopResponseHeaders.has(lowerKey)) continue;
+      if (kAlwaysStrippedResponseHeaders.has(lowerKey)) continue;
+      res.setHeader(key, value);
+    }
+    proxyRes.pipe(res);
+  });
+
+  proxyReq.on("error", () => {
+    if (!res.headersSent) {
+      res.status(502).json({ error: "Gateway unavailable" });
+    } else {
+      res.end();
+    }
+  });
+
+  if (bodyBuffer.length > 0) {
+    proxyReq.write(bodyBuffer);
+  }
+  proxyReq.end();
+};
+
 const registerProxyRoutes = ({
   app,
   proxy,
@@ -29,10 +132,23 @@ const registerProxyRoutes = ({
   app.all(kHooksPathPattern, webhookMiddleware);
   app.all(kWebhookPathPattern, webhookMiddleware);
 
+  app.all(kOpenAiCompatProxyPathPattern, (req, res) =>
+    proxyOpenAiCompatRequest({ req, res, getGatewayUrl }),
+  );
+
   app.all(kApiPathPattern, (req, res, next) => {
     if (SETUP_API_PREFIXES.some((p) => req.path.startsWith(p))) return next();
     proxy.web(req, res, { target: getGatewayUrl() });
   });
 };
 
-module.exports = { registerProxyRoutes };
+module.exports = {
+  kOpenAiCompatProxyPathPattern,
+  registerProxyRoutes,
+  // Exported for tests.
+  __testing: {
+    createGatewayProxyHeaders,
+    kHopByHopResponseHeaders,
+    kAlwaysStrippedResponseHeaders,
+  },
+};

--- a/lib/server/routes/proxy.js
+++ b/lib/server/routes/proxy.js
@@ -134,6 +134,7 @@ const registerProxyRoutes = ({
   proxy,
   getGatewayUrl,
   getGatewayToken,
+  isOpenAiCompatApiEnabled = () => true,
   SETUP_API_PREFIXES,
   requireAuth,
   oauthCallbackMiddleware,
@@ -161,9 +162,12 @@ const registerProxyRoutes = ({
   app.all(kHooksPathPattern, webhookMiddleware);
   app.all(kWebhookPathPattern, webhookMiddleware);
 
-  app.all(kOpenAiCompatProxyPathPattern, (req, res) =>
-    proxyOpenAiCompatRequest({ req, res, getGatewayUrl, getGatewayToken }),
-  );
+  app.all(kOpenAiCompatProxyPathPattern, (req, res) => {
+    if (!isOpenAiCompatApiEnabled()) {
+      return res.status(404).json({ error: "Not found" });
+    }
+    return proxyOpenAiCompatRequest({ req, res, getGatewayUrl, getGatewayToken });
+  });
 
   app.all(kApiPathPattern, (req, res, next) => {
     if (SETUP_API_PREFIXES.some((p) => req.path.startsWith(p))) return next();

--- a/lib/server/routes/proxy.js
+++ b/lib/server/routes/proxy.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const http = require("http");
 const https = require("https");
 const { URL } = require("url");
@@ -20,6 +21,20 @@ const kHopByHopResponseHeaders = new Set([
 // gateway, and a stray Set-Cookie crossing the AlphaClaw boundary would be a
 // real leak.
 const kAlwaysStrippedResponseHeaders = new Set(["set-cookie"]);
+
+const extractBearerToken = (authorization) => {
+  const match = String(authorization || "").match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : "";
+};
+
+const timingSafeStringEqual = (left, right) => {
+  const leftBuffer = Buffer.from(String(left || ""), "utf8");
+  const rightBuffer = Buffer.from(String(right || ""), "utf8");
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    crypto.timingSafeEqual(leftBuffer, rightBuffer)
+  );
+};
 
 const extractBodyBuffer = (req) => {
   if (Buffer.isBuffer(req.body)) return req.body;
@@ -48,9 +63,19 @@ const createGatewayProxyHeaders = ({ reqHeaders, bodyBuffer }) => {
   return headers;
 };
 
-const proxyOpenAiCompatRequest = ({ req, res, getGatewayUrl }) => {
-  const authorization = String(req.headers.authorization || "").trim();
-  if (!authorization.toLowerCase().startsWith("bearer ")) {
+const proxyOpenAiCompatRequest = ({
+  req,
+  res,
+  getGatewayUrl,
+  getGatewayToken,
+}) => {
+  const bearerToken = extractBearerToken(req.headers.authorization);
+  const expectedGatewayToken = String(getGatewayToken?.() || "").trim();
+  if (
+    !bearerToken ||
+    !expectedGatewayToken ||
+    !timingSafeStringEqual(bearerToken, expectedGatewayToken)
+  ) {
     return res.status(401).json({ error: "Unauthorized" });
   }
 
@@ -63,16 +88,19 @@ const proxyOpenAiCompatRequest = ({ req, res, getGatewayUrl }) => {
 
   const bodyBuffer = extractBodyBuffer(req);
   const protocolClient = gateway.protocol === "https:" ? https : http;
+  const headers = createGatewayProxyHeaders({
+    reqHeaders: req.headers,
+    bodyBuffer,
+  });
+  headers.authorization = `Bearer ${bearerToken}`;
+
   const requestOptions = {
     protocol: gateway.protocol,
     hostname: gateway.hostname,
     port: gateway.port,
     method: req.method,
     path: req.originalUrl || req.url,
-    headers: createGatewayProxyHeaders({
-      reqHeaders: req.headers,
-      bodyBuffer,
-    }),
+    headers,
   };
 
   const proxyReq = protocolClient.request(requestOptions, (proxyRes) => {
@@ -105,6 +133,7 @@ const registerProxyRoutes = ({
   app,
   proxy,
   getGatewayUrl,
+  getGatewayToken,
   SETUP_API_PREFIXES,
   requireAuth,
   oauthCallbackMiddleware,
@@ -133,7 +162,7 @@ const registerProxyRoutes = ({
   app.all(kWebhookPathPattern, webhookMiddleware);
 
   app.all(kOpenAiCompatProxyPathPattern, (req, res) =>
-    proxyOpenAiCompatRequest({ req, res, getGatewayUrl }),
+    proxyOpenAiCompatRequest({ req, res, getGatewayUrl, getGatewayToken }),
   );
 
   app.all(kApiPathPattern, (req, res, next) => {
@@ -148,6 +177,7 @@ module.exports = {
   // Exported for tests.
   __testing: {
     createGatewayProxyHeaders,
+    extractBearerToken,
     kHopByHopResponseHeaders,
     kAlwaysStrippedResponseHeaders,
   },

--- a/lib/server/routes/system.js
+++ b/lib/server/routes/system.js
@@ -1,5 +1,9 @@
 const { buildManagedPaths } = require("../internal-files-migration");
 const { readOpenclawConfig } = require("../openclaw-config");
+const {
+  readAlphaclawConfig,
+  updateOpenAiCompatApiFeature,
+} = require("../alphaclaw-config");
 const https = require("https");
 
 const registerSystemRoutes = ({
@@ -26,6 +30,8 @@ const registerSystemRoutes = ({
   authProfiles,
   watchdog,
   doctorService,
+  ensureGatewayProxyConfig,
+  getBaseUrl,
 }) => {
   let envRestartPending = false;
   let openclawSecretRuntimePromise = null;
@@ -590,6 +596,10 @@ const registerSystemRoutes = ({
       repo,
       openclawVersion,
       alphaclawVersion,
+      alphaclaw: readAlphaclawConfig({
+        fsModule: fs,
+        openclawDir: OPENCLAW_DIR,
+      }),
       syncCron: getSystemCronStatus(),
     };
   };
@@ -666,6 +676,57 @@ const registerSystemRoutes = ({
     };
     const status = applySystemCronConfig(nextConfig);
     res.json({ ok: true, syncCron: status });
+  });
+
+  app.get("/api/alphaclaw/config", (req, res) => {
+    res.json({
+      ok: true,
+      config: readAlphaclawConfig({
+        fsModule: fs,
+        openclawDir: OPENCLAW_DIR,
+      }),
+    });
+  });
+
+  app.put("/api/alphaclaw/config/features/openai-compat-api", async (req, res) => {
+    const { enabled } = req.body || {};
+    if (typeof enabled !== "boolean") {
+      return res
+        .status(400)
+        .json({ ok: false, error: "enabled must be a boolean" });
+    }
+
+    try {
+      const { config, changed } = updateOpenAiCompatApiFeature({
+        fsModule: fs,
+        openclawDir: OPENCLAW_DIR,
+        enabled,
+      });
+      let gatewayConfigChanged = false;
+      if (enabled && isOnboarded() && typeof ensureGatewayProxyConfig === "function") {
+        gatewayConfigChanged = ensureGatewayProxyConfig(getBaseUrl?.(req));
+        if (gatewayConfigChanged && restartRequiredState?.markRequired) {
+          restartRequiredState.markRequired("openai_compat_api_enabled");
+        }
+      }
+      const snapshot =
+        typeof restartRequiredState?.getSnapshot === "function"
+          ? await restartRequiredState.getSnapshot()
+          : null;
+      res.json({
+        ok: true,
+        changed,
+        gatewayConfigChanged,
+        config,
+        restartRequired:
+          Boolean(snapshot?.restartRequired) || (envRestartPending && isOnboarded()),
+      });
+    } catch (err) {
+      res.status(500).json({
+        ok: false,
+        error: err.message || "Could not update AlphaClaw config",
+      });
+    }
   });
 
   app.get("/api/alphaclaw/version", async (req, res) => {

--- a/tests/server/alphaclaw-config.test.js
+++ b/tests/server/alphaclaw-config.test.js
@@ -1,0 +1,75 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  isOpenAiCompatApiEnabled,
+  readAlphaclawConfig,
+  updateOpenAiCompatApiFeature,
+} = require("../../lib/server/alphaclaw-config");
+
+const createTempOpenclawDir = () =>
+  fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-config-test-"));
+
+describe("server/alphaclaw-config", () => {
+  it("defaults the OpenAI-compatible API feature to disabled when config is missing", () => {
+    const openclawDir = createTempOpenclawDir();
+
+    expect(isOpenAiCompatApiEnabled({ openclawDir })).toBe(false);
+    expect(readAlphaclawConfig({ openclawDir }).features.openaiCompatApi).toEqual({
+      enabled: false,
+    });
+  });
+
+  it("defaults to disabled when alphaclaw.json is malformed", () => {
+    const openclawDir = createTempOpenclawDir();
+    fs.writeFileSync(path.join(openclawDir, "alphaclaw.json"), "{broken", "utf8");
+
+    expect(isOpenAiCompatApiEnabled({ openclawDir })).toBe(false);
+  });
+
+  it("persists the explicit API feature toggle in alphaclaw.json", () => {
+    const openclawDir = createTempOpenclawDir();
+
+    const result = updateOpenAiCompatApiFeature({ openclawDir, enabled: true });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.features.openaiCompatApi.enabled).toBe(true);
+    expect(isOpenAiCompatApiEnabled({ openclawDir })).toBe(true);
+    expect(
+      JSON.parse(fs.readFileSync(path.join(openclawDir, "alphaclaw.json"), "utf8")),
+    ).toEqual({
+      features: {
+        openaiCompatApi: {
+          enabled: true,
+        },
+      },
+    });
+  });
+
+  it("preserves unknown keys while updating the feature flag", () => {
+    const openclawDir = createTempOpenclawDir();
+    const configPath = path.join(openclawDir, "alphaclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        custom: { keep: true },
+        features: {
+          futureFeature: { enabled: true },
+          openaiCompatApi: { enabled: true, note: "keep" },
+        },
+      }),
+      "utf8",
+    );
+
+    updateOpenAiCompatApiFeature({ openclawDir, enabled: false });
+
+    expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).toEqual({
+      custom: { keep: true },
+      features: {
+        futureFeature: { enabled: true },
+        openaiCompatApi: { enabled: false, note: "keep" },
+      },
+    });
+  });
+});

--- a/tests/server/gateway.test.js
+++ b/tests/server/gateway.test.js
@@ -383,6 +383,8 @@ describe("server/gateway restart behavior", () => {
     expect(currentConfig.gateway.controlUi.allowedOrigins).toEqual([
       "https://setup.example.com",
     ]);
+    expect(currentConfig.gateway.http.endpoints.chatCompletions.enabled).toBe(true);
+    expect(currentConfig.gateway.http.endpoints.responses.enabled).toBe(true);
   });
 
   it("preserves existing allowed origins and remains idempotent", () => {
@@ -418,7 +420,418 @@ describe("server/gateway restart behavior", () => {
       "https://existing.example.com",
       "https://setup.example.com",
     ]);
+    expect(currentConfig.gateway.http.endpoints.chatCompletions.enabled).toBe(true);
+    expect(currentConfig.gateway.http.endpoints.responses.enabled).toBe(true);
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves existing gateway endpoint options while enabling public API endpoints", () => {
+    let currentConfig = {
+      gateway: {
+        trustedProxies: ["127.0.0.1"],
+        http: {
+          endpoints: {
+            chatCompletions: {
+              maxBodyBytes: 12345,
+            },
+            responses: {
+              maxBodyBytes: 67890,
+            },
+          },
+        },
+        controlUi: {
+          allowedOrigins: ["https://setup.example.com"],
+        },
+      },
+    };
+    fs.existsSync = vi.fn((targetPath) => targetPath === kOnboardingMarkerPath);
+    fs.writeFileSync = vi.fn((targetPath, contents) => {
+      if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
+        currentConfig = JSON.parse(contents);
+      }
+    });
+    delete require.cache[modulePath];
+    const gateway = require(modulePath);
+    fs.readFileSync = vi.fn((targetPath) => {
+      if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
+        return JSON.stringify(currentConfig);
+      }
+      return "{}";
+    });
+
+    const changed = gateway.ensureGatewayProxyConfig("https://setup.example.com");
+
+    expect(changed).toBe(true);
+    expect(currentConfig.gateway.http.endpoints.chatCompletions).toEqual({
+      enabled: true,
+      maxBodyBytes: 12345,
+    });
+    expect(currentConfig.gateway.http.endpoints.responses).toEqual({
+      enabled: true,
+      maxBodyBytes: 67890,
+    });
+  });
+
+  describe("Managed remote MCP server config", () => {
+    const kRemoteMcpEnvKeys = [
+      "REMOTE_MCP_URL",
+      "REMOTE_MCP_API_TOKEN",
+      "REMOTE_MCP_PROXY_URL",
+      "REMOTE_MCP_NAME",
+    ];
+
+    const withEnv = (vars, fn) => {
+      const prev = {};
+      for (const key of kRemoteMcpEnvKeys) prev[key] = process.env[key];
+      try {
+        for (const [key, value] of Object.entries(vars)) {
+          if (value === undefined) delete process.env[key];
+          else process.env[key] = value;
+        }
+        return fn();
+      } finally {
+        for (const key of kRemoteMcpEnvKeys) {
+          if (prev[key] === undefined) delete process.env[key];
+          else process.env[key] = prev[key];
+        }
+      }
+    };
+
+    const setupConfigIo = (initial) => {
+      let currentConfig = initial;
+      let lastRawContents = null;
+      fs.existsSync = vi.fn((targetPath) => targetPath === kOnboardingMarkerPath);
+      fs.writeFileSync = vi.fn((targetPath, contents) => {
+        if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
+          lastRawContents = contents;
+          currentConfig = JSON.parse(contents);
+        }
+      });
+      delete require.cache[modulePath];
+      const gateway = require(modulePath);
+      fs.readFileSync = vi.fn((targetPath) => {
+        if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
+          return JSON.stringify(currentConfig);
+        }
+        return "{}";
+      });
+      return {
+        gateway,
+        getConfig: () => currentConfig,
+        getRawContents: () => lastRawContents,
+      };
+    };
+
+    it("writes remote MCP server with placeholder when env vars are set", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: undefined,
+        },
+        () => {
+          const io = setupConfigIo({ gateway: {} });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.remote).toEqual({
+            url: "https://sure.example.com/mcp",
+            transport: "streamable-http",
+            headers: { Authorization: "Bearer ${REMOTE_MCP_API_TOKEN}" },
+            _alphaclawManaged: true,
+          });
+          expect(io.getRawContents()).not.toContain("sk-sure-secret-token");
+          expect(io.getRawContents()).toContain("Bearer ${REMOTE_MCP_API_TOKEN}");
+        },
+      );
+    });
+
+    it("routes through REMOTE_MCP_PROXY_URL when set", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: "http://127.0.0.1:8889/mcp",
+        },
+        () => {
+          const io = setupConfigIo({ gateway: {} });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.remote.url).toBe(
+            "http://127.0.0.1:8889/mcp",
+          );
+          expect(io.getConfig().mcp.servers.remote.headers.Authorization).toBe(
+            "Bearer ${REMOTE_MCP_API_TOKEN}",
+          );
+        },
+      );
+    });
+
+    it("removes existing remote MCP server when env vars unset", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: undefined,
+          REMOTE_MCP_API_TOKEN: undefined,
+          REMOTE_MCP_PROXY_URL: undefined,
+        },
+        () => {
+          const io = setupConfigIo({
+            gateway: {},
+            mcp: {
+              servers: {
+                remote: {
+                  url: "https://old.example.com/mcp",
+                  transport: "streamable-http",
+                  headers: { Authorization: "Bearer ${REMOTE_MCP_API_TOKEN}" },
+                },
+              },
+            },
+          });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp).toBeUndefined();
+        },
+      );
+    });
+
+    it("uses REMOTE_MCP_NAME as the server key when set", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: undefined,
+          REMOTE_MCP_NAME: "sure",
+        },
+        () => {
+          const io = setupConfigIo({ gateway: {} });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.sure).toBeDefined();
+          expect(io.getConfig().mcp.servers.remote).toBeUndefined();
+          expect(io.getConfig().mcp.servers.sure.url).toBe(
+            "https://sure.example.com/mcp",
+          );
+        },
+      );
+    });
+
+    it("is idempotent when remote MCP server already matches", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: "http://127.0.0.1:8889/mcp",
+        },
+        () => {
+          const io = setupConfigIo({ gateway: {} });
+
+          const firstChanged = io.gateway.ensureGatewayProxyConfig(undefined);
+          const secondChanged = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(firstChanged).toBe(true);
+          expect(secondChanged).toBe(false);
+          expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+        },
+      );
+    });
+
+    it("uses REMOTE_MCP_URL directly when REMOTE_MCP_PROXY_URL is unset", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: undefined,
+        },
+        () => {
+          const io = setupConfigIo({ gateway: {} });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.remote.url).toBe(
+            "https://sure.example.com/mcp",
+          );
+        },
+      );
+    });
+
+    it("scrubs an existing plaintext Authorization back to the placeholder reference", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: undefined,
+          PIPELOCK_ENABLED: undefined,
+        },
+        () => {
+          const io = setupConfigIo({
+            gateway: {},
+            mcp: {
+              servers: {
+                sure: {
+                  url: "https://sure.example.com/mcp",
+                  transport: "streamable-http",
+                  headers: {
+                    Authorization: "Bearer sk-sure-secret-token",
+                  },
+                },
+              },
+            },
+          });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.remote.headers.Authorization).toBe(
+            "Bearer ${REMOTE_MCP_API_TOKEN}",
+          );
+          expect(io.getRawContents()).not.toContain("sk-sure-secret-token");
+        },
+      );
+    });
+
+    it("removes the prior managed entry when REMOTE_MCP_NAME changes", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: undefined,
+          REMOTE_MCP_NAME: "notion",
+        },
+        () => {
+          const io = setupConfigIo({
+            gateway: {},
+            mcp: {
+              servers: {
+                sure: {
+                  url: "https://old.example.com/mcp",
+                  transport: "streamable-http",
+                  headers: { Authorization: "Bearer ${REMOTE_MCP_API_TOKEN}" },
+                  _alphaclawManaged: true,
+                },
+              },
+            },
+          });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.sure).toBeUndefined();
+          expect(io.getConfig().mcp.servers.notion).toBeDefined();
+          expect(io.getConfig().mcp.servers.notion._alphaclawManaged).toBe(true);
+        },
+      );
+    });
+
+    it("does not touch unmarked user entries when REMOTE_MCP_NAME differs", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: undefined,
+          REMOTE_MCP_NAME: "notion",
+        },
+        () => {
+          const io = setupConfigIo({
+            gateway: {},
+            mcp: {
+              servers: {
+                "user-server": {
+                  url: "https://user.example.com/mcp",
+                  transport: "sse",
+                },
+              },
+            },
+          });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers["user-server"]).toEqual({
+            url: "https://user.example.com/mcp",
+            transport: "sse",
+          });
+          expect(io.getConfig().mcp.servers.notion._alphaclawManaged).toBe(true);
+        },
+      );
+    });
+
+    it.each([
+      ["__proto__"],
+      ["constructor"],
+      ["prototype"],
+      ["has spaces"],
+      ["path/like"],
+      ["dot.notation"],
+      [""],
+    ])("rejects invalid REMOTE_MCP_NAME %j and falls back to default", (badName) => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: undefined,
+          REMOTE_MCP_NAME: badName === "" ? undefined : badName,
+        },
+        () => {
+          const io = setupConfigIo({ gateway: {} });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.remote).toBeDefined();
+          expect(Object.keys(io.getConfig().mcp.servers)).not.toContain(badName);
+          // Empty REMOTE_MCP_NAME is a normal default, not a warning.
+          if (badName) {
+            expect(warnSpy).toHaveBeenCalledWith(
+              expect.stringContaining("REMOTE_MCP_NAME"),
+            );
+          }
+        },
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("preserves unrelated mcp.servers entries when the remote config changes", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: "https://sure.example.com/mcp",
+          REMOTE_MCP_API_TOKEN: "sk-sure-secret-token",
+          REMOTE_MCP_PROXY_URL: undefined,
+        },
+        () => {
+          const io = setupConfigIo({
+            gateway: {},
+            mcp: {
+              servers: {
+                other: {
+                  url: "https://other.example.com/mcp",
+                  transport: "sse",
+                },
+              },
+            },
+          });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.other).toEqual({
+            url: "https://other.example.com/mcp",
+            transport: "sse",
+          });
+          expect(io.getConfig().mcp.servers.remote.url).toBe(
+            "https://sure.example.com/mcp",
+          );
+        },
+      );
+    });
   });
 
   it("reports channel status per account while preserving provider summary", () => {

--- a/tests/server/gateway.test.js
+++ b/tests/server/gateway.test.js
@@ -586,6 +586,7 @@ describe("server/gateway restart behavior", () => {
                   url: "https://old.example.com/mcp",
                   transport: "streamable-http",
                   headers: { Authorization: "Bearer ${REMOTE_MCP_API_TOKEN}" },
+                  _alphaclawManaged: true,
                 },
               },
             },
@@ -595,6 +596,39 @@ describe("server/gateway restart behavior", () => {
 
           expect(changed).toBe(true);
           expect(io.getConfig().mcp).toBeUndefined();
+        },
+      );
+    });
+
+    it("preserves an unmarked user remote MCP server when env vars are unset", () => {
+      withEnv(
+        {
+          REMOTE_MCP_URL: undefined,
+          REMOTE_MCP_API_TOKEN: undefined,
+          REMOTE_MCP_PROXY_URL: undefined,
+        },
+        () => {
+          const io = setupConfigIo({
+            gateway: {},
+            mcp: {
+              servers: {
+                remote: {
+                  url: "https://user.example.com/mcp",
+                  transport: "sse",
+                  headers: { Authorization: "Bearer user-token" },
+                },
+              },
+            },
+          });
+
+          const changed = io.gateway.ensureGatewayProxyConfig(undefined);
+
+          expect(changed).toBe(true);
+          expect(io.getConfig().mcp.servers.remote).toEqual({
+            url: "https://user.example.com/mcp",
+            transport: "sse",
+            headers: { Authorization: "Bearer user-token" },
+          });
         },
       );
     });

--- a/tests/server/gateway.test.js
+++ b/tests/server/gateway.test.js
@@ -12,6 +12,7 @@ const {
 } = require("../../lib/server/openclaw-runtime-env");
 
 const kLegacyControlUiSkillPath = path.join(OPENCLAW_DIR, "skills", "control-ui", "SKILL.md");
+const kAlphaclawConfigPath = path.join(OPENCLAW_DIR, "alphaclaw.json");
 
 const modulePath = require.resolve("../../lib/server/gateway");
 const originalSpawn = childProcess.spawn;
@@ -383,8 +384,7 @@ describe("server/gateway restart behavior", () => {
     expect(currentConfig.gateway.controlUi.allowedOrigins).toEqual([
       "https://setup.example.com",
     ]);
-    expect(currentConfig.gateway.http.endpoints.chatCompletions.enabled).toBe(true);
-    expect(currentConfig.gateway.http.endpoints.responses.enabled).toBe(true);
+    expect(currentConfig.gateway.http).toBeUndefined();
   });
 
   it("preserves existing allowed origins and remains idempotent", () => {
@@ -420,12 +420,11 @@ describe("server/gateway restart behavior", () => {
       "https://existing.example.com",
       "https://setup.example.com",
     ]);
-    expect(currentConfig.gateway.http.endpoints.chatCompletions.enabled).toBe(true);
-    expect(currentConfig.gateway.http.endpoints.responses.enabled).toBe(true);
+    expect(currentConfig.gateway.http).toBeUndefined();
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves existing gateway endpoint options while enabling public API endpoints", () => {
+  it("preserves existing gateway endpoint options while enabling opted-in public API endpoints", () => {
     let currentConfig = {
       gateway: {
         trustedProxies: ["127.0.0.1"],
@@ -455,6 +454,11 @@ describe("server/gateway restart behavior", () => {
     fs.readFileSync = vi.fn((targetPath) => {
       if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
         return JSON.stringify(currentConfig);
+      }
+      if (targetPath === kAlphaclawConfigPath) {
+        return JSON.stringify({
+          features: { openaiCompatApi: { enabled: true } },
+        });
       }
       return "{}";
     });

--- a/tests/server/onboarding-openclaw.test.js
+++ b/tests/server/onboarding-openclaw.test.js
@@ -98,6 +98,53 @@ describe("server/onboarding/openclaw", () => {
       enabled: true,
       hooks: { allowConversationAccess: true },
     });
+    expect(next.gateway.http.endpoints.chatCompletions.enabled).toBe(true);
+    expect(next.gateway.http.endpoints.responses.enabled).toBe(true);
+  });
+
+  it("preserves existing gateway HTTP endpoint settings while enabling OpenAI compatibility", () => {
+    const openclawDir = createTempOpenclawDir();
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          plugins: { allow: [], load: { paths: [] }, entries: {} },
+          channels: {},
+          gateway: {
+            http: {
+              endpoints: {
+                chatCompletions: {
+                  maxBodyBytes: 1234,
+                },
+                responses: {
+                  maxBodyBytes: 5678,
+                },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    writeSanitizedOpenclawConfig({
+      fs,
+      openclawDir,
+      varMap: {},
+    });
+
+    const next = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(next.gateway.http.endpoints.chatCompletions).toEqual({
+      enabled: true,
+      maxBodyBytes: 1234,
+    });
+    expect(next.gateway.http.endpoints.responses).toEqual({
+      enabled: true,
+      maxBodyBytes: 5678,
+    });
   });
 
   it("resets imported allowlist dmPolicy to pairing when re-enabling discord", () => {

--- a/tests/server/onboarding-openclaw.test.js
+++ b/tests/server/onboarding-openclaw.test.js
@@ -98,13 +98,17 @@ describe("server/onboarding/openclaw", () => {
       enabled: true,
       hooks: { allowConversationAccess: true },
     });
-    expect(next.gateway.http.endpoints.chatCompletions.enabled).toBe(true);
-    expect(next.gateway.http.endpoints.responses.enabled).toBe(true);
+    expect(next.gateway.http).toBeUndefined();
   });
 
-  it("preserves existing gateway HTTP endpoint settings while enabling OpenAI compatibility", () => {
+  it("preserves existing gateway HTTP endpoint settings when API exposure is opted in", () => {
     const openclawDir = createTempOpenclawDir();
     const configPath = path.join(openclawDir, "openclaw.json");
+    fs.writeFileSync(
+      path.join(openclawDir, "alphaclaw.json"),
+      JSON.stringify({ features: { openaiCompatApi: { enabled: true } } }),
+      "utf8",
+    );
     fs.writeFileSync(
       configPath,
       JSON.stringify(

--- a/tests/server/routes-proxy.test.js
+++ b/tests/server/routes-proxy.test.js
@@ -1,0 +1,214 @@
+const express = require("express");
+const http = require("http");
+const zlib = require("zlib");
+const request = require("supertest");
+
+const { registerProxyRoutes } = require("../../lib/server/routes/proxy");
+
+const listen = (server) =>
+  new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve(server.address().port);
+    });
+  });
+
+const close = (server) =>
+  new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+
+const createApp = ({ gatewayUrl }) => {
+  const app = express();
+  app.use(express.json());
+  registerProxyRoutes({
+    app,
+    proxy: {
+      web: vi.fn((_req, res) => res.status(502).json({ error: "Unexpected proxy" })),
+    },
+    getGatewayUrl: () => gatewayUrl,
+    SETUP_API_PREFIXES: [],
+    requireAuth: (_req, _res, next) => next(),
+    oauthCallbackMiddleware: (_req, res) => res.status(204).end(),
+    webhookMiddleware: (_req, res) => res.status(204).end(),
+  });
+  return app;
+};
+
+describe("server/routes/proxy OpenAI compatibility", () => {
+  let upstream;
+
+  afterEach(async () => {
+    if (upstream) {
+      await close(upstream);
+      upstream = null;
+    }
+  });
+
+  it("requires bearer auth before proxying /v1 requests", async () => {
+    let upstreamCalls = 0;
+    upstream = http.createServer((_req, res) => {
+      upstreamCalls += 1;
+      res.statusCode = 200;
+      res.end("{}");
+    });
+    const port = await listen(upstream);
+    const app = createApp({ gatewayUrl: `http://127.0.0.1:${port}` });
+
+    const res = await request(app).post("/v1/chat/completions").send({
+      model: "openclaw/default",
+      stream: true,
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+    expect(upstreamCalls).toBe(0);
+  });
+
+  it("forwards /v1 chat requests with parsed JSON bodies and streams gateway responses", async () => {
+    const seen = {};
+    upstream = http.createServer((req, res) => {
+      const chunks = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        seen.method = req.method;
+        seen.url = req.url;
+        seen.authorization = req.headers.authorization;
+        seen.cookie = req.headers.cookie;
+        seen.contentType = req.headers["content-type"];
+        seen.body = Buffer.concat(chunks).toString("utf8");
+        res.writeHead(200, {
+          "keep-alive": "timeout=5",
+          "proxy-authenticate": "Basic realm=test",
+          "content-type": "text/event-stream",
+          upgrade: "websocket",
+        });
+        res.write('data: {"choices":[{"delta":{"content":"ok"}}]}\n\n');
+        res.end("data: [DONE]\n\n");
+      });
+    });
+    const port = await listen(upstream);
+    const app = createApp({ gatewayUrl: `http://127.0.0.1:${port}` });
+
+    const res = await request(app)
+      .post("/v1/chat/completions?trace=1")
+      .set("Authorization", "Bearer gateway-token")
+      .set("Cookie", "setup_token=private")
+      .send({
+        model: "openclaw/default",
+        stream: true,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/event-stream");
+    expect(res.headers["proxy-authenticate"]).toBeUndefined();
+    expect(res.headers.upgrade).toBeUndefined();
+    expect(res.text).toContain("data: [DONE]");
+    expect(seen).toEqual({
+      method: "POST",
+      url: "/v1/chat/completions?trace=1",
+      authorization: "Bearer gateway-token",
+      cookie: undefined,
+      contentType: expect.stringContaining("application/json"),
+      body: JSON.stringify({
+        model: "openclaw/default",
+        stream: true,
+      }),
+    });
+  });
+
+  describe("createGatewayProxyHeaders (unit)", () => {
+    const { __testing } = require("../../lib/server/routes/proxy");
+    const { createGatewayProxyHeaders } = __testing;
+
+    it("strips Content-Encoding because Express has already inflated the body", () => {
+      const headers = createGatewayProxyHeaders({
+        reqHeaders: {
+          host: "alphaclaw.example.com",
+          "content-type": "application/json",
+          "content-encoding": "gzip",
+          "content-length": "1234",
+          authorization: "Bearer abc",
+        },
+        bodyBuffer: Buffer.from(JSON.stringify({ model: "openclaw/default" })),
+      });
+      expect(headers["content-encoding"]).toBeUndefined();
+      expect(headers["content-length"]).toBe(String(
+        Buffer.from(JSON.stringify({ model: "openclaw/default" })).length,
+      ));
+      expect(headers.authorization).toBe("Bearer abc");
+    });
+
+    it("strips hop-by-hop request headers", () => {
+      const headers = createGatewayProxyHeaders({
+        reqHeaders: {
+          host: "alphaclaw.example.com",
+          connection: "keep-alive",
+          "transfer-encoding": "chunked",
+          cookie: "setup_token=leak",
+          "content-type": "application/json",
+          authorization: "Bearer abc",
+        },
+        bodyBuffer: Buffer.from("{}"),
+      });
+      expect(headers.host).toBeUndefined();
+      expect(headers.connection).toBeUndefined();
+      expect(headers["transfer-encoding"]).toBeUndefined();
+      expect(headers.cookie).toBeUndefined();
+    });
+
+    it("defaults missing Content-Type to application/json when body present", () => {
+      const headers = createGatewayProxyHeaders({
+        reqHeaders: { authorization: "Bearer abc" },
+        bodyBuffer: Buffer.from('{"x":1}'),
+      });
+      expect(headers["content-type"]).toBe("application/json");
+    });
+
+    it("does not set Content-Type when body is empty", () => {
+      const headers = createGatewayProxyHeaders({
+        reqHeaders: { authorization: "Bearer abc" },
+        bodyBuffer: Buffer.alloc(0),
+      });
+      expect(headers["content-type"]).toBeUndefined();
+      expect(headers["content-length"]).toBeUndefined();
+    });
+  });
+
+  it("strips Set-Cookie from upstream responses", async () => {
+    upstream = http.createServer((_req, res) => {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "set-cookie": "session=leaked-from-gateway; Path=/",
+      });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const port = await listen(upstream);
+    const app = createApp({ gatewayUrl: `http://127.0.0.1:${port}` });
+
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .set("Authorization", "Bearer gateway-token")
+      .send({ model: "openclaw/default", messages: [{ role: "user", content: "hi" }] });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("forwards OpenAI-compatible model list paths", async () => {
+    const seenUrls = [];
+    upstream = http.createServer((req, res) => {
+      seenUrls.push(req.url);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ data: [] }));
+    });
+    const port = await listen(upstream);
+    const app = createApp({ gatewayUrl: `http://127.0.0.1:${port}` });
+
+    const res = await request(app)
+      .get("/v1/models/openclaw%2Fdefault")
+      .set("Authorization", "Bearer gateway-token");
+
+    expect(res.status).toBe(200);
+    expect(seenUrls).toEqual(["/v1/models/openclaw%2Fdefault"]);
+  });
+});

--- a/tests/server/routes-proxy.test.js
+++ b/tests/server/routes-proxy.test.js
@@ -17,15 +17,22 @@ const close = (server) =>
     server.close((err) => (err ? reject(err) : resolve()));
   });
 
-const createApp = ({ gatewayUrl }) => {
+const createApp = ({
+  gatewayUrl,
+  gatewayToken = "gateway-token",
+  openAiJsonLimit = "50mb",
+  globalJsonLimit = "5mb",
+}) => {
   const app = express();
-  app.use(express.json());
+  app.use("/v1", express.json({ limit: openAiJsonLimit }));
+  app.use(express.json({ limit: globalJsonLimit }));
   registerProxyRoutes({
     app,
     proxy: {
       web: vi.fn((_req, res) => res.status(502).json({ error: "Unexpected proxy" })),
     },
     getGatewayUrl: () => gatewayUrl,
+    getGatewayToken: () => gatewayToken,
     SETUP_API_PREFIXES: [],
     requireAuth: (_req, _res, next) => next(),
     oauthCallbackMiddleware: (_req, res) => res.status(204).end(),
@@ -58,6 +65,55 @@ describe("server/routes/proxy OpenAI compatibility", () => {
       model: "openclaw/default",
       stream: true,
     });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+    expect(upstreamCalls).toBe(0);
+  });
+
+  it("rejects bearer tokens that do not match the configured gateway token", async () => {
+    let upstreamCalls = 0;
+    upstream = http.createServer((_req, res) => {
+      upstreamCalls += 1;
+      res.statusCode = 200;
+      res.end("{}");
+    });
+    const port = await listen(upstream);
+    const app = createApp({ gatewayUrl: `http://127.0.0.1:${port}` });
+
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .set("Authorization", "Bearer wrong-token")
+      .send({
+        model: "openclaw/default",
+        stream: true,
+      });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ error: "Unauthorized" });
+    expect(upstreamCalls).toBe(0);
+  });
+
+  it("rejects /v1 requests when no gateway token is configured", async () => {
+    let upstreamCalls = 0;
+    upstream = http.createServer((_req, res) => {
+      upstreamCalls += 1;
+      res.statusCode = 200;
+      res.end("{}");
+    });
+    const port = await listen(upstream);
+    const app = createApp({
+      gatewayUrl: `http://127.0.0.1:${port}`,
+      gatewayToken: "",
+    });
+
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .set("Authorization", "Bearer gateway-token")
+      .send({
+        model: "openclaw/default",
+        stream: true,
+      });
 
     expect(res.status).toBe(401);
     expect(res.body).toEqual({ error: "Unauthorized" });
@@ -114,6 +170,37 @@ describe("server/routes/proxy OpenAI compatibility", () => {
         stream: true,
       }),
     });
+  });
+
+  it("uses the /v1 JSON parser limit before the smaller global JSON limit", async () => {
+    const seen = {};
+    upstream = http.createServer((req, res) => {
+      const chunks = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        seen.bodyLength = Buffer.concat(chunks).length;
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    const port = await listen(upstream);
+    const app = createApp({
+      gatewayUrl: `http://127.0.0.1:${port}`,
+      openAiJsonLimit: "10kb",
+      globalJsonLimit: "1kb",
+    });
+    const payload = {
+      model: "openclaw/default",
+      messages: [{ role: "user", content: "x".repeat(2048) }],
+    };
+
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .set("Authorization", "Bearer gateway-token")
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(seen.bodyLength).toBe(Buffer.byteLength(JSON.stringify(payload)));
   });
 
   describe("createGatewayProxyHeaders (unit)", () => {

--- a/tests/server/routes-proxy.test.js
+++ b/tests/server/routes-proxy.test.js
@@ -22,9 +22,16 @@ const createApp = ({
   gatewayToken = "gateway-token",
   openAiJsonLimit = "50mb",
   globalJsonLimit = "5mb",
+  openAiCompatApiEnabled = true,
 }) => {
   const app = express();
-  app.use("/v1", express.json({ limit: openAiJsonLimit }));
+  const openAiParser = express.json({ limit: openAiJsonLimit });
+  app.use("/v1", (req, res, next) => {
+    if (!openAiCompatApiEnabled) {
+      return res.status(404).json({ error: "Not found" });
+    }
+    return openAiParser(req, res, next);
+  });
   app.use(express.json({ limit: globalJsonLimit }));
   registerProxyRoutes({
     app,
@@ -33,6 +40,7 @@ const createApp = ({
     },
     getGatewayUrl: () => gatewayUrl,
     getGatewayToken: () => gatewayToken,
+    isOpenAiCompatApiEnabled: () => openAiCompatApiEnabled,
     SETUP_API_PREFIXES: [],
     requireAuth: (_req, _res, next) => next(),
     oauthCallbackMiddleware: (_req, res) => res.status(204).end(),
@@ -117,6 +125,32 @@ describe("server/routes/proxy OpenAI compatibility", () => {
 
     expect(res.status).toBe(401);
     expect(res.body).toEqual({ error: "Unauthorized" });
+    expect(upstreamCalls).toBe(0);
+  });
+
+  it("returns 404 for /v1 requests when the API feature is disabled", async () => {
+    let upstreamCalls = 0;
+    upstream = http.createServer((_req, res) => {
+      upstreamCalls += 1;
+      res.statusCode = 200;
+      res.end("{}");
+    });
+    const port = await listen(upstream);
+    const app = createApp({
+      gatewayUrl: `http://127.0.0.1:${port}`,
+      openAiCompatApiEnabled: false,
+    });
+
+    const res = await request(app)
+      .post("/v1/chat/completions")
+      .set("Authorization", "Bearer gateway-token")
+      .send({
+        model: "openclaw/default",
+        stream: true,
+      });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "Not found" });
     expect(upstreamCalls).toBe(0);
   });
 

--- a/tests/server/routes-system.test.js
+++ b/tests/server/routes-system.test.js
@@ -73,6 +73,7 @@ const createSystemDeps = () => {
     clawCmd: vi.fn(async () => ({ ok: true, stdout: "" })),
     restartGateway: vi.fn(),
     restartRequiredState: {
+      markRequired: vi.fn(),
       getSnapshot: vi.fn(async () => ({
         restartRequired: false,
         restartInProgress: false,
@@ -94,6 +95,8 @@ const createSystemDeps = () => {
       removeApiKeyProfileForEnvVar: vi.fn(),
     },
     OPENCLAW_DIR: "/tmp/openclaw",
+    ensureGatewayProxyConfig: vi.fn(() => false),
+    getBaseUrl: vi.fn(() => "https://setup.example.com"),
   };
   return deps;
 };
@@ -350,6 +353,13 @@ describe("server/routes/system", () => {
         gateway: "running",
         configExists: true,
         openclawVersion: "1.2.3",
+        alphaclaw: {
+          features: {
+            openaiCompatApi: {
+              enabled: false,
+            },
+          },
+        },
         syncCron: expect.objectContaining({
           enabled: true,
           schedule: "0 * * * *",
@@ -605,6 +615,109 @@ describe("server/routes/system", () => {
       expect.objectContaining({ mode: 0o644 }),
     );
     expect(res.body.ok).toBe(true);
+  });
+
+  it("returns AlphaClaw config on GET /api/alphaclaw/config", async () => {
+    const deps = createSystemDeps();
+    deps.fs.readFileSync.mockImplementation((targetPath) => {
+      if (targetPath === "/tmp/openclaw/alphaclaw.json") {
+        return JSON.stringify({
+          features: { openaiCompatApi: { enabled: true } },
+        });
+      }
+      throw new Error("no config");
+    });
+    const app = createApp(deps);
+
+    const res = await request(app).get("/api/alphaclaw/config");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      config: {
+        features: {
+          openaiCompatApi: {
+            enabled: true,
+          },
+        },
+      },
+    });
+  });
+
+  it("persists the OpenAI-compatible API feature toggle", async () => {
+    const deps = createSystemDeps();
+    const app = createApp(deps);
+
+    const res = await request(app)
+      .put("/api/alphaclaw/config/features/openai-compat-api")
+      .send({ enabled: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        ok: true,
+        changed: true,
+        gatewayConfigChanged: false,
+        config: {
+          features: {
+            openaiCompatApi: {
+              enabled: true,
+            },
+          },
+        },
+      }),
+    );
+    expect(deps.fs.mkdirSync).toHaveBeenCalledWith("/tmp/openclaw", {
+      recursive: true,
+    });
+    expect(deps.fs.writeFileSync).toHaveBeenCalledWith(
+      "/tmp/openclaw/alphaclaw.json",
+      expect.stringContaining('"enabled": true'),
+    );
+    expect(deps.ensureGatewayProxyConfig).toHaveBeenCalledWith(
+      "https://setup.example.com",
+    );
+  });
+
+  it("marks restart required when enabling API changes OpenClaw gateway config", async () => {
+    const deps = createSystemDeps();
+    deps.ensureGatewayProxyConfig.mockReturnValue(true);
+    deps.restartRequiredState.getSnapshot.mockResolvedValueOnce({
+      restartRequired: true,
+      restartInProgress: false,
+      gatewayRunning: true,
+    });
+    const app = createApp(deps);
+
+    const res = await request(app)
+      .put("/api/alphaclaw/config/features/openai-compat-api")
+      .send({ enabled: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.restartRequired).toBe(true);
+    expect(res.body.gatewayConfigChanged).toBe(true);
+    expect(deps.restartRequiredState.markRequired).toHaveBeenCalledWith(
+      "openai_compat_api_enabled",
+    );
+  });
+
+  it("rejects non-boolean OpenAI-compatible API feature updates", async () => {
+    const deps = createSystemDeps();
+    const app = createApp(deps);
+
+    const res = await request(app)
+      .put("/api/alphaclaw/config/features/openai-compat-api")
+      .send({ enabled: "yes" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: "enabled must be a boolean",
+    });
+    expect(deps.fs.writeFileSync).not.toHaveBeenCalledWith(
+      "/tmp/openclaw/alphaclaw.json",
+      expect.any(String),
+    );
   });
 
   it("returns alphaclaw version status on GET /api/alphaclaw/version", async () => {


### PR DESCRIPTION
## Summary

Adds two opt-in features that let AlphaClaw front an OpenClaw deployment for OpenAI-compatible clients and for OpenClaw-managed remote MCP servers, without anyone hand-editing `openclaw.json`.

Both default off. Existing deployments are unaffected until the relevant env vars are set.

### 1. OpenAI-compatible `/v1/*` proxy

Bearer-auth proxy from AlphaClaw's public Express to the loopback OpenClaw gateway:

- `POST /v1/chat/completions`
- `POST /v1/responses`
- `POST /v1/embeddings`
- `GET /v1/models`, `GET /v1/models/<id>`

Lets a self-hosted backend use this AlphaClaw deployment as its OpenAI-compatible endpoint without exposing OpenClaw's gateway port directly.

- Requires `Authorization: Bearer <OPENCLAW_GATEWAY_TOKEN>`. AlphaClaw enforces the header is present; OpenClaw validates the value.
- Setup cookies stripped before forwarding.
- Hop-by-hop response headers and `Set-Cookie` stripped on the way back out.
- `Content-Encoding` stripped on forwarded requests because Express has already inflated the body.
- `gateway.http.endpoints.chatCompletions.enabled` and `responses.enabled` are set in managed-onboarding writes AND backfilled on every `gateway start`, so existing managed deployments pick up the flags on image bump.

### 2. Env-driven managed `mcp.servers.<name>` entry

When `REMOTE_MCP_URL` + `REMOTE_MCP_API_TOKEN` are set, AlphaClaw writes a `streamable-http` MCP server block to `openclaw.json` and keeps it in sync at every gateway start.

| Env var | Default | Purpose |
|---|---|---|
| `REMOTE_MCP_URL` | unset | Upstream MCP endpoint. |
| `REMOTE_MCP_API_TOKEN` | unset | Bearer token. Persisted as `${REMOTE_MCP_API_TOKEN}`, not plaintext. |
| `REMOTE_MCP_NAME` | `remote` | Key under `mcp.servers.<name>`. Validated `^[A-Za-z0-9_-]{1,64}$`; `__proto__`/`constructor`/`prototype` rejected. |
| `REMOTE_MCP_PROXY_URL` | unset | If set, OpenClaw connects here instead of `REMOTE_MCP_URL`. For same-host scanning proxies. |

- Idempotent: only rewrites when something actually changes.
- Plaintext rewrite: any existing plaintext `Authorization` value gets re-scrubbed to the `${REMOTE_MCP_API_TOKEN}` placeholder on next run.
- Rename cleanup: managed entries are tagged `_alphaclawManaged: true`. If `REMOTE_MCP_NAME` changes, the prior managed entry is removed. Unmarked (user-managed) entries are never touched.
- When the env vars are unset, the managed entry is removed.

## Security boundary

`/v1/chat/completions` is an operator-access surface on OpenClaw's side: anyone holding `OPENCLAW_GATEWAY_TOKEN` can run any tool the agent profile allows. The README's "Security Notes" section is updated to call this out and to recommend the surface be used only for trusted server-to-server callers.

## Tests

Test count moves from 619 to 637. New cases cover the `/v1/*` proxy (bearer-auth gate, body re-serialize, model-list path, Set-Cookie strip, hop-by-hop strip, Content-Encoding strip) and the managed MCP entry (write with placeholder, route via proxy URL, plaintext scrub, name validation + reserved-key rejection, rename cleanup, user-entry preservation, idempotency, remove-on-unset, gateway-start backfill).

`npm test` clean against Node 22. `npm run build:ui` unaffected.

## Backwards compatibility

Defaults unchanged: `/v1/*` route only registers when configured, no managed MCP entry without env vars, no schema breaks. Existing tests still pass. The only addition to managed config writes is enabling the chat-completions and responses endpoints (the precondition for #1 to be useful).
