### PR TITLE
Refresh Codex models after authentication

### DIFF
--- a/lib/public/js/components/models-tab/index.js
+++ b/lib/public/js/components/models-tab/index.js
@@ -110,7 +110,8 @@ export const Models = ({ onRestartRequired = () => {}, agentId, embedded = false
     () =>
       Object.keys(configuredModels).map((key) => {
         const catalogEntry =
-          catalog.find((m) => m.key === key) || buildSyntheticModelEntry(key);
+          selectableCatalog.find((m) => m.key === key) ||
+          buildSyntheticModelEntry(key);
         const provider = getModelsTabAuthProvider(key);
         const hasAuth = !!providerHasAuth[provider];
         return {
@@ -121,7 +122,7 @@ export const Models = ({ onRestartRequired = () => {}, agentId, embedded = false
           hasAuth,
         };
       }),
-    [configuredModels, catalog, primary, providerHasAuth],
+    [configuredModels, selectableCatalog, primary, providerHasAuth],
   );
 
   const headerActions = html`

--- a/lib/public/js/components/models-tab/use-models.js
+++ b/lib/public/js/components/models-tab/use-models.js
@@ -343,15 +343,24 @@ export const useModels = (agentId) => {
   ]);
 
   const refreshCodexStatus = useCallback(async () => {
+    let codex;
     try {
-      const codex = await fetchCodexStatus();
+      codex = await fetchCodexStatus();
       setCodexStatus(codex || { connected: false });
       updateCache({ codexStatus: codex || { connected: false } });
     } catch {
       setCodexStatus({ connected: false });
       updateCache({ codexStatus: { connected: false } });
+      return;
     }
-  }, [updateCache]);
+    try {
+      invalidateCache(kModelCatalogCacheKey);
+      const catalogResult = await catalogFetchState.refresh({ force: true });
+      applyCatalogResult(catalogResult);
+    } catch {
+      // Keep the successful auth status; catalog polling will retry discovery.
+    }
+  }, [applyCatalogResult, catalogFetchState, updateCache]);
 
   return {
     catalog,

--- a/lib/server/init/register-server-routes.js
+++ b/lib/server/init/register-server-routes.js
@@ -97,7 +97,7 @@ const registerServerRoutes = ({
   });
 
   registerPageRoutes({ app, requireAuth, isGatewayRunning });
-  registerModelRoutes({
+  const modelCatalogCache = registerModelRoutes({
     app,
     shellCmd,
     gatewayEnv,
@@ -150,6 +150,7 @@ const registerServerRoutes = ({
     parseCodexAuthorizationInput,
     getCodexAccountId,
     authProfiles,
+    onAuthChanged: () => modelCatalogCache.markStale(),
   });
   registerGoogleRoutes({
     app,

--- a/lib/server/routes/codex.js
+++ b/lib/server/routes/codex.js
@@ -29,6 +29,7 @@ const registerCodexRoutes = ({
   parseCodexAuthorizationInput,
   getCodexAccountId,
   authProfiles,
+  onAuthChanged = () => {},
 }) => {
   const { kCodexOauthStates, cleanupCodexOauthStates } = createCodexOauthState();
 
@@ -123,6 +124,7 @@ const registerCodexRoutes = ({
       const accountId = getCodexAccountId(access);
 
       authProfiles.upsertCodexProfile({ access, refresh, expires, accountId });
+      onAuthChanged();
 
       return res.send(`<!DOCTYPE html><html><body><script>
       window.opener?.postMessage({ codex: 'success' }, '*');
@@ -186,6 +188,7 @@ const registerCodexRoutes = ({
       const expires = Date.now() + Number(json.expires_in) * 1000;
       const accountId = getCodexAccountId(access);
       authProfiles.upsertCodexProfile({ access, refresh, expires, accountId });
+      onAuthChanged();
       return res.json({ ok: true });
     } catch (err) {
       console.error("[codex] Manual exchange error:", err);
@@ -197,6 +200,7 @@ const registerCodexRoutes = ({
 
   app.post("/api/codex/disconnect", (req, res) => {
     const changed = authProfiles.removeCodexProfiles();
+    if (changed) onAuthChanged();
     res.json({ ok: true, changed });
   });
 };

--- a/lib/server/routes/models.js
+++ b/lib/server/routes/models.js
@@ -422,6 +422,8 @@ const registerModelRoutes = ({
         });
     }
   });
+
+  return modelCatalogCache;
 };
 
 module.exports = { registerModelRoutes };

--- a/tests/server/routes-codex.test.js
+++ b/tests/server/routes-codex.test.js
@@ -1,0 +1,45 @@
+const express = require("express");
+const request = require("supertest");
+const { registerCodexRoutes } = require("../../lib/server/routes/codex");
+
+const createApp = ({ changed = true } = {}) => {
+  const app = express();
+  app.use(express.json());
+  const onAuthChanged = vi.fn();
+  registerCodexRoutes({
+    app,
+    createPkcePair: () => ({ verifier: "verifier", challenge: "challenge" }),
+    parseCodexAuthorizationInput: () => ({}),
+    getCodexAccountId: () => null,
+    authProfiles: {
+      getCodexProfile: () => null,
+      removeCodexProfiles: () => changed,
+    },
+    onAuthChanged,
+  });
+  return { app, onAuthChanged };
+};
+
+describe("server/routes/codex", () => {
+  it("invalidates model discovery when Codex auth is disconnected", async () => {
+    const { app, onAuthChanged } = createApp();
+
+    await request(app).post("/api/codex/disconnect").expect(200, {
+      ok: true,
+      changed: true,
+    });
+
+    expect(onAuthChanged).toHaveBeenCalledOnce();
+  });
+
+  it("does not invalidate model discovery when disconnect changes nothing", async () => {
+    const { app, onAuthChanged } = createApp({ changed: false });
+
+    await request(app).post("/api/codex/disconnect").expect(200, {
+      ok: true,
+      changed: false,
+    });
+
+    expect(onAuthChanged).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- resolve configured model labels from the same merged catalog used by the picker
- invalidate the server model catalog when Codex OAuth changes
- refresh the browser catalog immediately after Codex status changes
- preserve successful auth status when catalog discovery fails

## Verification
- `npm test` (686 tests, 97 files)
- `npm run build:ui`