### PR TITLE
onboarding: write ALPHACLAW_ROOT_DIR into the generated system cron file

### DIFF
--- a/lib/server/onboarding/cron.js
+++ b/lib/server/onboarding/cron.js
@@ -1,5 +1,5 @@
 const path = require("path");
-const { kSetupDir } = require("../constants");
+const { kSetupDir, kRootDir } = require("../constants");
 const { buildManagedPaths } = require("../internal-files-migration");
 const { shouldSkipSystemCronInstall } = require("../../cli/git-runtime");
 
@@ -13,6 +13,7 @@ const buildSystemCronFile = ({ schedule, scriptPath }) =>
   [
     "SHELL=/bin/bash",
     "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    `ALPHACLAW_ROOT_DIR=${kRootDir}`,
     `${schedule} root bash "${scriptPath}" >> /var/log/openclaw-hourly-sync.log 2>&1`,
     "",
   ].join("\n");

--- a/tests/server/onboarding-cron.test.js
+++ b/tests/server/onboarding-cron.test.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { kRootDir } = require("../../lib/server/constants");
+const {
+  installHourlyGitSyncCron,
+} = require("../../lib/server/onboarding/cron");
+
+const kSystemCronPath = "/etc/cron.d/openclaw-hourly-sync";
+
+const createMockFs = () => {
+  const writes = {};
+  return {
+    writes,
+    fs: {
+      mkdirSync: (dir, opts) => fs.mkdirSync(dir, opts),
+      writeFileSync: (target, data, opts) => {
+        const t = String(target || "");
+        writes[t] = String(data);
+        if (t.startsWith("/etc/cron.d/")) return;
+        return fs.writeFileSync(target, data, opts);
+      },
+      readFileSync: (...args) => fs.readFileSync(...args),
+    },
+  };
+};
+
+describe("server/onboarding/cron", () => {
+  it("writes ALPHACLAW_ROOT_DIR into the generated system cron file", async () => {
+    const openclawDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "alphaclaw-onboard-cron-"),
+    );
+    const { fs: mockFs, writes } = createMockFs();
+
+    const installed = await installHourlyGitSyncCron({
+      fs: mockFs,
+      openclawDir,
+    });
+
+    expect(installed).toBe(true);
+    const cronContent = writes[kSystemCronPath];
+    expect(cronContent).toBeDefined();
+    // cron applies no environment beyond what this file declares; without
+    // ALPHACLAW_ROOT_DIR the CLI resolves os.homedir()/.alphaclaw and the
+    // hourly sync no-ops against a phantom install (issue #105).
+    expect(cronContent).toContain(`ALPHACLAW_ROOT_DIR=${kRootDir}`);
+    expect(cronContent).toContain("SHELL=/bin/bash");
+    expect(cronContent).toMatch(/^0 \* \* \* \* root bash /m);
+    // /etc/cron.d files without a trailing newline are ignored by cron.
+    expect(cronContent.endsWith("\n")).toBe(true);
+  });
+});


### PR DESCRIPTION
**What:** `buildSystemCronFile` now emits `ALPHACLAW_ROOT_DIR=<resolved root>` alongside `SHELL` and `PATH`. Adds a unit test asserting the generated file's contents (root-dir line, env preamble, schedule line, trailing newline).

**Why:** Fixes #105. cron applies no environment beyond what the cron file declares, so on any deployment where the install root ≠ the cron user's homedir (including containers built from this repo's own Dockerfile template), the hourly sync CLI falls back to `os.homedir()/.alphaclaw` — a phantom install — and silently no-ops every hour. A HOME-based fix is insufficient since the fallback appends `/.alphaclaw`; the root dir itself must reach the job's environment.

**How to test:** `npx vitest run tests/server/onboarding-cron.test.js` (new), `npm test` (100 files / 701 tests passing). Verified live on a Docker deployment from the README template: with the variable present in the cron job's environment, the hourly run logs `Root directory: /data`, loads the real `.env`, and commits normally — previously it logged `No git repository` hourly since first boot.