### PR TITLE
Show Codex runtime models in model picker

### DIFF
--- a/lib/public/js/components/models-tab/use-models.js
+++ b/lib/public/js/components/models-tab/use-models.js
@@ -199,13 +199,17 @@ export const useModels = (agentId) => {
   const addModel = useCallback(
     (modelKey) => {
       if (!modelKey) return;
+      const catalogEntry = catalog.find((model) => model?.key === modelKey);
+      const modelConfig = catalogEntry?.agentRuntime
+        ? { agentRuntime: catalogEntry.agentRuntime }
+        : {};
       setConfiguredModels((prev) => {
-        const next = { ...prev, [modelKey]: {} };
+        const next = { ...prev, [modelKey]: modelConfig };
         updateCache({ configuredModels: next });
         return next;
       });
     },
-    [updateCache],
+    [catalog, updateCache],
   );
 
   const removeModel = useCallback(

--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -115,13 +115,21 @@ const normalizeOnboardingModels = (models) => {
   const deduped = new Map();
   for (const model of models || []) {
     if (!model?.key || typeof model.key !== "string") continue;
-    const provider = resolveModelProvider(model.key);
+    const sourceProvider = resolveModelProvider(model.key);
+    const isCodexRuntimeModel = sourceProvider === "codex";
+    const key = isCodexRuntimeModel
+      ? `openai/${model.key.split("/").slice(1).join("/")}`
+      : model.key;
+    const provider = resolveModelProvider(key);
     if (!kOnboardingModelProviders.has(provider)) continue;
-    if (!deduped.has(model.key)) {
-      deduped.set(model.key, {
-        key: model.key,
+    if (!deduped.has(key)) {
+      deduped.set(key, {
+        key,
         provider,
         label: model.name || model.key,
+        ...(isCodexRuntimeModel
+          ? { agentRuntime: { id: "codex" } }
+          : {}),
       });
     }
   }

--- a/lib/server/model-catalog-cache.js
+++ b/lib/server/model-catalog-cache.js
@@ -38,6 +38,7 @@ const normalizeCachedModels = ({
     (Array.isArray(models) ? models : []).map((model) => ({
       key: model?.key,
       name: model?.label || model?.name || model?.key,
+      ...(model?.agentRuntime ? { agentRuntime: model.agentRuntime } : {}),
     })),
   );
 

--- a/tests/server/helpers.test.js
+++ b/tests/server/helpers.test.js
@@ -68,6 +68,7 @@ describe("server/helpers", () => {
     const normalized = normalizeOnboardingModels([
       { key: "unknown/model-a", name: "Ignore me" },
       { key: "openai/gpt-5.1-codex", name: "OpenAI A" },
+      { key: "codex/gpt-5.4-mini", name: "GPT-5.4-Mini" },
       { key: "anthropic/claude-opus-4-6", name: "Opus 4.6" },
       { key: "zai/glm-5", name: "GLM 5" },
       { key: "minimax/MiniMax-M2.5", name: "MiniMax M2.5" },
@@ -96,6 +97,12 @@ describe("server/helpers", () => {
         key: "openai/gpt-5.1-codex",
         provider: "openai",
         label: "OpenAI A",
+      },
+      {
+        key: "openai/gpt-5.4-mini",
+        provider: "openai",
+        label: "GPT-5.4-Mini",
+        agentRuntime: { id: "codex" },
       },
       {
         key: "zai/glm-5",


### PR DESCRIPTION
## Summary

- normalize OpenClaw `codex/*` catalog entries to canonical `openai/*` model keys
- retain `agentRuntime.id = "codex"` through cache serialization
- save the runtime marker when users add a discovered Codex model

## Validation

- live OpenClaw 2026.6.11 catalog now produces selectable `openai/gpt-5.4-mini` and `openai/gpt-5.5`
- both entries carry the Codex runtime marker
- UI bundle rebuilt
- full suite: 98 files, 689 tests passing

Upstream tracking: https://github.com/openclaw/openclaw/issues/105561
