### PR TITLE
Reject a GCP project number in the Gmail setup wizard

### DIFF
--- a/lib/public/js/components/google/gmail-setup-wizard.js
+++ b/lib/public/js/components/google/gmail-setup-wizard.js
@@ -14,6 +14,7 @@ import { SessionSelectField } from "../session-select-field.js";
 import { sendAgentMessage } from "../../lib/api.js";
 import { showToast } from "../toast.js";
 import { useAgentSessions } from "../../hooks/useAgentSessions.js";
+import { looksLikeProjectNumber } from "./project-id.js";
 import {
   kNoDestinationSessionValue,
   useDestinationSessionSelection,
@@ -147,12 +148,17 @@ export const GmailSetupWizard = ({
     String(account?.client || clientConfig?.client || "default").trim() ||
     "default";
 
+  const projectIdIsNumber = useMemo(
+    () => looksLikeProjectNumber(projectIdInput),
+    [projectIdInput],
+  );
+
   const canAdvance = useMemo(() => {
     if (needsProjectId) {
-      return String(projectIdInput || "").trim().length > 0;
+      return String(projectIdInput || "").trim().length > 0 && !projectIdIsNumber;
     }
     return true;
-  }, [needsProjectId, projectIdInput]);
+  }, [needsProjectId, projectIdInput, projectIdIsNumber]);
 
   const handleCopy = useCallback(async (value) => {
     const ok = await copyText(value);
@@ -291,6 +297,12 @@ export const GmailSetupWizard = ({
                   class="w-full bg-field border border-border rounded-lg px-2.5 py-2 text-xs font-mono focus:border-fg-muted focus:outline-none"
                   placeholder="my-gcp-project"
                 />
+                ${projectIdIsNumber
+                  ? html`<div class="text-xs text-status-error-muted">
+                      That looks like the project number. Enter the project ID
+                      instead — it has letters (e.g. my-gcp-project).
+                    </div>`
+                  : null}
               </div>
             `
           : null

--- a/lib/public/js/components/google/project-id.js
+++ b/lib/public/js/components/google/project-id.js
@@ -1,0 +1,5 @@
+// A Google Cloud project ID always contains a letter (e.g. `my-gcp-project`); a
+// bare all-digits string is the project *number*, which the Pub/Sub and Gmail
+// APIs reject. Catch that common mix-up before saving.
+export const looksLikeProjectNumber = (value) =>
+  /^\d+$/.test(String(value || "").trim());

--- a/tests/frontend/project-id.test.js
+++ b/tests/frontend/project-id.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { looksLikeProjectNumber } from "../../lib/public/js/components/google/project-id.js";
+
+describe("looksLikeProjectNumber", () => {
+  it("flags a bare numeric project number", () => {
+    expect(looksLikeProjectNumber("1030476043583")).toBe(true);
+  });
+
+  it("accepts a real project ID with letters", () => {
+    expect(looksLikeProjectNumber("claude-email-487317")).toBe(false);
+  });
+});


### PR DESCRIPTION
It's pretty easy to accidentally copy in your project number instead of the ID by mistake. This UX tweak will hopefully save others from this speedbump that I personally ran into.

```
Google API error (400 invalidArgument): Invalid topicName does not match projects/<project-id>/topics/*
```

## Fix

A one-line `looksLikeProjectNumber` check (a project ID has letters; a bare all-digits string is the project number). The wizard blocks **Next** and shows a clear inline message when the entry looks like a project number.

## Tests

This input path had no tests before. Added two cases in `tests/frontend/project-id.test.js` for the helper. All green; `npm run build:ui` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)