### PR TITLE
Persist Codex auth in OpenClaw SQLite state

### DIFF
--- a/lib/server/auth-profiles.js
+++ b/lib/server/auth-profiles.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const { DatabaseSync } = require("node:sqlite");
 const { AUTH_PROFILES_PATH, CODEX_PROFILE_ID, OPENCLAW_DIR } = require("./constants");
 
 const kDefaultAgentId = "main";
@@ -54,6 +55,86 @@ const resolveAgentDir = (agentId = kDefaultAgentId) =>
 const resolveAuthProfilesPath = (agentId = kDefaultAgentId) =>
   path.join(resolveAgentDir(agentId), "auth-profiles.json");
 
+const resolveAuthDatabasePath = (agentId = kDefaultAgentId) =>
+  path.join(resolveAgentDir(agentId), "openclaw-agent.sqlite");
+
+const loadSqliteAuthStore = (agentId = kDefaultAgentId) => {
+  const databasePath = resolveAuthDatabasePath(agentId);
+  if (!fs.existsSync(databasePath)) return null;
+  let database;
+  try {
+    database = new DatabaseSync(databasePath, { readOnly: true });
+    const secretsRow = database
+      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+      .get("primary");
+    if (!secretsRow?.store_json) return null;
+    const secrets = JSON.parse(secretsRow.store_json);
+    const stateRow = database
+      .prepare("SELECT state_json FROM auth_profile_state WHERE state_key = ?")
+      .get("primary");
+    const state = stateRow?.state_json ? JSON.parse(stateRow.state_json) : {};
+    return {
+      version: Number(secrets.version || state.version || 1),
+      profiles: secrets.profiles || {},
+      order: state.order,
+      lastGood: state.lastGood,
+      usageStats: state.usageStats,
+    };
+  } catch {
+    return null;
+  } finally {
+    database?.close();
+  }
+};
+
+const saveSqliteAuthStore = (agentId, store) => {
+  const databasePath = resolveAuthDatabasePath(agentId);
+  if (!fs.existsSync(databasePath)) return false;
+  let database;
+  try {
+    database = new DatabaseSync(databasePath);
+    const now = Date.now();
+    const secrets = {
+      version: Number(store.version || 1),
+      profiles: store.profiles || {},
+    };
+    const state = {
+      version: Number(store.version || 1),
+      ...(store.order !== undefined ? { order: store.order } : {}),
+      ...(store.lastGood !== undefined ? { lastGood: store.lastGood } : {}),
+      ...(store.usageStats !== undefined ? { usageStats: store.usageStats } : {}),
+    };
+    database.exec("BEGIN IMMEDIATE");
+    database
+      .prepare(
+        `INSERT INTO auth_profile_store (store_key, store_json, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(store_key) DO UPDATE SET
+           store_json = excluded.store_json,
+           updated_at = excluded.updated_at`,
+      )
+      .run("primary", JSON.stringify(secrets), now);
+    database
+      .prepare(
+        `INSERT INTO auth_profile_state (state_key, state_json, updated_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT(state_key) DO UPDATE SET
+           state_json = excluded.state_json,
+           updated_at = excluded.updated_at`,
+      )
+      .run("primary", JSON.stringify(state), now);
+    database.exec("COMMIT");
+    return true;
+  } catch {
+    try {
+      database?.exec("ROLLBACK");
+    } catch {}
+    return false;
+  } finally {
+    database?.close();
+  }
+};
+
 const resolveOpenclawConfigPath = () =>
   path.join(OPENCLAW_DIR, "openclaw.json");
 
