### PR TITLE
Always offer validated Codex Mini model

### DIFF
--- a/lib/public/js/lib/model-config.js
+++ b/lib/public/js/lib/model-config.js
@@ -44,9 +44,16 @@ export const kFeaturedModelDefs = [
 
 export const kAlwaysAvailableModelDefs = [
   {
+    key: "openai/gpt-5.4-mini",
+    provider: "openai",
+    label: "GPT-5.4 Mini",
+    agentRuntime: { id: "codex" },
+  },
+  {
     key: "openai/gpt-5.5",
     provider: "openai",
     label: "GPT-5.5",
+    agentRuntime: { id: "codex" },
   },
 ];
 

--- a/tests/frontend/model-config.test.js
+++ b/tests/frontend/model-config.test.js
@@ -63,6 +63,13 @@ describe("frontend/model-config", () => {
       key: "openai/gpt-5.5",
       provider: "openai",
       label: "GPT-5.5",
+      agentRuntime: { id: "codex" },
+    });
+    expect(catalog).toContainEqual({
+      key: "openai/gpt-5.4-mini",
+      provider: "openai",
+      label: "GPT-5.4 Mini",
+      agentRuntime: { id: "codex" },
     });
     expect(
       modelConfig.withAlwaysAvailableModels(catalog).filter(


### PR DESCRIPTION
OpenClaw can return an empty Codex catalog even when GPT-5.4 Mini executes successfully through the Codex harness. Add GPT-5.4 Mini as a known-safe canonical fallback alongside GPT-5.5, including the Codex runtime marker. Validated with a real MINI_TEST_OK turn; full suite: 98 files, 691 tests.