### PR TITLE
Preserve Codex runtime across model saves

### DIFF
--- a/lib/server/auth-profiles.js
+++ b/lib/server/auth-profiles.js
@@ -340,12 +340,41 @@ const createAuthProfiles = () => {
 
   // ── Model config operations ──
 
+  const preserveCodexRuntimeModels = (configuredModels) => {
+    const models =
+      configuredModels && typeof configuredModels === "object"
+        ? configuredModels
+        : {};
+    if (!hasCodexOauthProfile()) return models;
+    return Object.fromEntries(
+      Object.entries(models).map(([modelKey, modelConfig]) => {
+        if (!modelKey.startsWith("openai/gpt-")) {
+          return [modelKey, modelConfig];
+        }
+        return [
+          modelKey,
+          {
+            ...(modelConfig && typeof modelConfig === "object"
+              ? modelConfig
+              : {}),
+            agentRuntime: { id: "codex" },
+          },
+        ];
+      }),
+    );
+  };
+
   const getModelConfig = () => {
     const cfg = loadOpenclawConfig();
     const defaults = cfg.agents?.defaults || {};
+    const configuredModels = preserveCodexRuntimeModels(defaults.models || {});
+    if (JSON.stringify(configuredModels) !== JSON.stringify(defaults.models || {})) {
+      cfg.agents.defaults.models = configuredModels;
+      saveOpenclawConfig(cfg);
+    }
     return {
       primary: defaults.model?.primary || null,
-      configuredModels: defaults.models || {},
+      configuredModels,
     };
   };
 
@@ -358,7 +387,7 @@ const createAuthProfiles = () => {
       cfg.agents.defaults.model.primary = primary;
     }
     if (configuredModels !== undefined) {
-      cfg.agents.defaults.models = configuredModels;
+      cfg.agents.defaults.models = preserveCodexRuntimeModels(configuredModels);
     }
     saveOpenclawConfig(cfg);
   };

--- a/tests/server/auth-profiles.test.js
+++ b/tests/server/auth-profiles.test.js
@@ -322,6 +322,27 @@ describe("server/auth-profiles", () => {
     expect(config.gateway.port).toBe(18789);
   });
 
+  it("preserves the Codex runtime marker when model settings are saved", () => {
+    ap.upsertCodexProfile({
+      access: "codex-access",
+      refresh: "codex-refresh",
+      expires: Date.now() + 3_600_000,
+    });
+
+    ap.setModelConfig({
+      primary: "openai/gpt-5.5",
+      configuredModels: {
+        "openai/gpt-5.5": {},
+        "anthropic/claude-opus-4-6": {},
+      },
+    });
+
+    expect(ap.getModelConfig().configuredModels).toEqual({
+      "openai/gpt-5.5": { agentRuntime: { id: "codex" } },
+      "anthropic/claude-opus-4-6": {},
+    });
+  });
+
   it("legacy upsertCodexProfile writes oauth and syncs config", () => {
     ap.upsertCodexProfile({
       access: "jwt",


### PR DESCRIPTION
## Summary

- enforce the Codex runtime marker for configured `openai/gpt-*` models whenever Codex OAuth is present
- apply the invariant on both config reads and saves
- prevent stale browser/UI state from stripping runtime metadata and suppressing Codex model discovery

## Production reproduction

`0.9.25` restored `agentRuntime.id = "codex"` during startup, but a subsequent Models UI save wrote `openai/gpt-5.5: {}`. OpenClaw then returned no `codex/*` catalog entries, so GPT-5.4 Mini disappeared again.

## Validation

- reproduced a UI/API save containing an empty GPT model config
- verified the server persists `agentRuntime.id = "codex"`
- verified the Codex OAuth profile remains in SQLite
- full suite: 98 files, 691 tests passing