@@ -61,6 +142,8 @@ const hasCompletedOnboardingConfig = (cfg) =>
   String(cfg?.agents?.defaults?.model?.primary || "").trim().includes("/");
 
 const loadAuthStore = (agentId = kDefaultAgentId) => {
+  const sqliteStore = loadSqliteAuthStore(agentId);
+  if (sqliteStore) return sqliteStore;
   const storePath = resolveAuthProfilesPath(agentId);
   let store = { version: 1, profiles: {} };
   try {
@@ -86,6 +169,7 @@ const loadAuthStore = (agentId = kDefaultAgentId) => {
 };
 
 const saveAuthStore = (agentId, store) => {
+  if (saveSqliteAuthStore(agentId, store)) return;
   const storePath = resolveAuthProfilesPath(agentId);
   fs.mkdirSync(path.dirname(storePath), { recursive: true });
   fs.writeFileSync(

--- a/lib/server/openclaw-codex-migration.js
+++ b/lib/server/openclaw-codex-migration.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const { pathToFileURL } = require("url");
+const { DatabaseSync } = require("node:sqlite");
 
 const findOpenclawDistModule = (prefix) => {
   const entryPath = require.resolve("openclaw");
@@ -14,6 +15,53 @@ const findOpenclawDistModule = (prefix) => {
 
 const writeConfig = (configPath, cfg) => {
   fs.writeFileSync(configPath, `${JSON.stringify(cfg, null, 2)}\n`, "utf8");
+};
+
+const hasCanonicalCodexOauthProfile = (configPath) => {
+  const databasePath = path.join(
+    path.dirname(configPath),
+    "agents",
+    "main",
+    "agent",
+    "openclaw-agent.sqlite",
+  );
+  if (!fs.existsSync(databasePath)) return false;
+  let database;
+  try {
+    database = new DatabaseSync(databasePath, { readOnly: true });
+    const row = database
+      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+      .get("primary");
+    const store = row?.store_json ? JSON.parse(row.store_json) : {};
+    return Object.values(store.profiles || {}).some(
+      (profile) =>
+        profile?.type === "oauth" &&
+        profile?.provider === "openai" &&
+        profile?.access &&
+        profile?.refresh,
+    );
+  } catch {
+    return false;
+  } finally {
+    database?.close();
+  }
+};
+
+const restoreCanonicalCodexRuntimeModels = ({ configPath, cfg }) => {
+  if (!hasCanonicalCodexOauthProfile(configPath)) return false;
+  const configuredModels = cfg?.agents?.defaults?.models;
+  if (!configuredModels || typeof configuredModels !== "object") return false;
+  let changed = false;
+  for (const [modelKey, modelConfig] of Object.entries(configuredModels)) {
+    if (!modelKey.startsWith("openai/gpt-")) continue;
+    if (modelConfig?.agentRuntime?.id === "codex") continue;
+    configuredModels[modelKey] = {
+      ...(modelConfig && typeof modelConfig === "object" ? modelConfig : {}),
+      agentRuntime: { id: "codex" },
+    };
+    changed = true;
+  }
+  return changed;
 };
 
 const migrateLegacyCodexState = async ({
@@ -59,6 +107,11 @@ const migrateLegacyCodexState = async ({
   changes.push(...sqliteMigration.changes);
   warnings.push(...sqliteMigration.warnings);
   if (sqliteMigration.configChanged) writeConfig(configPath, nextCfg);
+
+  if (restoreCanonicalCodexRuntimeModels({ configPath, cfg: nextCfg })) {
+    changes.push("Restored Codex runtime metadata for canonical OpenAI models.");
+    writeConfig(configPath, nextCfg);
+  }
 
   const sessionRepair = await routeModule.i({
     cfg: nextCfg,

--- a/tests/server/auth-profiles.test.js
+++ b/tests/server/auth-profiles.test.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { DatabaseSync } = require("node:sqlite");
 
 let tmpDir;
 let ap;
@@ -64,6 +65,14 @@ beforeEach(() => {
     "auth-profiles.json",
   );
   if (fs.existsSync(storePath)) fs.unlinkSync(storePath);
+  const databasePath = path.join(
+    openclawDir,
+    "agents",
+    "main",
+    "agent",
+    "openclaw-agent.sqlite",
+  );
+  if (fs.existsSync(databasePath)) fs.unlinkSync(databasePath);
 });
 
 afterAll(() => {
@@ -72,6 +81,86 @@ afterAll(() => {
 });
 
 describe("server/auth-profiles", () => {
+  it("reads and updates Codex OAuth credentials in the SQLite auth store", () => {
+    const databasePath = path.join(
+      tmpDir,
+      ".openclaw",
+      "agents",
+      "main",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    const database = new DatabaseSync(databasePath);
+    database.exec(`
+      CREATE TABLE auth_profile_store (
+        store_key TEXT NOT NULL PRIMARY KEY,
+        store_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      CREATE TABLE auth_profile_state (
+        state_key TEXT NOT NULL PRIMARY KEY,
+        state_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        "INSERT INTO auth_profile_store (store_key, store_json, updated_at) VALUES (?, ?, ?)",
+      )
+      .run(
+        "primary",
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "openai:codex-cli": {
+              type: "oauth",
+              provider: "openai",
+              access: "sqlite-access",
+              refresh: "sqlite-refresh",
+              expires: 123,
+            },
+          },
+        }),
+        1,
+      );
+    database
+      .prepare(
+        "INSERT INTO auth_profile_state (state_key, state_json, updated_at) VALUES (?, ?, ?)",
+      )
+      .run("primary", JSON.stringify({ version: 1 }), 1);
+    database.close();
+
+    expect(ap.getCodexProfile()).toMatchObject({
+      profileId: "openai:codex-cli",
+      provider: "openai",
+      access: "sqlite-access",
+      refresh: "sqlite-refresh",
+    });
+
+    ap.upsertCodexProfile({
+      access: "updated-access",
+      refresh: "updated-refresh",
+      expires: 456,
+      accountId: "account-1",
+    });
+
+    const updatedDatabase = new DatabaseSync(databasePath, { readOnly: true });
+    const row = updatedDatabase
+      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+      .get("primary");
+    updatedDatabase.close();
+    const updated = JSON.parse(row.store_json);
+    expect(updated.profiles["openai:codex-cli"]).toMatchObject({
+      access: "updated-access",
+      refresh: "updated-refresh",
+      expires: 456,
+      accountId: "account-1",
+    });
+    expect(fs.existsSync(path.join(path.dirname(databasePath), "auth-profiles.json"))).toBe(
+      false,
+    );
+  });
+
   it("upserts an api_key profile and syncs openclaw.json", () => {
     ap.upsertProfile("anthropic:default", {
       type: "api_key",

--- a/tests/server/openclaw-codex-migration.test.js
+++ b/tests/server/openclaw-codex-migration.test.js
@@ -71,6 +71,16 @@ describe("server/openclaw-codex-migration", () => {
     expect(fs.existsSync(path.join(agentDir, "openclaw-agent.sqlite"))).toBe(true);
     expect(fs.existsSync(path.join(agentDir, "auth-profiles.json"))).toBe(false);
 
+    cfg.agents.defaults.models["openai/gpt-5.5"] = {};
+    fs.writeFileSync(configPath, JSON.stringify(cfg), "utf8");
+
+    const restored = await migrateLegacyCodexState({ configPath, env });
+    expect(restored.changed).toBe(true);
+    const restoredCfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(restoredCfg.agents.defaults.models["openai/gpt-5.5"]).toEqual({
+      agentRuntime: { id: "codex" },
+    });
+
     const second = await migrateLegacyCodexState({ configPath, env });
     expect(second.changed).toBe(false);
   });


### PR DESCRIPTION
## Summary

- read and write OpenClaw's canonical per-agent SQLite auth store
- retain legacy JSON fallback for pre-migration installs
- restore missing Codex runtime metadata for canonical OpenAI GPT models when Codex OAuth exists

## Root cause

OpenClaw 2026.6.11 migrates `auth-profiles.json` into `openclaw-agent.sqlite` and removes the legacy file. AlphaClaw continued reading and writing only the JSON path, so the UI reported Codex disconnected after every restart even though the credential remained valid in SQLite.

The production config had also lost `agentRuntime.id = "codex"` on `openai/gpt-5.5`. Consequently, OpenClaw returned no `codex/*` catalog entries and AlphaClaw could not expose GPT-5.4 Mini.

## Validation

- reproduced both failures against the live production state shape and a retained local Docker volume
- verified Codex remains connected after restart without reauthentication
- verified startup restores the Codex runtime marker
- verified catalog returns GPT-5.4 Mini and GPT-5.5 with canonical OpenAI keys and Codex runtime metadata
- full suite: 98 files, 690 tests passing
