### PR TITLE
feat(cost): add pricing metadata and resolve prefix shadowing

### DIFF
--- a/lib/server/cost-utils.js
+++ b/lib/server/cost-utils.js
@@ -56,6 +56,14 @@ const kGlobalModelPricing = {
   "gemini-3.1-pro-preview": { input: 2.0, output: 12.0 },
   "gemini-3-flash-preview": { input: 0.5, output: 3.0 },
   "gemini-2.0-flash": { input: 0.1, output: 0.4 },
+  "gpt-5.5": { input: 5.0, output: 30.0, cacheRead: 0.5, cacheWrite: 5.0 },
+  "kimi-k2.6:cloud": { input: 0.8, output: 3.0, cacheRead: 0.1, cacheWrite: 0.8 },
+  "deepseek-v4-flash:cloud": { input: 0.14, output: 0.28, cacheRead: 0.0028, cacheWrite: 0.14 },
+  "glm-5.1:cloud": { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 1.4 },
+  "grok-4.3": { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 1.25 },
+  "qwen3-coder-next": { input: 0.11, output: 0.8, cacheRead: 0.0, cacheWrite: 0.11 },
+  "gpt-5.4-mini": { input: 0.75, output: 3.0, cacheRead: 0.075, cacheWrite: 0.75 },
+  "minimax-m3:cloud": { input: 0.6, output: 2.4, cacheRead: 0.06, cacheWrite: 0.6 },
 };
 
 const toInt = (value, fallbackValue = 0) => {

--- a/lib/server/cost-utils.js
+++ b/lib/server/cost-utils.js
@@ -62,7 +62,7 @@ const kGlobalModelPricing = {
   "glm-5.1:cloud": { input: 1.4, output: 4.4, cacheRead: 0.26, cacheWrite: 1.4 },
   "grok-4.3": { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 1.25 },
   "qwen3-coder-next": { input: 0.11, output: 0.8, cacheRead: 0.0, cacheWrite: 0.11 },
-  "gpt-5.4-mini": { input: 0.75, output: 3.0, cacheRead: 0.075, cacheWrite: 0.75 },
+  "gpt-5.4-mini": { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0.75 },
   "minimax-m3:cloud": { input: 0.6, output: 2.4, cacheRead: 0.06, cacheWrite: 0.6 },
 };
 
@@ -264,9 +264,13 @@ const resolvePricingFromFallbackMap = (model = "") => {
   if (!normalized) return null;
   const exact = kGlobalModelPricing[normalized];
   if (exact) return exact;
-  const matchKey = Object.keys(kGlobalModelPricing).find((key) =>
-    normalized.includes(key),
-  );
+  const modelId = normalized.split("/").filter(Boolean).pop();
+  if (modelId && kGlobalModelPricing[modelId]) {
+    return kGlobalModelPricing[modelId];
+  }
+  const matchKey = Object.keys(kGlobalModelPricing)
+    .sort((a, b) => b.length - a.length)
+    .find((key) => normalized.includes(key));
   return matchKey ? kGlobalModelPricing[matchKey] : null;
 };
 

--- a/tests/server/cost-utils.test.js
+++ b/tests/server/cost-utils.test.js
@@ -29,4 +29,31 @@ describe("server/cost-utils", () => {
     expect(breakdown.pricingFound).toBe(true);
     expect(breakdown.totalCost).toBeCloseTo(5, 8);
   });
+
+  it("prices provider-qualified GPT-5.5 correctly without gpt-5 shadowing", () => {
+    const breakdown = deriveCostBreakdown({
+      provider: "openai",
+      model: "openai/gpt-5.5",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+
+    expect(breakdown.pricingFound).toBe(true);
+    // GPT-5.5 is input: 5.0, output: 30.0 (total $35.0 per million)
+    // GPT-5 would be input: 1.25, output: 10.0 (total $11.25 per million)
+    expect(breakdown.totalCost).toBeCloseTo(35.0, 8);
+  });
+
+  it("prices provider-qualified GPT-5.4-mini correctly without gpt-5 shadowing", () => {
+    const breakdown = deriveCostBreakdown({
+      provider: "openai",
+      model: "openai/gpt-5.4-mini",
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+    });
+
+    expect(breakdown.pricingFound).toBe(true);
+    // GPT-5.4-mini is input: 0.75, output: 4.5 (total $5.25 per million)
+    expect(breakdown.totalCost).toBeCloseTo(5.25, 8);
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds fallback model pricing metadata for several new flagship and cloud models and refines the fallback resolver logic to prevent prefix shadowing.

## Changes
- **Model Pricing Expansion**: Added fallback pricing metadata for new models including `gpt-5.5`, `gpt-5.4-mini`, `kimi-k2.6:cloud`, `deepseek-v4-flash:cloud`, `glm-5.1:cloud`, `grok-4.3`, `qwen3-coder-next`, and `minimax-m3:cloud`.
- **Model ID Fallback Resolution**: Updated `resolvePricingFromFallbackMap` to extract the trailing model ID component (e.g. `gpt-5.5` from `openai/gpt-5.5`) for direct matching. Additionally, fallback keys are now sorted by specificity (length descending) before suffix matching to prevent shorter keys (like `gpt-5`) from shadowing longer prefix-matching keys (like `gpt-5.5`).
- **gpt-5.4-mini Price Alignment**: Aligned the output pricing rate of `gpt-5.4-mini` to `$4.50/M` to match the repository's pinned `openclaw` provider metadata.

## Verification
- Added test cases in `tests/server/cost-utils.test.js` validating correct pricing calculations for provider-qualified model names `openai/gpt-5.5` and `openai/gpt-5.4-mini`.
- Ran the full test suite (`npx vitest run`) to confirm clean execution.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Gemini CLI](https://img.shields.io/badge/Gemini_3.5_Flash-4285F4?logo=googlegemini&logoColor=white)
