### PR TITLE
Fix Codex auth and model discovery

### DIFF
--- a/lib/public/js/components/models-tab/index.js
+++ b/lib/public/js/components/models-tab/index.js
@@ -13,13 +13,15 @@ import {
   buildSyntheticModelEntry,
   getModelCatalogProvider,
   getModelsTabAuthProvider,
+  getModelsTabRequiredAuthProviders,
+  getProviderAuthDisplayOrder,
   getProviderSortIndex,
   SearchableModelPicker,
 } from "./model-picker.js";
 import { ProviderAuthCard } from "./provider-auth-card.js";
 import {
   getFeaturedModels,
-  kProviderOrder,
+  withAlwaysAvailableModels,
 } from "../../lib/model-config.js";
 
 const html = htm.bind(h);
@@ -27,18 +29,12 @@ const html = htm.bind(h);
 const deriveRequiredProviders = (configuredModels) => {
   const providers = new Set();
   for (const modelKey of Object.keys(configuredModels)) {
-    const provider = getModelsTabAuthProvider(modelKey);
-    if (provider) providers.add(provider);
+    for (const provider of getModelsTabRequiredAuthProviders(modelKey)) {
+      providers.add(provider);
+    }
   }
   return [...providers];
 };
-
-const kProviderDisplayOrder = [
-  "anthropic",
-  "openai",
-  "openai-codex",
-  ...kProviderOrder.filter((provider) => !["anthropic", "openai"].includes(provider)),
-];
 
 export const Models = ({ onRestartRequired = () => {}, agentId, embedded = false }) => {
   const {
@@ -70,14 +66,22 @@ export const Models = ({ onRestartRequired = () => {}, agentId, embedded = false
     [configuredModels],
   );
 
-  const featuredModels = useMemo(() => getFeaturedModels(catalog), [catalog]);
+  const selectableCatalog = useMemo(
+    () => withAlwaysAvailableModels(catalog),
+    [catalog],
+  );
+
+  const featuredModels = useMemo(
+    () => getFeaturedModels(selectableCatalog),
+    [selectableCatalog],
+  );
   const popularPickerModels = useMemo(
     () => featuredModels.filter((model) => !configuredKeys.has(model.key)),
     [featuredModels, configuredKeys],
   );
 
   const pickerModels = useMemo(() => {
-    return [...catalog]
+    return [...selectableCatalog]
       .filter((model) => !configuredKeys.has(model.key))
       .sort((a, b) => {
         const providerCompare =
@@ -86,7 +90,7 @@ export const Models = ({ onRestartRequired = () => {}, agentId, embedded = false
         if (providerCompare !== 0) return providerCompare;
         return String(a.label || a.key).localeCompare(String(b.label || b.key));
       });
-  }, [catalog, configuredKeys]);
+  }, [selectableCatalog, configuredKeys]);
 
   const requiredProviders = useMemo(
     () => deriveRequiredProviders(configuredModels),
@@ -94,14 +98,7 @@ export const Models = ({ onRestartRequired = () => {}, agentId, embedded = false
   );
 
   const sortedProviders = useMemo(() => {
-    const ordered = [];
-    for (const p of kProviderDisplayOrder) {
-      if (requiredProviders.includes(p)) ordered.push(p);
-    }
-    for (const p of requiredProviders) {
-      if (!ordered.includes(p)) ordered.push(p);
-    }
-    return ordered;
+    return getProviderAuthDisplayOrder(requiredProviders);
   }, [requiredProviders]);
 
   const providerHasAuth = useMemo(

--- a/lib/public/js/components/models-tab/model-picker.js
+++ b/lib/public/js/components/models-tab/model-picker.js
@@ -19,8 +19,28 @@ const kProviderDisplayOrder = [
 
 export const getModelsTabAuthProvider = (modelKey) => {
   const provider = getModelProvider(modelKey);
-  if (provider === "openai-codex") return "openai-codex";
+  if (provider === "openai" || provider === "openai-codex") {
+    return "openai-codex";
+  }
   return getAuthProviderFromModelProvider(provider);
+};
+
+export const getModelsTabRequiredAuthProviders = (modelKey) => {
+  const provider = getModelProvider(modelKey);
+  if (provider === "openai" || provider === "openai-codex") {
+    return ["openai", "openai-codex"];
+  }
+  const authProvider = getAuthProviderFromModelProvider(provider);
+  return authProvider ? [authProvider] : [];
+};
+
+export const getProviderAuthDisplayOrder = (requiredProviders = []) => {
+  const required = new Set(["openai-codex", ...requiredProviders]);
+  const ordered = kProviderDisplayOrder.filter((provider) => required.has(provider));
+  for (const provider of required) {
+    if (!ordered.includes(provider)) ordered.push(provider);
+  }
+  return ordered;
 };
 
 export const getModelCatalogProvider = (model) =>
@@ -86,6 +106,9 @@ export const buildProviderHasAuth = ({
     }
   }
   if (codexStatus?.connected) {
+    result["openai-codex"] = true;
+  }
+  if (result.openai) {
     result["openai-codex"] = true;
   }
   return result;

--- a/lib/public/js/lib/model-config.js
+++ b/lib/public/js/lib/model-config.js
@@ -27,17 +27,37 @@ export const kFeaturedModelDefs = [
   },
   {
     label: "Codex 5.3",
-    preferredKeys: ["openai-codex/gpt-5.3-codex"],
+    preferredKeys: [
+      "openai/gpt-5.3-codex",
+      "openai-codex/gpt-5.3-codex",
+    ],
   },
   {
     label: "GPT-5.5",
-    preferredKeys: ["openai-codex/gpt-5.5"],
+    preferredKeys: ["openai/gpt-5.5", "openai-codex/gpt-5.5"],
   },
   {
     label: "Gemini 3.1 Pro",
     preferredKeys: ["google/gemini-3.1-pro-preview"],
   },
 ];
+
+export const kAlwaysAvailableModelDefs = [
+  {
+    key: "openai/gpt-5.5",
+    provider: "openai",
+    label: "GPT-5.5",
+  },
+];
+
+export const withAlwaysAvailableModels = (models = []) => {
+  const merged = [...models];
+  const keys = new Set(merged.map((model) => model?.key));
+  for (const model of kAlwaysAvailableModelDefs) {
+    if (!keys.has(model.key)) merged.push(model);
+  }
+  return merged;
+};
 
 export const getFeaturedModels = (allModels) => {
   const picked = [];

--- a/lib/server/constants.js
+++ b/lib/server/constants.js
@@ -173,13 +173,13 @@ const kMinimalFallbackOnboardingModels = [
     label: "Claude Haiku 4.6",
   },
   {
-    key: "openai-codex/gpt-5.5",
-    provider: "openai-codex",
+    key: "openai/gpt-5.5",
+    provider: "openai",
     label: "GPT-5.5",
   },
   {
-    key: "openai-codex/gpt-5.3-codex",
-    provider: "openai-codex",
+    key: "openai/gpt-5.3-codex",
+    provider: "openai",
     label: "Codex GPT-5.3",
   },
   {

--- a/tests/frontend/model-config.test.js
+++ b/tests/frontend/model-config.test.js
@@ -32,6 +32,8 @@ describe("frontend/model-config", () => {
       { key: "anthropic/claude-opus-4-8", label: "Opus 4.8" },
       { key: "anthropic/claude-opus-4-7", label: "Opus 4.7" },
       { key: "anthropic/claude-opus-4-6", label: "Opus 4.6" },
+      { key: "openai/gpt-5.3-codex", label: "Codex 5.3" },
+      { key: "openai/gpt-5.5", label: "GPT-5.5" },
       { key: "openai-codex/gpt-5.3-codex", label: "Codex 5.3" },
       { key: "openai-codex/gpt-5.4", label: "GPT-5.4" },
       { key: "openai-codex/gpt-5.5", label: "GPT-5.5" },
@@ -41,13 +43,31 @@ describe("frontend/model-config", () => {
       "anthropic/claude-opus-4-8",
       "anthropic/claude-opus-4-7",
       "anthropic/claude-opus-4-6",
-      "openai-codex/gpt-5.3-codex",
-      "openai-codex/gpt-5.5",
+      "openai/gpt-5.3-codex",
+      "openai/gpt-5.5",
       "google/gemini-3.1-pro-preview",
     ]);
     expect(featured[0]?.featuredLabel).toBe("Opus 4.8");
     expect(featured[1]?.featuredLabel).toBe("Opus 4.7");
     expect(featured[4]?.featuredLabel).toBe("GPT-5.5");
     expect(featured[5]?.featuredLabel).toBe("Gemini 3.1 Pro");
+  });
+
+  it("keeps canonical GPT-5.5 selectable when live discovery omits it", async () => {
+    const modelConfig = await loadModelConfig();
+    const catalog = modelConfig.withAlwaysAvailableModels([
+      { key: "anthropic/claude-opus-4-6", label: "Opus 4.6" },
+    ]);
+
+    expect(catalog).toContainEqual({
+      key: "openai/gpt-5.5",
+      provider: "openai",
+      label: "GPT-5.5",
+    });
+    expect(
+      modelConfig.withAlwaysAvailableModels(catalog).filter(
+        (model) => model.key === "openai/gpt-5.5",
+      ),
+    ).toHaveLength(1);
   });
 });

--- a/tests/frontend/models-tab-model-picker.test.js
+++ b/tests/frontend/models-tab-model-picker.test.js
@@ -1,0 +1,43 @@
+const loadModelPicker = async () =>
+  import("../../lib/public/js/components/models-tab/model-picker.js");
+
+describe("frontend/models-tab/model-picker", () => {
+  it("uses Codex auth for canonical and legacy OpenAI agent models", async () => {
+    const modelPicker = await loadModelPicker();
+
+    expect(modelPicker.getModelsTabAuthProvider("openai/gpt-5.5")).toBe(
+      "openai-codex",
+    );
+    expect(
+      modelPicker.getModelsTabAuthProvider("openai-codex/gpt-5.5"),
+    ).toBe("openai-codex");
+    expect(
+      modelPicker.getModelsTabRequiredAuthProviders("openai/gpt-5.5"),
+    ).toEqual(["openai", "openai-codex"]);
+  });
+
+  it("always includes Codex OAuth in provider authentication", async () => {
+    const modelPicker = await loadModelPicker();
+
+    expect(modelPicker.getProviderAuthDisplayOrder([])).toEqual([
+      "openai-codex",
+    ]);
+    expect(modelPicker.getProviderAuthDisplayOrder(["anthropic"])).toEqual([
+      "anthropic",
+      "openai-codex",
+    ]);
+  });
+
+  it("accepts Codex OAuth or an OpenAI API key for canonical models", async () => {
+    const modelPicker = await loadModelPicker();
+
+    expect(
+      modelPicker.buildProviderHasAuth({ codexStatus: { connected: true } }),
+    ).toMatchObject({ "openai-codex": true });
+    expect(
+      modelPicker.buildProviderHasAuth({
+        authProfiles: [{ provider: "openai", key: "configured" }],
+      }),
+    ).toMatchObject({ openai: true, "openai-codex": true });
+  });
+});


### PR DESCRIPTION
## Summary
- always expose OpenAI Codex OAuth in Models provider authentication
- treat canonical `openai/*` agent models as Codex-authenticated while accepting an OpenAI API-key backup
- keep canonical `openai/gpt-5.5` selectable when live Codex catalog discovery is unavailable
- prefer canonical OpenAI model refs while retaining legacy catalog compatibility

## Verification
- `npm test` (684 tests, 96 files)
- `npm run build:ui`
- focused model-auth/catalog regression tests