### PR TITLE
Hotfix persisted Codex plugin version drift

### DIFF
--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -748,6 +748,22 @@ if (fs.existsSync(configPath)) {
 }
 
 if (fs.existsSync(configPath)) {
+  try {
+    execFileSync(process.execPath, [
+      path.join(__dirname, "..", "lib", "scripts", "reconcile-codex-plugin.js"),
+    ], {
+      env: process.env,
+      stdio: "inherit",
+      timeout: 150_000,
+    });
+  } catch (error) {
+    console.error(
+      `[alphaclaw] Codex plugin reconciliation process failed: ${error.message}`,
+    );
+  }
+}
+
+if (fs.existsSync(configPath)) {
   console.log("[alphaclaw] Config exists, reconciling channels...");
 
   try {

--- a/lib/scripts/reconcile-codex-plugin.js
+++ b/lib/scripts/reconcile-codex-plugin.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+"use strict";
+
+const { execFileSync } = require("child_process");
+const { parseJsonObjectFromNoisyOutput } = require("../server/utils/json");
+const pkg = require("../../package.json");
+
+const getPinnedOpenclawVersion = () =>
+  String(pkg.dependencies?.openclaw || "").trim();
+
+const getInstalledCodexPlugin = ({ exec = execFileSync } = {}) => {
+  try {
+    const output = exec("openclaw", ["plugins", "list", "--json"], {
+      encoding: "utf8",
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+    const parsed = parseJsonObjectFromNoisyOutput(output) || {};
+    return (parsed.plugins || []).find(
+      (plugin) => plugin?.id === "codex" && plugin?.origin === "global",
+    );
+  } catch {
+    return null;
+  }
+};
+
+const reconcileCodexPlugin = ({ exec = execFileSync, logger = console } = {}) => {
+  const expectedVersion = getPinnedOpenclawVersion();
+  if (!expectedVersion) return { changed: false, reason: "missing-pin" };
+
+  const installed = getInstalledCodexPlugin({ exec });
+  if (!installed) return { changed: false, reason: "not-installed" };
+  if (installed.version === expectedVersion) {
+    return { changed: false, reason: "current", version: expectedVersion };
+  }
+
+  logger.log(
+    `[alphaclaw] Updating Codex plugin ${installed.version || "unknown"} -> ${expectedVersion}`,
+  );
+  exec(
+    "openclaw",
+    ["plugins", "install", `@openclaw/codex@${expectedVersion}`, "--force"],
+    {
+      encoding: "utf8",
+      env: process.env,
+      stdio: "inherit",
+      timeout: 120_000,
+    },
+  );
+  return {
+    changed: true,
+    previousVersion: installed.version || null,
+    version: expectedVersion,
+  };
+};
+
+if (require.main === module) {
+  try {
+    reconcileCodexPlugin();
+  } catch (error) {
+    console.warn(
+      `[alphaclaw] Codex plugin reconciliation warning: ${error.message}`,
+    );
+  }
+}
+
+module.exports = {
+  getInstalledCodexPlugin,
+  getPinnedOpenclawVersion,
+  reconcileCodexPlugin,
+};

--- a/tests/server/reconcile-codex-plugin.test.js
+++ b/tests/server/reconcile-codex-plugin.test.js
@@ -1,0 +1,67 @@
+const {
+  getPinnedOpenclawVersion,
+  reconcileCodexPlugin,
+} = require("../../lib/scripts/reconcile-codex-plugin");
+
+describe("scripts/reconcile-codex-plugin", () => {
+  it("replaces a stale persisted Codex plugin with the pinned OpenClaw version", () => {
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce(
+        JSON.stringify({
+          plugins: [
+            {
+              id: "codex",
+              origin: "global",
+              version: "2026.5.28",
+            },
+          ],
+        }),
+      )
+      .mockReturnValueOnce("");
+
+    const result = reconcileCodexPlugin({ exec, logger: { log: vi.fn() } });
+
+    expect(result).toEqual({
+      changed: true,
+      previousVersion: "2026.5.28",
+      version: getPinnedOpenclawVersion(),
+    });
+    expect(exec).toHaveBeenLastCalledWith(
+      "openclaw",
+      [
+        "plugins",
+        "install",
+        `@openclaw/codex@${getPinnedOpenclawVersion()}`,
+        "--force",
+      ],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+  });
+
+  it("is a no-op when the installed plugin matches the pin", () => {
+    const version = getPinnedOpenclawVersion();
+    const exec = vi.fn().mockReturnValue(
+      JSON.stringify({
+        plugins: [{ id: "codex", origin: "global", version }],
+      }),
+    );
+
+    expect(reconcileCodexPlugin({ exec })).toEqual({
+      changed: false,
+      reason: "current",
+      version,
+    });
+    expect(exec).toHaveBeenCalledOnce();
+  });
+
+  it("does not install Codex for users who do not already have it", () => {
+    const exec = vi.fn().mockReturnValue(JSON.stringify({ plugins: [] }));
+
+    expect(reconcileCodexPlugin({ exec })).toEqual({
+      changed: false,
+      reason: "not-installed",
+    });
+    expect(exec).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- reconcile an installed external Codex plugin to AlphaClaw's exact OpenClaw pin during startup
- preserve users who have not installed the Codex plugin
- keep reconciliation failures nonfatal so the setup server remains available

## Root cause

An external `@openclaw/codex@2026.5.28` persisted across an OpenClaw core upgrade to `2026.6.11` and shadowed the compatible plugin. The stale plugin rejected a valid canonical `openai:codex-cli` OAuth profile with:

```text
Codex app-server auth profile "openai:codex-cli" must be OpenAI Codex auth or an OpenAI API-key backup.
```

`openclaw plugins update codex` incorrectly reported the exact stale install spec as current.

## Validation

- reproduced stale `2026.5.28` plugin against core `2026.6.11` in the local Railway template container
- reconciled to exact `@openclaw/codex@2026.6.11`
- restarted the gateway
- completed a real `openai/gpt-5.5` Codex-harness turn through the canonical OAuth profile (`RECONCILE_TEST_OK`)
- verified a second reconciliation is a no-op
- focused migration and reconciliation tests pass
- full suite: 98 files, 689 tests passing

Upstream tracking:

- https://github.com/openclaw/openclaw/issues/83337#issuecomment-4952110575
- https://github.com/openclaw/openclaw/issues/105561
