### PR TITLE
Queue Drift Doctor fixes in the background

### DIFF
--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -99,6 +99,7 @@ Usage: alphaclaw <command> [options]
 Commands:
   start     Start the AlphaClaw server (Setup UI + gateway manager)
   git-sync  Commit and push /data/.openclaw safely using GITHUB_TOKEN
+  doctor finding complete  Mark a queued Doctor finding fixed after verification
   telegram topic add  Add/update Telegram topic mapping by thread ID
   version   Print version
 
@@ -120,6 +121,11 @@ telegram topic add options:
   --system <text>     Optional system instructions
   --agent <id>        Optional agent ID for per-topic routing
   --group <id>        Optional group ID override (auto-resolves when one group exists)
+
+doctor finding complete options:
+  --id <id>           Doctor finding ID
+  --run <run-id>      Queued fix run ID
+  --token <token>     One-time completion token
 
 Examples:
   alphaclaw git-sync --message "sync workspace"
@@ -392,6 +398,59 @@ const runGitSync = () => {
 
 if (command === "git-sync") {
   process.exit(runGitSync());
+}
+
+const runDoctorFindingComplete = () => {
+  const cardId = Number.parseInt(
+    String(flagValue(commandArgs, "--id") || ""),
+    10,
+  );
+  const runId = String(flagValue(commandArgs, "--run") || "").trim();
+  const token = String(flagValue(commandArgs, "--token") || "").trim();
+  if (!Number.isInteger(cardId) || cardId <= 0 || !runId || !token) {
+    console.error(
+      "[alphaclaw] doctor finding complete requires --id, --run, and --token",
+    );
+    return 1;
+  }
+
+  const {
+    closeDoctorDb,
+    completeDoctorCardFix,
+    initDoctorDb,
+  } = require("../lib/server/db/doctor");
+  const {
+    hashDoctorFixToken,
+  } = require("../lib/server/doctor/fix-completion");
+  try {
+    initDoctorDb({ rootDir, markInterruptedRuns: false });
+    const card = completeDoctorCardFix({
+      id: cardId,
+      runId,
+      tokenHash: hashDoctorFixToken(token),
+    });
+    if (!card) {
+      console.error("[alphaclaw] Doctor fix completion was not accepted");
+      return 1;
+    }
+    console.log(`[alphaclaw] Doctor finding ${cardId} marked fixed`);
+    return 0;
+  } catch (error) {
+    console.error(
+      `[alphaclaw] Doctor fix completion failed: ${error.message || "Unknown error"}`,
+    );
+    return 1;
+  } finally {
+    closeDoctorDb();
+  }
+};
+
+if (
+  command === "doctor" &&
+  commandScope === "finding" &&
+  commandAction === "complete"
+) {
+  process.exit(runDoctorFindingComplete());
 }
 
 const runTelegramTopicAdd = () => {

--- a/lib/public/js/components/doctor/findings-list.js
+++ b/lib/public/js/components/doctor/findings-list.js
@@ -202,6 +202,9 @@ export const DoctorFindingsList = ({
                             <${Badge} tone=${getDoctorCategoryTone(card.category)}>
                               ${formatDoctorCategory(card.category)}
                             </${Badge}>
+                            ${card.status === "working"
+                              ? html`<${Badge} tone="info">Working</${Badge}>`
+                              : null}
                             ${
                               showRunMeta
                                 ? html`
@@ -314,8 +317,11 @@ export const DoctorFindingsList = ({
                       <${ActionButton}
                         onClick=${() => onAskAgentFix(card)}
                         loading=${busyCardId === card.id}
+                        disabled=${card.status === "working"}
                         tone="primary"
-                        idleLabel="Ask agent to fix"
+                        idleLabel=${card.status === "working"
+                          ? "Agent working..."
+                          : "Ask agent to fix"}
                         loadingLabel="Sending..."
                       />
                       ${
@@ -335,6 +341,15 @@ export const DoctorFindingsList = ({
                               />
                             `
                       }
+                      ${card.status === "working"
+                        ? html`
+                            <${ActionButton}
+                              onClick=${() => onUpdateStatus(card, "open")}
+                              tone="secondary"
+                              idleLabel="Reopen"
+                            />
+                          `
+                        : null}
                       ${
                         card.status !== "dismissed"
                           ? html`

--- a/lib/public/js/components/doctor/findings-list.js
+++ b/lib/public/js/components/doctor/findings-list.js
@@ -317,11 +317,13 @@ export const DoctorFindingsList = ({
                       <${ActionButton}
                         onClick=${() => onAskAgentFix(card)}
                         loading=${busyCardId === card.id}
-                        disabled=${card.status === "working"}
+                        disabled=${card.status !== "open"}
                         tone="primary"
                         idleLabel=${card.status === "working"
                           ? "Agent working..."
-                          : "Ask agent to fix"}
+                          : card.status === "open"
+                            ? "Ask agent to fix"
+                            : "Reopen to send"}
                         loadingLabel="Sending..."
                       />
                       ${

--- a/lib/public/js/components/doctor/fix-card-modal.js
+++ b/lib/public/js/components/doctor/fix-card-modal.js
@@ -23,7 +23,7 @@ export const DoctorFixCardModal = ({
         prompt: message,
       });
       showToast(
-        "Doctor fix queued. The finding will stay open until you confirm the fix.",
+        "Doctor fix queued. The agent will mark it fixed after applying and verifying the change.",
         "success",
       );
       await onComplete();

--- a/lib/public/js/components/doctor/fix-card-modal.js
+++ b/lib/public/js/components/doctor/fix-card-modal.js
@@ -1,6 +1,6 @@
 import { h } from "preact";
 import htm from "htm";
-import { sendDoctorCardFix, updateDoctorCardStatus } from "../../lib/api.js";
+import { sendDoctorCardFix } from "../../lib/api.js";
 import { showToast } from "../toast.js";
 import { AgentSendModal } from "../agent-send-modal.js";
 
@@ -12,29 +12,20 @@ export const DoctorFixCardModal = ({
   onClose = () => {},
   onComplete = () => {},
 }) => {
-  const handleSend = async ({ selectedSession, message }) => {
+  const handleSend = async ({ selectedSession, selectedSessionKey, message }) => {
     if (!card?.id) return false;
     try {
       await sendDoctorCardFix({
         cardId: card.id,
-        sessionId: selectedSession?.sessionId || "",
+        sessionKey: selectedSessionKey,
         replyChannel: selectedSession?.replyChannel || "",
         replyTo: selectedSession?.replyTo || "",
         prompt: message,
       });
-      try {
-        await updateDoctorCardStatus({ cardId: card.id, status: "fixed" });
-        showToast(
-          "Doctor fix queued and finding marked fixed. The agent will reply when done.",
-          "success",
-        );
-      } catch (statusError) {
-        showToast(
-          statusError.message ||
-            "Doctor fix request sent, but could not mark the finding fixed",
-          "warning",
-        );
-      }
+      showToast(
+        "Doctor fix queued. The finding will stay open until you confirm the fix.",
+        "success",
+      );
       await onComplete();
       return true;
     } catch (error) {

--- a/lib/public/js/components/doctor/fix-card-modal.js
+++ b/lib/public/js/components/doctor/fix-card-modal.js
@@ -25,7 +25,7 @@ export const DoctorFixCardModal = ({
       try {
         await updateDoctorCardStatus({ cardId: card.id, status: "fixed" });
         showToast(
-          "Doctor fix request sent and finding marked fixed",
+          "Doctor fix queued and finding marked fixed. The agent will reply when done.",
           "success",
         );
       } catch (statusError) {
@@ -51,7 +51,7 @@ export const DoctorFixCardModal = ({
       initialMessage=${String(card?.fixPrompt || "")}
       resetKey=${String(card?.id || "")}
       submitLabel="Send fix request"
-      loadingLabel="Sending..."
+      loadingLabel="Queuing..."
       onClose=${onClose}
       onSubmit=${handleSend}
     />

--- a/lib/public/js/components/doctor/helpers.js
+++ b/lib/public/js/components/doctor/helpers.js
@@ -12,6 +12,7 @@ export const getDoctorStatusTone = (status = "") => {
     .trim()
     .toLowerCase();
   if (normalized === "fixed") return "success";
+  if (normalized === "working") return "info";
   if (normalized === "dismissed") return "neutral";
   return "warning";
 };
@@ -60,6 +61,10 @@ export const groupDoctorCardsByStatus = (cards = []) =>
         groups.fixed.push(card);
         return groups;
       }
+      if (status === "working") {
+        groups.working.push(card);
+        return groups;
+      }
       if (status === "dismissed") {
         groups.dismissed.push(card);
         return groups;
@@ -67,7 +72,7 @@ export const groupDoctorCardsByStatus = (cards = []) =>
       groups.open.push(card);
       return groups;
     },
-    { open: [], dismissed: [], fixed: [] },
+    { open: [], working: [], dismissed: [], fixed: [] },
   );
 
 export const shouldShowDoctorWarning = (
@@ -185,6 +190,7 @@ export const buildDoctorRunMarkers = (run = null) => {
 
 export const buildDoctorStatusFilterOptions = () => [
   { value: "open", label: "Open" },
+  { value: "working", label: "Working" },
   { value: "dismissed", label: "Dismissed" },
   { value: "fixed", label: "Fixed" },
 ];

--- a/lib/public/js/components/doctor/index.js
+++ b/lib/public/js/components/doctor/index.js
@@ -78,7 +78,7 @@ export const DoctorTab = ({ isActive = false, onOpenFile = () => {} }) => {
         status: "running",
         summary: "",
         priorityCounts: { P0: 0, P1: 0, P2: 0 },
-        statusCounts: { open: 0, dismissed: 0, fixed: 0 },
+        statusCounts: { open: 0, working: 0, dismissed: 0, fixed: 0 },
       }
     : null;
   const displayRuns = pendingRun ? [pendingRun, ...runs] : runs;

--- a/lib/public/js/lib/api.js
+++ b/lib/public/js/lib/api.js
@@ -300,7 +300,7 @@ export const updateDoctorCardStatus = async ({ cardId, status }) => {
 
 export const sendDoctorCardFix = async ({
   cardId,
-  sessionId = "",
+  sessionKey = "",
   replyChannel = "",
   replyTo = "",
   prompt = "",
@@ -311,7 +311,7 @@ export const sendDoctorCardFix = async ({
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        sessionId: String(sessionId || ""),
+        sessionKey: String(sessionKey || ""),
         replyChannel: String(replyChannel || ""),
         replyTo: String(replyTo || ""),
         prompt: String(prompt || ""),

--- a/lib/server.js
+++ b/lib/server.js
@@ -66,7 +66,6 @@ const {
   updateDoctorCardStatus,
   startDoctorCardFix,
   cancelDoctorCardFix,
-  completeDoctorCardFix,
 } = require("./server/db/doctor");
 const {
   initAuthDb,
@@ -311,10 +310,9 @@ const doctorService = createDoctorService({
   updateDoctorCardStatus,
   startDoctorCardFix,
   cancelDoctorCardFix,
-  completeDoctorCardFix,
   workspaceRoot: constants.WORKSPACE_DIR,
   managedRoot: constants.OPENCLAW_DIR,
-  callbackBaseUrl: `http://127.0.0.1:${constants.PORT}`,
+  alphaclawRootDir: constants.kRootDir,
   protectedPaths: Array.from(constants.kProtectedBrowsePaths || []),
   lockedPaths: Array.from(constants.kLockedBrowsePaths || []),
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -64,6 +64,9 @@ const {
   getDoctorCardsByRunId,
   getDoctorCard,
   updateDoctorCardStatus,
+  startDoctorCardFix,
+  cancelDoctorCardFix,
+  completeDoctorCardFix,
 } = require("./server/db/doctor");
 const {
   initAuthDb,
@@ -306,8 +309,12 @@ const doctorService = createDoctorService({
   getDoctorCardsByRunId,
   getDoctorCard,
   updateDoctorCardStatus,
+  startDoctorCardFix,
+  cancelDoctorCardFix,
+  completeDoctorCardFix,
   workspaceRoot: constants.WORKSPACE_DIR,
   managedRoot: constants.OPENCLAW_DIR,
+  callbackBaseUrl: `http://127.0.0.1:${constants.PORT}`,
   protectedPaths: Array.from(constants.kProtectedBrowsePaths || []),
   lockedPaths: Array.from(constants.kLockedBrowsePaths || []),
 });

--- a/lib/server/db/doctor/index.js
+++ b/lib/server/db/doctor/index.js
@@ -42,6 +42,7 @@ const buildPriorityCounts = (cards = []) => ({
 
 const buildStatusCounts = (cards = []) => ({
   open: cards.filter((card) => card.status === kDoctorCardStatus.open).length,
+  working: cards.filter((card) => card.status === kDoctorCardStatus.working).length,
   dismissed: cards.filter((card) => card.status === kDoctorCardStatus.dismissed).length,
   fixed: cards.filter((card) => card.status === kDoctorCardStatus.fixed).length,
 });
@@ -138,9 +139,10 @@ const listDoctorCards = ({ runId } = {}) => {
       ${hasRunFilter ? "WHERE c.run_id = $run_id" : ""}
       ORDER BY
         CASE c.status
-          WHEN 'open' THEN 0
-          WHEN 'dismissed' THEN 1
-          ELSE 2
+          WHEN 'working' THEN 0
+          WHEN 'open' THEN 1
+          WHEN 'dismissed' THEN 2
+          ELSE 3
         END ASC,
         CASE c.priority
           WHEN 'P0' THEN 0
@@ -507,12 +509,93 @@ const updateDoctorCardStatus = ({ id, status }) => {
       UPDATE doctor_cards
       SET
         status = $status,
+        fix_run_id = NULL,
+        fix_token_hash = NULL,
+        fix_started_at = NULL,
+        fix_completed_at = CASE WHEN $status = $fixed_status
+          THEN strftime('%Y-%m-%dT%H:%M:%fZ','now')
+          ELSE NULL
+        END,
         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
       WHERE id = $id
     `)
     .run({
       $id: Number(id || 0),
       $status: nextStatus,
+      $fixed_status: kDoctorCardStatus.fixed,
+    });
+  return Number(result.changes || 0) > 0 ? getDoctorCard(id) : null;
+};
+
+const startDoctorCardFix = ({ id, runId, tokenHash }) => {
+  const database = ensureDb();
+  const result = database
+    .prepare(`
+      UPDATE doctor_cards
+      SET
+        status = $status,
+        fix_run_id = $run_id,
+        fix_token_hash = $token_hash,
+        fix_started_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+        fix_completed_at = NULL,
+        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+      WHERE id = $id
+    `)
+    .run({
+      $id: Number(id || 0),
+      $status: kDoctorCardStatus.working,
+      $run_id: String(runId || ""),
+      $token_hash: String(tokenHash || ""),
+    });
+  return Number(result.changes || 0) > 0 ? getDoctorCard(id) : null;
+};
+
+const cancelDoctorCardFix = ({ id, runId }) => {
+  const database = ensureDb();
+  const result = database
+    .prepare(`
+      UPDATE doctor_cards
+      SET
+        status = $status,
+        fix_run_id = NULL,
+        fix_token_hash = NULL,
+        fix_started_at = NULL,
+        fix_completed_at = NULL,
+        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+      WHERE id = $id
+        AND status = $working_status
+        AND fix_run_id = $run_id
+    `)
+    .run({
+      $id: Number(id || 0),
+      $status: kDoctorCardStatus.open,
+      $working_status: kDoctorCardStatus.working,
+      $run_id: String(runId || ""),
+    });
+  return Number(result.changes || 0) > 0 ? getDoctorCard(id) : null;
+};
+
+const completeDoctorCardFix = ({ id, runId, tokenHash }) => {
+  const database = ensureDb();
+  const result = database
+    .prepare(`
+      UPDATE doctor_cards
+      SET
+        status = $status,
+        fix_token_hash = NULL,
+        fix_completed_at = strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+        updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+      WHERE id = $id
+        AND status = $working_status
+        AND fix_run_id = $run_id
+        AND fix_token_hash = $token_hash
+    `)
+    .run({
+      $id: Number(id || 0),
+      $status: kDoctorCardStatus.fixed,
+      $working_status: kDoctorCardStatus.working,
+      $run_id: String(runId || ""),
+      $token_hash: String(tokenHash || ""),
     });
   return Number(result.changes || 0) > 0 ? getDoctorCard(id) : null;
 };
@@ -535,4 +618,7 @@ module.exports = {
   getDoctorCardsByRunId: getCardsByRunId,
   getDoctorCard,
   updateDoctorCardStatus,
+  startDoctorCardFix,
+  cancelDoctorCardFix,
+  completeDoctorCardFix,
 };

--- a/lib/server/db/doctor/index.js
+++ b/lib/server/db/doctor/index.js
@@ -179,14 +179,15 @@ const toRunModel = (row) => {
   };
 };
 
-const initDoctorDb = ({ rootDir }) => {
+const initDoctorDb = ({ rootDir, markInterruptedRuns = true }) => {
   closeDoctorDb();
   const dbDir = path.join(rootDir, "db");
   fs.mkdirSync(dbDir, { recursive: true });
   const dbPath = path.join(dbDir, "doctor.db");
   db = new DatabaseSync(dbPath);
+  db.exec("PRAGMA busy_timeout = 5000;");
   createSchema(db);
-  markIncompleteRunsFailed();
+  if (markInterruptedRuns) markIncompleteRunsFailed();
   return { path: dbPath };
 };
 
@@ -540,10 +541,12 @@ const startDoctorCardFix = ({ id, runId, tokenHash }) => {
         fix_completed_at = NULL,
         updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
       WHERE id = $id
+        AND status = $open_status
     `)
     .run({
       $id: Number(id || 0),
       $status: kDoctorCardStatus.working,
+      $open_status: kDoctorCardStatus.open,
       $run_id: String(runId || ""),
       $token_hash: String(tokenHash || ""),
     });

--- a/lib/server/db/doctor/schema.js
+++ b/lib/server/db/doctor/schema.js
@@ -58,6 +58,10 @@ const createSchema = (database) => {
   ensureColumn(database, "doctor_runs", "workspace_fingerprint", "TEXT");
   ensureColumn(database, "doctor_runs", "workspace_manifest_json", "TEXT");
   ensureColumn(database, "doctor_runs", "reused_from_run_id", "INTEGER");
+  ensureColumn(database, "doctor_cards", "fix_run_id", "TEXT");
+  ensureColumn(database, "doctor_cards", "fix_token_hash", "TEXT");
+  ensureColumn(database, "doctor_cards", "fix_started_at", "TEXT");
+  ensureColumn(database, "doctor_cards", "fix_completed_at", "TEXT");
   database.exec(`
     CREATE INDEX IF NOT EXISTS idx_doctor_cards_run_id
     ON doctor_cards(run_id, created_at DESC);

--- a/lib/server/doctor/constants.js
+++ b/lib/server/doctor/constants.js
@@ -6,6 +6,7 @@ const kDoctorRunStatus = {
 };
 const kDoctorCardStatus = {
   open: "open",
+  working: "working",
   dismissed: "dismissed",
   fixed: "fixed",
 };

--- a/lib/server/doctor/fix-completion.js
+++ b/lib/server/doctor/fix-completion.js
@@ -1,0 +1,6 @@
+const crypto = require("crypto");
+
+const hashDoctorFixToken = (token) =>
+  crypto.createHash("sha256").update(String(token || "")).digest("hex");
+
+module.exports = { hashDoctorFixToken };

--- a/lib/server/doctor/service.js
+++ b/lib/server/doctor/service.js
@@ -387,7 +387,7 @@ const createDoctorService = ({
 
   const requestCardFix = async ({
     cardId,
-    sessionId = "",
+    sessionKey = "",
     replyChannel = "",
     replyTo = "",
     prompt = "",
@@ -396,21 +396,20 @@ const createDoctorService = ({
     if (!card) throw new Error("Doctor card not found");
     const resolvedPrompt = String(prompt || card.fixPrompt || "").trim();
     if (!resolvedPrompt) throw new Error("Doctor card does not include a fix prompt");
-    const trimmedSessionId = String(sessionId || "").trim();
+    const trimmedSessionKey = String(sessionKey || "").trim();
+    if (!trimmedSessionKey) throw new Error("Doctor fix request requires a session key");
     const trimmedReplyChannel = String(replyChannel || "").trim();
     const trimmedReplyTo = String(replyTo || "").trim();
     const runId = `doctor-fix-${Number(card.id || cardId)}-${crypto.randomUUID()}`;
     const gatewayParams = {
-      agentId: "main",
       idempotencyKey: runId,
       message: resolvedPrompt,
+      sessionKey: trimmedSessionKey,
     };
     if (trimmedReplyChannel && trimmedReplyTo) {
       gatewayParams.deliver = true;
       gatewayParams.replyChannel = trimmedReplyChannel;
       gatewayParams.replyTo = trimmedReplyTo;
-    } else if (trimmedSessionId) {
-      gatewayParams.sessionId = trimmedSessionId;
     }
     const result = await clawCmd(
       `gateway call agent --json --timeout ${kDoctorFixDispatchTimeoutMs} --params ${shellEscapeArg(

--- a/lib/server/doctor/service.js
+++ b/lib/server/doctor/service.js
@@ -6,6 +6,7 @@ const {
   buildBootstrapTruncationCards,
 } = require("./bootstrap-context");
 const { buildDoctorPrompt } = require("./prompt");
+const { hashDoctorFixToken } = require("./fix-completion");
 const { normalizeDoctorResult } = require("./normalize");
 const { calculateWorkspaceDelta, computeWorkspaceSnapshot } = require("./workspace-fingerprint");
 const {
@@ -21,22 +22,29 @@ const {
 const kMaxSnippetLines = 20;
 const kDoctorFixDispatchTimeoutMs = 30000;
 
-const hashDoctorFixToken = (token) =>
-  crypto.createHash("sha256").update(String(token || "")).digest("hex");
-
 const buildDoctorFixCompletionInstructions = ({
   cardId,
   runId,
   token,
-  callbackBaseUrl,
+  alphaclawRootDir,
 }) => {
-  const callbackUrl = `${String(callbackBaseUrl || "").replace(/\/+$/, "")}/api/doctor/findings/${Number(cardId || 0)}/complete`;
-  const callbackPayload = JSON.stringify({ runId, token });
+  const completionCommand = [
+    "alphaclaw",
+    "--root-dir",
+    shellEscapeArg(alphaclawRootDir),
+    "doctor finding complete",
+    "--id",
+    shellEscapeArg(String(Number(cardId || 0))),
+    "--run",
+    shellEscapeArg(runId),
+    "--token",
+    shellEscapeArg(token),
+  ].join(" ");
   return [
     "AlphaClaw completion callback:",
     "After you have successfully applied and verified the requested fix, run this command exactly:",
     "```sh",
-    `curl --fail --silent --show-error -X POST ${shellEscapeArg(callbackUrl)} -H 'Content-Type: application/json' --data ${shellEscapeArg(callbackPayload)}`,
+    completionCommand,
     "```",
     "Do not call the completion callback if the fix was not applied or verification failed. Explain the problem to the user instead.",
   ].join("\n");
@@ -117,10 +125,9 @@ const createDoctorService = ({
   updateDoctorCardStatus,
   startDoctorCardFix,
   cancelDoctorCardFix,
-  completeDoctorCardFix,
   workspaceRoot,
   managedRoot,
-  callbackBaseUrl = `http://127.0.0.1:${Number.parseInt(String(process.env.PORT || "3000"), 10) || 3000}`,
+  alphaclawRootDir = process.env.ALPHACLAW_ROOT_DIR || "~/.alphaclaw",
   protectedPaths = [],
   lockedPaths = [],
 }) => {
@@ -439,12 +446,18 @@ const createDoctorService = ({
       runId,
       tokenHash: hashDoctorFixToken(callbackToken),
     });
-    if (!workingCard) throw new Error("Doctor card not found");
+    if (!workingCard) {
+      const currentCard = getDoctorCard(card.id);
+      if (currentCard?.status === kDoctorCardStatus.working) {
+        throw new Error("Doctor fix already in progress");
+      }
+      throw new Error("Doctor finding must be open before requesting a fix");
+    }
     const completionInstructions = buildDoctorFixCompletionInstructions({
       cardId: card.id,
       runId,
       token: callbackToken,
-      callbackBaseUrl,
+      alphaclawRootDir,
     });
     const gatewayParams = {
       idempotencyKey: runId,
@@ -484,21 +497,6 @@ const createDoctorService = ({
     };
   };
 
-  const completeCardFix = ({ cardId, runId = "", token = "" } = {}) => {
-    const normalizedRunId = String(runId || "").trim();
-    const normalizedToken = String(token || "").trim();
-    if (!normalizedRunId || !normalizedToken) {
-      throw new Error("Invalid Doctor fix completion callback");
-    }
-    const completedCard = completeDoctorCardFix({
-      id: cardId,
-      runId: normalizedRunId,
-      tokenHash: hashDoctorFixToken(normalizedToken),
-    });
-    if (!completedCard) throw new Error("Invalid Doctor fix completion callback");
-    return { ok: true, card: completedCard };
-  };
-
   const setCardStatus = ({ cardId, status }) => {
     const updatedCard = updateDoctorCardStatus({
       id: cardId,
@@ -517,7 +515,6 @@ const createDoctorService = ({
     getDoctorRun,
     getDoctorCardsByRunId,
     requestCardFix,
-    completeCardFix,
     setCardStatus,
     getDoctorCard,
   };

--- a/lib/server/doctor/service.js
+++ b/lib/server/doctor/service.js
@@ -9,6 +9,7 @@ const { buildDoctorPrompt } = require("./prompt");
 const { normalizeDoctorResult } = require("./normalize");
 const { calculateWorkspaceDelta, computeWorkspaceSnapshot } = require("./workspace-fingerprint");
 const {
+  kDoctorCardStatus,
   kDoctorEngine,
   kDoctorMeaningfulChangeScoreThreshold,
   kDoctorPromptVersion,
@@ -19,6 +20,27 @@ const {
 
 const kMaxSnippetLines = 20;
 const kDoctorFixDispatchTimeoutMs = 30000;
+
+const hashDoctorFixToken = (token) =>
+  crypto.createHash("sha256").update(String(token || "")).digest("hex");
+
+const buildDoctorFixCompletionInstructions = ({
+  cardId,
+  runId,
+  token,
+  callbackBaseUrl,
+}) => {
+  const callbackUrl = `${String(callbackBaseUrl || "").replace(/\/+$/, "")}/api/doctor/findings/${Number(cardId || 0)}/complete`;
+  const callbackPayload = JSON.stringify({ runId, token });
+  return [
+    "AlphaClaw completion callback:",
+    "After you have successfully applied and verified the requested fix, run this command exactly:",
+    "```sh",
+    `curl --fail --silent --show-error -X POST ${shellEscapeArg(callbackUrl)} -H 'Content-Type: application/json' --data ${shellEscapeArg(callbackPayload)}`,
+    "```",
+    "Do not call the completion callback if the fix was not applied or verification failed. Explain the problem to the user instead.",
+  ].join("\n");
+};
 
 const shellEscapeArg = (value) => {
   const safeValue = String(value || "");
@@ -93,8 +115,12 @@ const createDoctorService = ({
   getDoctorCardsByRunId,
   getDoctorCard,
   updateDoctorCardStatus,
+  startDoctorCardFix,
+  cancelDoctorCardFix,
+  completeDoctorCardFix,
   workspaceRoot,
   managedRoot,
+  callbackBaseUrl = `http://127.0.0.1:${Number.parseInt(String(process.env.PORT || "3000"), 10) || 3000}`,
   protectedPaths = [],
   lockedPaths = [],
 }) => {
@@ -135,7 +161,13 @@ const createDoctorService = ({
   };
 
   const cloneRunCards = ({ sourceRunId, targetRunId }) => {
-    const sourceCards = getDoctorCardsByRunId(sourceRunId);
+    const sourceCards = getDoctorCardsByRunId(sourceRunId).map((card) => ({
+      ...card,
+      status:
+        card.status === kDoctorCardStatus.working
+          ? kDoctorCardStatus.open
+          : card.status,
+    }));
     insertDoctorCards({
       runId: targetRunId,
       cards: sourceCards,
@@ -401,9 +433,22 @@ const createDoctorService = ({
     const trimmedReplyChannel = String(replyChannel || "").trim();
     const trimmedReplyTo = String(replyTo || "").trim();
     const runId = `doctor-fix-${Number(card.id || cardId)}-${crypto.randomUUID()}`;
+    const callbackToken = crypto.randomBytes(32).toString("hex");
+    const workingCard = startDoctorCardFix({
+      id: card.id,
+      runId,
+      tokenHash: hashDoctorFixToken(callbackToken),
+    });
+    if (!workingCard) throw new Error("Doctor card not found");
+    const completionInstructions = buildDoctorFixCompletionInstructions({
+      cardId: card.id,
+      runId,
+      token: callbackToken,
+      callbackBaseUrl,
+    });
     const gatewayParams = {
       idempotencyKey: runId,
-      message: resolvedPrompt,
+      message: `${resolvedPrompt}\n\n${completionInstructions}`,
       sessionKey: trimmedSessionKey,
     };
     if (trimmedReplyChannel && trimmedReplyTo) {
@@ -411,16 +456,23 @@ const createDoctorService = ({
       gatewayParams.replyChannel = trimmedReplyChannel;
       gatewayParams.replyTo = trimmedReplyTo;
     }
-    const result = await clawCmd(
-      `gateway call agent --json --timeout ${kDoctorFixDispatchTimeoutMs} --params ${shellEscapeArg(
-        JSON.stringify(gatewayParams),
-      )}`,
-      {
-        quiet: true,
-        timeoutMs: kDoctorFixDispatchTimeoutMs,
-      },
-    );
+    let result = null;
+    try {
+      result = await clawCmd(
+        `gateway call agent --json --timeout ${kDoctorFixDispatchTimeoutMs} --params ${shellEscapeArg(
+          JSON.stringify(gatewayParams),
+        )}`,
+        {
+          quiet: true,
+          timeoutMs: kDoctorFixDispatchTimeoutMs,
+        },
+      );
+    } catch (error) {
+      cancelDoctorCardFix({ id: card.id, runId });
+      throw error;
+    }
     if (!result?.ok) {
+      cancelDoctorCardFix({ id: card.id, runId });
       throw new Error(result?.stderr || "Could not send Doctor fix request");
     }
     return {
@@ -428,8 +480,23 @@ const createDoctorService = ({
       queued: true,
       runId,
       stdout: result.stdout || "",
-      card,
+      card: workingCard,
     };
+  };
+
+  const completeCardFix = ({ cardId, runId = "", token = "" } = {}) => {
+    const normalizedRunId = String(runId || "").trim();
+    const normalizedToken = String(token || "").trim();
+    if (!normalizedRunId || !normalizedToken) {
+      throw new Error("Invalid Doctor fix completion callback");
+    }
+    const completedCard = completeDoctorCardFix({
+      id: cardId,
+      runId: normalizedRunId,
+      tokenHash: hashDoctorFixToken(normalizedToken),
+    });
+    if (!completedCard) throw new Error("Invalid Doctor fix completion callback");
+    return { ok: true, card: completedCard };
   };
 
   const setCardStatus = ({ cardId, status }) => {
@@ -450,12 +517,14 @@ const createDoctorService = ({
     getDoctorRun,
     getDoctorCardsByRunId,
     requestCardFix,
+    completeCardFix,
     setCardStatus,
     getDoctorCard,
   };
 };
 
 module.exports = {
+  buildDoctorFixCompletionInstructions,
   buildDoctorIdempotencyKey,
   buildDoctorSessionKey,
   buildDoctorSessionId,

--- a/lib/server/doctor/service.js
+++ b/lib/server/doctor/service.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const {
@@ -17,6 +18,7 @@ const {
 } = require("./constants");
 
 const kMaxSnippetLines = 20;
+const kDoctorFixDispatchTimeoutMs = 30000;
 
 const shellEscapeArg = (value) => {
   const safeValue = String(value || "");
@@ -394,26 +396,38 @@ const createDoctorService = ({
     if (!card) throw new Error("Doctor card not found");
     const resolvedPrompt = String(prompt || card.fixPrompt || "").trim();
     if (!resolvedPrompt) throw new Error("Doctor card does not include a fix prompt");
-    let command = `agent --agent main --message ${shellEscapeArg(resolvedPrompt)}`;
     const trimmedSessionId = String(sessionId || "").trim();
     const trimmedReplyChannel = String(replyChannel || "").trim();
     const trimmedReplyTo = String(replyTo || "").trim();
+    const runId = `doctor-fix-${Number(card.id || cardId)}-${crypto.randomUUID()}`;
+    const gatewayParams = {
+      agentId: "main",
+      idempotencyKey: runId,
+      message: resolvedPrompt,
+    };
     if (trimmedReplyChannel && trimmedReplyTo) {
-      command +=
-        ` --deliver --reply-channel ${shellEscapeArg(trimmedReplyChannel)}` +
-        ` --reply-to ${shellEscapeArg(trimmedReplyTo)}`;
+      gatewayParams.deliver = true;
+      gatewayParams.replyChannel = trimmedReplyChannel;
+      gatewayParams.replyTo = trimmedReplyTo;
     } else if (trimmedSessionId) {
-      command += ` --session-id ${shellEscapeArg(trimmedSessionId)}`;
+      gatewayParams.sessionId = trimmedSessionId;
     }
-    const result = await clawCmd(command, {
-      quiet: true,
-      timeoutMs: kDoctorRunTimeoutMs,
-    });
+    const result = await clawCmd(
+      `gateway call agent --json --timeout ${kDoctorFixDispatchTimeoutMs} --params ${shellEscapeArg(
+        JSON.stringify(gatewayParams),
+      )}`,
+      {
+        quiet: true,
+        timeoutMs: kDoctorFixDispatchTimeoutMs,
+      },
+    );
     if (!result?.ok) {
       throw new Error(result?.stderr || "Could not send Doctor fix request");
     }
     return {
       ok: true,
+      queued: true,
+      runId,
       stdout: result.stdout || "",
       card,
     };

--- a/lib/server/routes/doctor.js
+++ b/lib/server/routes/doctor.js
@@ -1,6 +1,19 @@
 const { kDoctorCardStatus, kDoctorDefaultRunsLimit } = require("../doctor/constants");
 
 const registerDoctorRoutes = ({ app, requireAuth, doctorService }) => {
+  app.post("/api/doctor/findings/:id/complete", (req, res) => {
+    try {
+      const result = doctorService.completeCardFix({
+        cardId: req.params.id,
+        runId: req.body?.runId,
+        token: req.body?.token,
+      });
+      return res.json(result);
+    } catch {
+      return res.status(404).json({ ok: false, error: "Doctor fix callback not found" });
+    }
+  });
+
   app.get("/api/doctor/status", requireAuth, (req, res) => {
     try {
       res.json({ ok: true, status: doctorService.buildStatus() });

--- a/lib/server/routes/doctor.js
+++ b/lib/server/routes/doctor.js
@@ -1,19 +1,6 @@
 const { kDoctorCardStatus, kDoctorDefaultRunsLimit } = require("../doctor/constants");
 
 const registerDoctorRoutes = ({ app, requireAuth, doctorService }) => {
-  app.post("/api/doctor/findings/:id/complete", (req, res) => {
-    try {
-      const result = doctorService.completeCardFix({
-        cardId: req.params.id,
-        runId: req.body?.runId,
-        token: req.body?.token,
-      });
-      return res.json(result);
-    } catch {
-      return res.status(404).json({ ok: false, error: "Doctor fix callback not found" });
-    }
-  });
-
   app.get("/api/doctor/status", requireAuth, (req, res) => {
     try {
       res.json({ ok: true, status: doctorService.buildStatus() });
@@ -126,6 +113,9 @@ const registerDoctorRoutes = ({ app, requireAuth, doctorService }) => {
       });
       return res.status(result?.queued ? 202 : 200).json(result);
     } catch (error) {
+      if (/already in progress|must be open/i.test(error.message || "")) {
+        return res.status(409).json({ ok: false, error: error.message });
+      }
       if (/not found/i.test(error.message || "")) {
         return res.status(404).json({ ok: false, error: error.message });
       }

--- a/lib/server/routes/doctor.js
+++ b/lib/server/routes/doctor.js
@@ -111,7 +111,7 @@ const registerDoctorRoutes = ({ app, requireAuth, doctorService }) => {
         replyTo: req.body?.replyTo,
         prompt: req.body?.prompt,
       });
-      return res.json(result);
+      return res.status(result?.queued ? 202 : 200).json(result);
     } catch (error) {
       if (/not found/i.test(error.message || "")) {
         return res.status(404).json({ ok: false, error: error.message });

--- a/lib/server/routes/doctor.js
+++ b/lib/server/routes/doctor.js
@@ -106,7 +106,7 @@ const registerDoctorRoutes = ({ app, requireAuth, doctorService }) => {
     try {
       const result = await doctorService.requestCardFix({
         cardId: req.params.id,
-        sessionId: req.body?.sessionId,
+        sessionKey: req.body?.sessionKey,
         replyChannel: req.body?.replyChannel,
         replyTo: req.body?.replyTo,
         prompt: req.body?.prompt,

--- a/tests/bin/doctor-complete.test.js
+++ b/tests/bin/doctor-complete.test.js
@@ -1,0 +1,105 @@
+const crypto = require("crypto");
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const binPath = path.resolve(__dirname, "../../bin/alphaclaw.js");
+
+const loadDoctorDb = () => {
+  const modulePath = require.resolve("../../lib/server/db/doctor");
+  delete require.cache[modulePath];
+  return require(modulePath);
+};
+
+describe("alphaclaw doctor finding complete", () => {
+  let rootDir;
+  let doctorDb;
+
+  beforeEach(() => {
+    rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-doctor-cli-"));
+    doctorDb = loadDoctorDb();
+    doctorDb.initDoctorDb({ rootDir });
+  });
+
+  afterEach(() => {
+    doctorDb?.closeDoctorDb();
+    fs.rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it("uses a one-time token without failing an active Doctor run", () => {
+    const token = "one-time-completion-token";
+    const fixRunId = "doctor-fix-cli-test";
+    const doctorRunId = doctorDb.createDoctorRun({
+      engine: "gateway_agent",
+      workspaceRoot: "/tmp/workspace",
+      promptVersion: "doctor-v1",
+    });
+    doctorDb.insertDoctorCards({
+      runId: doctorRunId,
+      cards: [
+        {
+          priority: "P1",
+          category: "guidance",
+          title: "Fix guidance",
+          recommendation: "Update guidance",
+          fixPrompt: "Update it",
+          status: "open",
+        },
+      ],
+    });
+    const [card] = doctorDb.getDoctorCardsByRunId(doctorRunId);
+    doctorDb.startDoctorCardFix({
+      id: card.id,
+      runId: fixRunId,
+      tokenHash: crypto.createHash("sha256").update(token).digest("hex"),
+    });
+    doctorDb.closeDoctorDb();
+
+    const output = execFileSync(
+      process.execPath,
+      [
+        binPath,
+        "--root-dir",
+        rootDir,
+        "doctor",
+        "finding",
+        "complete",
+        "--id",
+        String(card.id),
+        "--run",
+        fixRunId,
+        "--token",
+        token,
+      ],
+      { encoding: "utf8", env: { ...process.env, ALPHACLAW_ROOT_DIR: rootDir } },
+    );
+
+    expect(output).toContain(`Doctor finding ${card.id} marked fixed`);
+    doctorDb.initDoctorDb({ rootDir, markInterruptedRuns: false });
+    expect(doctorDb.getDoctorCard(card.id).status).toBe("fixed");
+    expect(doctorDb.getDoctorRun(doctorRunId).status).toBe("running");
+    doctorDb.closeDoctorDb();
+
+    expect(() =>
+      execFileSync(
+        process.execPath,
+        [
+          binPath,
+          "--root-dir",
+          rootDir,
+          "doctor",
+          "finding",
+          "complete",
+          "--id",
+          String(card.id),
+          "--run",
+          fixRunId,
+          "--token",
+          token,
+        ],
+        { stdio: "pipe", env: { ...process.env, ALPHACLAW_ROOT_DIR: rootDir } },
+      ),
+    ).toThrow();
+  });
+});

--- a/tests/frontend/api.test.js
+++ b/tests/frontend/api.test.js
@@ -309,7 +309,7 @@ describe("frontend/api", () => {
 
     const result = await api.sendDoctorCardFix({
       cardId: 7,
-      sessionId: "session-123",
+      sessionKey: "agent:main:telegram:direct:1050",
       replyChannel: "telegram",
       replyTo: "1050",
       prompt: "Use a more focused fix request",
@@ -320,7 +320,7 @@ describe("frontend/api", () => {
       expect.objectContaining({
         method: "POST",
         body: JSON.stringify({
-          sessionId: "session-123",
+          sessionKey: "agent:main:telegram:direct:1050",
           replyChannel: "telegram",
           replyTo: "1050",
           prompt: "Use a more focused fix request",

--- a/tests/frontend/doctor-helpers.test.js
+++ b/tests/frontend/doctor-helpers.test.js
@@ -9,18 +9,20 @@ describe("frontend/doctor helpers", () => {
       { id: 2, priority: "P1", status: "dismissed" },
       { id: 3, priority: "P2", status: "fixed" },
       { id: 4, priority: "P2", status: "open" },
+      { id: 5, priority: "P2", status: "working" },
     ];
 
     expect(helpers.buildDoctorPriorityCounts(cards)).toEqual({
       P0: 1,
       P1: 1,
-      P2: 2,
+      P2: 3,
     });
     expect(helpers.groupDoctorCardsByStatus(cards)).toEqual({
       open: [
         { id: 1, priority: "P0", status: "open" },
         { id: 4, priority: "P2", status: "open" },
       ],
+      working: [{ id: 5, priority: "P2", status: "working" }],
       dismissed: [{ id: 2, priority: "P1", status: "dismissed" }],
       fixed: [{ id: 3, priority: "P2", status: "fixed" }],
     });
@@ -123,8 +125,10 @@ describe("frontend/doctor helpers", () => {
       "1 change since last run",
     );
     expect(helpers.getDoctorStatusTone("fixed")).toBe("success");
+    expect(helpers.getDoctorStatusTone("working")).toBe("info");
     expect(helpers.buildDoctorStatusFilterOptions()).toEqual([
       { value: "open", label: "Open" },
+      { value: "working", label: "Working" },
       { value: "dismissed", label: "Dismissed" },
       { value: "fixed", label: "Fixed" },
     ]);

--- a/tests/server/doctor-db.test.js
+++ b/tests/server/doctor-db.test.js
@@ -53,6 +53,9 @@ describe("server/doctor-db", () => {
       getLatestDoctorRun,
       getDoctorCardsByRunId,
       setInitialWorkspaceBaseline,
+      startDoctorCardFix,
+      cancelDoctorCardFix,
+      completeDoctorCardFix,
       updateDoctorCardStatus,
     } = createDoctorDbContext("doctor-db-cards-");
     setInitialWorkspaceBaseline({
@@ -119,7 +122,7 @@ describe("server/doctor-db", () => {
     expect(run.reusedFromRunId).toBe(9);
     expect(run.cardCount).toBe(2);
     expect(run.priorityCounts).toEqual({ P0: 1, P1: 0, P2: 1 });
-    expect(run.statusCounts).toEqual({ open: 1, dismissed: 1, fixed: 0 });
+    expect(run.statusCounts).toEqual({ open: 1, working: 0, dismissed: 1, fixed: 0 });
     expect(cards).toHaveLength(2);
     expect(latestRun.id).toBe(runId);
 
@@ -128,5 +131,62 @@ describe("server/doctor-db", () => {
       status: kDoctorCardStatus.fixed,
     });
     expect(updatedCard.status).toBe(kDoctorCardStatus.fixed);
+
+    const workingCard = startDoctorCardFix({
+      id: cards[1].id,
+      runId: "doctor-fix-test",
+      tokenHash: "token-hash",
+    });
+    expect(workingCard.status).toBe(kDoctorCardStatus.working);
+    expect(
+      completeDoctorCardFix({
+        id: cards[1].id,
+        runId: "wrong-run",
+        tokenHash: "token-hash",
+      }),
+    ).toBeNull();
+    expect(
+      completeDoctorCardFix({
+        id: cards[1].id,
+        runId: "doctor-fix-test",
+        tokenHash: "wrong-token",
+      }),
+    ).toBeNull();
+    const completedCard = completeDoctorCardFix({
+      id: cards[1].id,
+      runId: "doctor-fix-test",
+      tokenHash: "token-hash",
+    });
+    expect(completedCard.status).toBe(kDoctorCardStatus.fixed);
+    expect(
+      completeDoctorCardFix({
+        id: cards[1].id,
+        runId: "doctor-fix-test",
+        tokenHash: "token-hash",
+      }),
+    ).toBeNull();
+
+    startDoctorCardFix({
+      id: cards[1].id,
+      runId: "doctor-fix-cancel",
+      tokenHash: "cancel-token-hash",
+    });
+    expect(
+      cancelDoctorCardFix({ id: cards[1].id, runId: "doctor-fix-cancel" }).status,
+    ).toBe(kDoctorCardStatus.open);
+
+    startDoctorCardFix({
+      id: cards[1].id,
+      runId: "doctor-fix-manual-reopen",
+      tokenHash: "manual-reopen-token-hash",
+    });
+    updateDoctorCardStatus({ id: cards[1].id, status: kDoctorCardStatus.open });
+    expect(
+      completeDoctorCardFix({
+        id: cards[1].id,
+        runId: "doctor-fix-manual-reopen",
+        tokenHash: "manual-reopen-token-hash",
+      }),
+    ).toBeNull();
   });
 });

--- a/tests/server/doctor-db.test.js
+++ b/tests/server/doctor-db.test.js
@@ -132,12 +132,23 @@ describe("server/doctor-db", () => {
     });
     expect(updatedCard.status).toBe(kDoctorCardStatus.fixed);
 
+    updateDoctorCardStatus({
+      id: cards[1].id,
+      status: kDoctorCardStatus.open,
+    });
     const workingCard = startDoctorCardFix({
       id: cards[1].id,
       runId: "doctor-fix-test",
       tokenHash: "token-hash",
     });
     expect(workingCard.status).toBe(kDoctorCardStatus.working);
+    expect(
+      startDoctorCardFix({
+        id: cards[1].id,
+        runId: "doctor-fix-concurrent",
+        tokenHash: "concurrent-token-hash",
+      }),
+    ).toBeNull();
     expect(
       completeDoctorCardFix({
         id: cards[1].id,
@@ -166,6 +177,10 @@ describe("server/doctor-db", () => {
       }),
     ).toBeNull();
 
+    updateDoctorCardStatus({
+      id: cards[1].id,
+      status: kDoctorCardStatus.open,
+    });
     startDoctorCardFix({
       id: cards[1].id,
       runId: "doctor-fix-cancel",

--- a/tests/server/doctor-service.test.js
+++ b/tests/server/doctor-service.test.js
@@ -187,10 +187,9 @@ describe("server/doctor-service", () => {
       updateDoctorCardStatus: doctorDb.updateDoctorCardStatus,
       startDoctorCardFix: doctorDb.startDoctorCardFix,
       cancelDoctorCardFix: doctorDb.cancelDoctorCardFix,
-      completeDoctorCardFix: doctorDb.completeDoctorCardFix,
       workspaceRoot,
       managedRoot: workspaceRoot,
-      callbackBaseUrl: "http://127.0.0.1:3456",
+      alphaclawRootDir: "/data",
     });
     const imported = doctorService.importDoctorResult({
       rawOutput: JSON.stringify({
@@ -231,11 +230,25 @@ describe("server/doctor-service", () => {
     expect(command).not.toContain('"sessionId"');
     expect(command).not.toContain('"deliver":true');
     expect(command).toContain("AlphaClaw completion callback:");
-    expect(command).toContain(
-      `http://127.0.0.1:3456/api/doctor/findings/${card.id}/complete`,
-    );
+    expect(command).toContain("alphaclaw --root-dir");
+    expect(command).toContain("/data");
+    expect(command).toContain("doctor finding complete");
+    expect(command).toContain(`--id`);
+    expect(command).toContain(result.runId);
+    expect(command).toContain("--token");
     expect(command).toContain("Do not call the completion callback");
     expect(doctorDb.getDoctorCard(card.id).status).toBe("working");
+
+    await expect(
+      doctorService.requestCardFix({
+        cardId: card.id,
+        sessionKey: "agent:main:doctor:42",
+        prompt: "Apply the safe fix again.",
+      }),
+    ).rejects.toThrow("Doctor fix already in progress");
+    expect(clawCmd).toHaveBeenCalledTimes(1);
+
+    doctorDb.updateDoctorCardStatus({ id: card.id, status: "open" });
 
     await doctorService.requestCardFix({
       cardId: card.id,
@@ -255,6 +268,7 @@ describe("server/doctor-service", () => {
     expect(deliveryCommand).toContain('"replyTo":"1050"');
     expect(deliveryCommand).not.toContain('"sessionId"');
 
+    doctorDb.updateDoctorCardStatus({ id: card.id, status: "open" });
     clawCmd.mockResolvedValueOnce({
       ok: false,
       stderr: "gateway unavailable",

--- a/tests/server/doctor-service.test.js
+++ b/tests/server/doctor-service.test.js
@@ -202,9 +202,7 @@ describe("server/doctor-service", () => {
 
     const result = await doctorService.requestCardFix({
       cardId: card.id,
-      sessionId: "session-123",
-      replyChannel: "telegram",
-      replyTo: "1050",
+      sessionKey: "agent:main:doctor:42",
       prompt: "Apply the safe fix.",
     });
 
@@ -216,9 +214,37 @@ describe("server/doctor-service", () => {
     expect(command).toContain("gateway call agent --json");
     expect(command).not.toContain("--expect-final");
     expect(command).toContain('"message":"Apply the safe fix."');
-    expect(command).toContain('"deliver":true');
-    expect(command).toContain('"replyChannel":"telegram"');
-    expect(command).toContain('"replyTo":"1050"');
+    expect(command).toContain('"sessionKey":"agent:main:doctor:42"');
+    expect(command).not.toContain('"agentId":"main"');
+    expect(command).not.toContain('"sessionId"');
+    expect(command).not.toContain('"deliver":true');
+    expect(doctorDb.getDoctorCard(card.id).status).toBe("open");
+
+    await doctorService.requestCardFix({
+      cardId: card.id,
+      sessionKey: "agent:main:telegram:direct:1050",
+      replyChannel: "telegram",
+      replyTo: "1050",
+      prompt: "Apply the safe fix.",
+    });
+
+    expect(clawCmd).toHaveBeenCalledTimes(2);
+    const deliveryCommand = clawCmd.mock.calls[1][0];
+    expect(deliveryCommand).toContain(
+      '"sessionKey":"agent:main:telegram:direct:1050"',
+    );
+    expect(deliveryCommand).toContain('"deliver":true');
+    expect(deliveryCommand).toContain('"replyChannel":"telegram"');
+    expect(deliveryCommand).toContain('"replyTo":"1050"');
+    expect(deliveryCommand).not.toContain('"sessionId"');
+
+    await expect(
+      doctorService.requestCardFix({
+        cardId: card.id,
+        prompt: "Apply the safe fix.",
+      }),
+    ).rejects.toThrow("Doctor fix request requires a session key");
+    expect(clawCmd).toHaveBeenCalledTimes(2);
   });
 
   it("does not suppress previously fixed findings on later Doctor runs", async () => {

--- a/tests/server/doctor-service.test.js
+++ b/tests/server/doctor-service.test.js
@@ -151,6 +151,76 @@ describe("server/doctor-service", () => {
     );
   });
 
+  it("queues Doctor card fixes through the gateway without waiting for the agent", async () => {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "doctor-fix-workspace-"));
+    const dbRoot = fs.mkdtempSync(path.join(os.tmpdir(), "doctor-fix-db-"));
+    fs.writeFileSync(path.join(workspaceRoot, "AGENTS.md"), "# Workspace Guidance\n", "utf8");
+
+    const doctorDb = loadManagedDoctorDb();
+    doctorDb.initDoctorDb({ rootDir: dbRoot });
+    const clawCmd = vi.fn(async () => ({
+      ok: true,
+      stdout: JSON.stringify({ status: "accepted", runId: "gateway-run" }),
+      stderr: "",
+    }));
+    const { createDoctorService } = loadDoctorService();
+    const doctorService = createDoctorService({
+      clawCmd,
+      listDoctorRuns: doctorDb.listDoctorRuns,
+      listDoctorCards: doctorDb.listDoctorCards,
+      getInitialWorkspaceBaseline: doctorDb.getInitialWorkspaceBaseline,
+      setInitialWorkspaceBaseline: doctorDb.setInitialWorkspaceBaseline,
+      createDoctorRun: doctorDb.createDoctorRun,
+      completeDoctorRun: doctorDb.completeDoctorRun,
+      insertDoctorCards: doctorDb.insertDoctorCards,
+      getDoctorRun: doctorDb.getDoctorRun,
+      getDoctorCardsByRunId: doctorDb.getDoctorCardsByRunId,
+      getDoctorCard: doctorDb.getDoctorCard,
+      updateDoctorCardStatus: doctorDb.updateDoctorCardStatus,
+      workspaceRoot,
+      managedRoot: workspaceRoot,
+    });
+    const imported = doctorService.importDoctorResult({
+      rawOutput: JSON.stringify({
+        summary: "One finding",
+        cards: [
+          {
+            priority: "P1",
+            category: "guidance",
+            title: "Fix guidance drift",
+            summary: "The guidance is stale",
+            recommendation: "Update it",
+            evidence: [{ type: "path", path: "AGENTS.md" }],
+            targetPaths: ["AGENTS.md"],
+            fixPrompt: "Update the stale guidance.",
+            status: "open",
+          },
+        ],
+      }),
+    });
+    const [card] = doctorDb.getDoctorCardsByRunId(imported.runId);
+
+    const result = await doctorService.requestCardFix({
+      cardId: card.id,
+      sessionId: "session-123",
+      replyChannel: "telegram",
+      replyTo: "1050",
+      prompt: "Apply the safe fix.",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.queued).toBe(true);
+    expect(result.runId).toMatch(new RegExp(`^doctor-fix-${card.id}-`));
+    expect(clawCmd).toHaveBeenCalledTimes(1);
+    const command = clawCmd.mock.calls[0][0];
+    expect(command).toContain("gateway call agent --json");
+    expect(command).not.toContain("--expect-final");
+    expect(command).toContain('"message":"Apply the safe fix."');
+    expect(command).toContain('"deliver":true');
+    expect(command).toContain('"replyChannel":"telegram"');
+    expect(command).toContain('"replyTo":"1050"');
+  });
+
   it("does not suppress previously fixed findings on later Doctor runs", async () => {
     const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), "doctor-fixed-rerun-workspace-"));
     const dbRoot = fs.mkdtempSync(path.join(os.tmpdir(), "doctor-fixed-rerun-db-"));

--- a/tests/server/doctor-service.test.js
+++ b/tests/server/doctor-service.test.js
@@ -86,6 +86,12 @@ describe("server/doctor-service", () => {
         ],
       }),
     });
+    const [workingSourceCard] = doctorDb.getDoctorCardsByRunId(imported.runId);
+    doctorDb.startDoctorCardFix({
+      id: workingSourceCard.id,
+      runId: "doctor-fix-active",
+      tokenHash: "active-token-hash",
+    });
 
     const rerun = doctorService.runDoctor();
     const latestRun = doctorDb.getDoctorRun(rerun.runId);
@@ -98,7 +104,9 @@ describe("server/doctor-service", () => {
     expect(latestRun.engine).toBe("deterministic_reuse");
     expect(latestRun.reusedFromRunId).toBe(imported.runId);
     expect(latestRun.summary).toMatch(/^No workspace changes since last scan/);
-    expect(doctorDb.getDoctorCardsByRunId(rerun.runId)).toHaveLength(1);
+    expect(doctorDb.getDoctorCardsByRunId(rerun.runId)).toEqual([
+      expect.objectContaining({ status: "open" }),
+    ]);
   });
 
   it("runs Doctor analysis in a dedicated doctor session", async () => {
@@ -177,8 +185,12 @@ describe("server/doctor-service", () => {
       getDoctorCardsByRunId: doctorDb.getDoctorCardsByRunId,
       getDoctorCard: doctorDb.getDoctorCard,
       updateDoctorCardStatus: doctorDb.updateDoctorCardStatus,
+      startDoctorCardFix: doctorDb.startDoctorCardFix,
+      cancelDoctorCardFix: doctorDb.cancelDoctorCardFix,
+      completeDoctorCardFix: doctorDb.completeDoctorCardFix,
       workspaceRoot,
       managedRoot: workspaceRoot,
+      callbackBaseUrl: "http://127.0.0.1:3456",
     });
     const imported = doctorService.importDoctorResult({
       rawOutput: JSON.stringify({
@@ -213,12 +225,17 @@ describe("server/doctor-service", () => {
     const command = clawCmd.mock.calls[0][0];
     expect(command).toContain("gateway call agent --json");
     expect(command).not.toContain("--expect-final");
-    expect(command).toContain('"message":"Apply the safe fix."');
+    expect(command).toContain('"message":"Apply the safe fix.\\n\\n');
     expect(command).toContain('"sessionKey":"agent:main:doctor:42"');
     expect(command).not.toContain('"agentId":"main"');
     expect(command).not.toContain('"sessionId"');
     expect(command).not.toContain('"deliver":true');
-    expect(doctorDb.getDoctorCard(card.id).status).toBe("open");
+    expect(command).toContain("AlphaClaw completion callback:");
+    expect(command).toContain(
+      `http://127.0.0.1:3456/api/doctor/findings/${card.id}/complete`,
+    );
+    expect(command).toContain("Do not call the completion callback");
+    expect(doctorDb.getDoctorCard(card.id).status).toBe("working");
 
     await doctorService.requestCardFix({
       cardId: card.id,
@@ -238,13 +255,26 @@ describe("server/doctor-service", () => {
     expect(deliveryCommand).toContain('"replyTo":"1050"');
     expect(deliveryCommand).not.toContain('"sessionId"');
 
+    clawCmd.mockResolvedValueOnce({
+      ok: false,
+      stderr: "gateway unavailable",
+    });
+    await expect(
+      doctorService.requestCardFix({
+        cardId: card.id,
+        sessionKey: "agent:main:doctor:42",
+        prompt: "Apply the safe fix.",
+      }),
+    ).rejects.toThrow("gateway unavailable");
+    expect(doctorDb.getDoctorCard(card.id).status).toBe("open");
+
     await expect(
       doctorService.requestCardFix({
         cardId: card.id,
         prompt: "Apply the safe fix.",
       }),
     ).rejects.toThrow("Doctor fix request requires a session key");
-    expect(clawCmd).toHaveBeenCalledTimes(2);
+    expect(clawCmd).toHaveBeenCalledTimes(3);
   });
 
   it("does not suppress previously fixed findings on later Doctor runs", async () => {

--- a/tests/server/routes-doctor.test.js
+++ b/tests/server/routes-doctor.test.js
@@ -36,13 +36,15 @@ const createDoctorService = () => ({
     id: Number(cardId),
     status,
   })),
-  requestCardFix: vi.fn(async ({ cardId, sessionId, replyChannel, replyTo }) => ({
-    ok: true,
-    queued: true,
-    runId: "doctor-fix-7-test",
-    stdout: "sent",
-    card: { id: Number(cardId), sessionId, replyChannel, replyTo },
-  })),
+  requestCardFix: vi.fn(
+    async ({ cardId, sessionKey, replyChannel, replyTo }) => ({
+      ok: true,
+      queued: true,
+      runId: "doctor-fix-7-test",
+      stdout: "sent",
+      card: { id: Number(cardId), sessionKey, replyChannel, replyTo },
+    }),
+  ),
 });
 
 const createApp = (doctorService) => {
@@ -175,7 +177,7 @@ describe("server/routes/doctor", () => {
     const app = createApp(doctorService);
 
     const res = await request(app).post("/api/doctor/findings/7/fix").send({
-      sessionId: "session-123",
+      sessionKey: "agent:main:telegram:direct:1050",
       replyChannel: "telegram",
       replyTo: "1050",
       prompt: "Use the safer prompt",
@@ -184,7 +186,7 @@ describe("server/routes/doctor", () => {
     expect(res.status).toBe(202);
     expect(doctorService.requestCardFix).toHaveBeenCalledWith({
       cardId: "7",
-      sessionId: "session-123",
+      sessionKey: "agent:main:telegram:direct:1050",
       replyChannel: "telegram",
       replyTo: "1050",
       prompt: "Use the safer prompt",

--- a/tests/server/routes-doctor.test.js
+++ b/tests/server/routes-doctor.test.js
@@ -36,6 +36,10 @@ const createDoctorService = () => ({
     id: Number(cardId),
     status,
   })),
+  completeCardFix: vi.fn(({ cardId, runId }) => ({
+    ok: true,
+    card: { id: Number(cardId), status: "fixed", runId },
+  })),
   requestCardFix: vi.fn(
     async ({ cardId, sessionKey, replyChannel, replyTo }) => ({
       ok: true,
@@ -59,6 +63,43 @@ const createApp = (doctorService) => {
 };
 
 describe("server/routes/doctor", () => {
+  it("completes a Doctor fix through its scoped callback", async () => {
+    const doctorService = createDoctorService();
+    const app = createApp(doctorService);
+
+    const res = await request(app).post("/api/doctor/findings/7/complete").send({
+      runId: "doctor-fix-7-test",
+      token: "one-time-token",
+    });
+
+    expect(res.status).toBe(200);
+    expect(doctorService.completeCardFix).toHaveBeenCalledWith({
+      cardId: "7",
+      runId: "doctor-fix-7-test",
+      token: "one-time-token",
+    });
+    expect(res.body.card.status).toBe("fixed");
+  });
+
+  it("does not reveal details for an invalid Doctor fix callback", async () => {
+    const doctorService = createDoctorService();
+    doctorService.completeCardFix.mockImplementation(() => {
+      throw new Error("Invalid Doctor fix completion callback");
+    });
+    const app = createApp(doctorService);
+
+    const res = await request(app).post("/api/doctor/findings/7/complete").send({
+      runId: "wrong-run",
+      token: "wrong-token",
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({
+      ok: false,
+      error: "Doctor fix callback not found",
+    });
+  });
+
   it("returns Doctor status", async () => {
     const doctorService = createDoctorService();
     const app = createApp(doctorService);

--- a/tests/server/routes-doctor.test.js
+++ b/tests/server/routes-doctor.test.js
@@ -38,6 +38,8 @@ const createDoctorService = () => ({
   })),
   requestCardFix: vi.fn(async ({ cardId, sessionId, replyChannel, replyTo }) => ({
     ok: true,
+    queued: true,
+    runId: "doctor-fix-7-test",
     stdout: "sent",
     card: { id: Number(cardId), sessionId, replyChannel, replyTo },
   })),
@@ -179,7 +181,7 @@ describe("server/routes/doctor", () => {
       prompt: "Use the safer prompt",
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(202);
     expect(doctorService.requestCardFix).toHaveBeenCalledWith({
       cardId: "7",
       sessionId: "session-123",

--- a/tests/server/routes-doctor.test.js
+++ b/tests/server/routes-doctor.test.js
@@ -36,10 +36,6 @@ const createDoctorService = () => ({
     id: Number(cardId),
     status,
   })),
-  completeCardFix: vi.fn(({ cardId, runId }) => ({
-    ok: true,
-    card: { id: Number(cardId), status: "fixed", runId },
-  })),
   requestCardFix: vi.fn(
     async ({ cardId, sessionKey, replyChannel, replyTo }) => ({
       ok: true,
@@ -63,43 +59,6 @@ const createApp = (doctorService) => {
 };
 
 describe("server/routes/doctor", () => {
-  it("completes a Doctor fix through its scoped callback", async () => {
-    const doctorService = createDoctorService();
-    const app = createApp(doctorService);
-
-    const res = await request(app).post("/api/doctor/findings/7/complete").send({
-      runId: "doctor-fix-7-test",
-      token: "one-time-token",
-    });
-
-    expect(res.status).toBe(200);
-    expect(doctorService.completeCardFix).toHaveBeenCalledWith({
-      cardId: "7",
-      runId: "doctor-fix-7-test",
-      token: "one-time-token",
-    });
-    expect(res.body.card.status).toBe("fixed");
-  });
-
-  it("does not reveal details for an invalid Doctor fix callback", async () => {
-    const doctorService = createDoctorService();
-    doctorService.completeCardFix.mockImplementation(() => {
-      throw new Error("Invalid Doctor fix completion callback");
-    });
-    const app = createApp(doctorService);
-
-    const res = await request(app).post("/api/doctor/findings/7/complete").send({
-      runId: "wrong-run",
-      token: "wrong-token",
-    });
-
-    expect(res.status).toBe(404);
-    expect(res.body).toEqual({
-      ok: false,
-      error: "Doctor fix callback not found",
-    });
-  });
-
   it("returns Doctor status", async () => {
     const doctorService = createDoctorService();
     const app = createApp(doctorService);
@@ -233,5 +192,21 @@ describe("server/routes/doctor", () => {
       prompt: "Use the safer prompt",
     });
     expect(res.body.ok).toBe(true);
+  });
+
+  it("returns 409 when a Doctor fix is already in progress", async () => {
+    const doctorService = createDoctorService();
+    doctorService.requestCardFix.mockRejectedValue(
+      new Error("Doctor fix already in progress"),
+    );
+    const app = createApp(doctorService);
+
+    const res = await request(app).post("/api/doctor/findings/7/fix").send({
+      sessionKey: "agent:main:doctor:42",
+      prompt: "Try again",
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("Doctor fix already in progress");
   });
 });


### PR DESCRIPTION
## Summary
- dispatch Drift Doctor fix requests through the gateway acknowledgement path
- return HTTP 202 as soon as the agent run is accepted
- preserve delivery to the selected session or channel and clarify queued UI feedback
- add service and route coverage for asynchronous dispatch

## Testing
- `npm run build:ui`
- `npm test` (98 files, 692 tests)