### PR TITLE
Add stable IDs to webhook mappings

### DIFF
--- a/lib/server/init/register-server-routes.js
+++ b/lib/server/init/register-server-routes.js
@@ -14,6 +14,7 @@ const { registerWebhookRoutes } = require("../routes/webhooks");
 const { registerWatchdogRoutes } = require("../routes/watchdog");
 const { registerUsageRoutes } = require("../routes/usage");
 const { registerGmailRoutes } = require("../routes/gmail");
+const { ensureWebhookMappingIds } = require("../webhooks");
 const { registerDoctorRoutes } = require("../routes/doctor");
 const { registerAgentRoutes } = require("../routes/agents");
 const { registerCronRoutes } = require("../routes/cron");
@@ -178,6 +179,7 @@ const registerServerRoutes = ({
     runOnboardedBootSequence({
       ensureManagedExecDefaults,
       ensureUsageTrackerPluginConfig,
+      ensureWebhookMappingIds: () => ensureWebhookMappingIds({ fs, constants }),
       doSyncPromptFiles,
       reloadEnv,
       syncChannelConfig,

--- a/lib/server/startup.js
+++ b/lib/server/startup.js
@@ -1,6 +1,7 @@
 const runOnboardedBootSequence = ({
   ensureManagedExecDefaults,
   ensureUsageTrackerPluginConfig,
+  ensureWebhookMappingIds,
   doSyncPromptFiles,
   reloadEnv,
   syncChannelConfig,
@@ -23,6 +24,18 @@ const runOnboardedBootSequence = ({
   } catch (error) {
     console.error(
       `[alphaclaw] Failed to ensure usage-tracker plugin config on boot: ${error.message}`,
+    );
+  }
+  try {
+    const result = ensureWebhookMappingIds();
+    if (result?.changed) {
+      console.log(
+        `[alphaclaw] Added IDs to webhook mappings: ${result.updatedIds.join(", ")}`,
+      );
+    }
+  } catch (error) {
+    console.error(
+      `[alphaclaw] Failed to ensure webhook mapping IDs on boot: ${error.message}`,
     );
   }
   doSyncPromptFiles();

--- a/lib/server/webhooks.js
+++ b/lib/server/webhooks.js
@@ -78,6 +78,10 @@ const ensureHooksRoot = (cfg) => {
 
 const getMappingHookName = (mapping) =>
   String(mapping?.match?.path || "").trim();
+const getMappingIdFromPath = (mapping) => {
+  const hookPath = getMappingHookName(mapping).replace(/^\/+|\/+$/g, "");
+  return kNamePattern.test(hookPath) ? hookPath : "";
+};
 const isWebhookMapping = (mapping) => !!getMappingHookName(mapping);
 const findMappingIndexByName = (mappings, name) =>
   mappings.findIndex((mapping) => getMappingHookName(mapping) === name);
@@ -142,6 +146,25 @@ const normalizeMappingTransformModules = (mappings) => {
   return changed;
 };
 
+const ensureWebhookMappingIds = ({ fs, constants }) => {
+  const { cfg, configPath } = readConfig({ fs, constants });
+  const mappings = Array.isArray(cfg?.hooks?.mappings)
+    ? cfg.hooks.mappings
+    : [];
+  const updatedIds = [];
+  for (const mapping of mappings) {
+    if (String(mapping?.id || "").trim()) continue;
+    const id = getMappingIdFromPath(mapping);
+    if (!id) continue;
+    mapping.id = id;
+    updatedIds.push(id);
+  }
+  if (updatedIds.length > 0) {
+    writeConfig({ fs, configPath, cfg });
+  }
+  return { changed: updatedIds.length > 0, updatedIds };
+};
+
 const buildDefaultTransformSource = (name) => {
   return [
     "export default async function transform(payload, context) {",
@@ -188,6 +211,7 @@ const ensureWebhookMapping = ({ cfg, name, mapping = {} }) => {
   const normalizedModulesChanged = normalizeMappingTransformModules(mappings);
   const index = findMappingIndexByName(mappings, webhookName);
   const defaults = {
+    id: webhookName,
     match: { path: webhookName },
     action: "agent",
     name: webhookName,
@@ -198,6 +222,7 @@ const ensureWebhookMapping = ({ cfg, name, mapping = {} }) => {
     mappings.push({
       ...defaults,
       ...mapping,
+      id: webhookName,
       match: { ...defaults.match, ...(mapping.match || {}) },
       transform: { ...defaults.transform, ...(mapping.transform || {}) },
     });
@@ -207,6 +232,7 @@ const ensureWebhookMapping = ({ cfg, name, mapping = {} }) => {
   const next = {
     ...current,
     ...mapping,
+    id: webhookName,
     match: {
       ...(current.match || {}),
       ...(mapping.match || {}),
@@ -436,6 +462,7 @@ const updateWebhookDestination = ({ fs, constants, name, destination = null }) =
   });
   const next = {
     ...current,
+    id: webhookName,
     deliver: true,
     channel:
       String(normalizedDestination?.channel || "").trim() ||
@@ -499,6 +526,7 @@ const deleteWebhook = ({ fs, constants, name, deleteTransformDir = false }) => {
 };
 
 module.exports = {
+  ensureWebhookMappingIds,
   listWebhooks,
   getWebhookDetail,
   createWebhook,

--- a/lib/server/webhooks.js
+++ b/lib/server/webhooks.js
@@ -1,4 +1,8 @@
 const path = require("path");
+const {
+  readOpenclawConfig,
+  resolveOpenclawConfigPath,
+} = require("./openclaw-config");
 
 const kNamePattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const kTransformsDir = "hooks/transforms";
@@ -12,11 +16,16 @@ const kManagedWebhookConfigs = [
 ];
 
 const getConfigPath = ({ OPENCLAW_DIR }) =>
-  path.join(OPENCLAW_DIR, "openclaw.json");
+  resolveOpenclawConfigPath({ openclawDir: OPENCLAW_DIR });
 
 const readConfig = ({ fs, constants }) => {
   const configPath = getConfigPath(constants);
-  const cfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
+  const cfg = readOpenclawConfig({
+    fsModule: fs,
+    openclawDir: constants.OPENCLAW_DIR,
+    fallback: null,
+  });
+  if (!cfg) throw new Error("Could not read openclaw.json");
   return { cfg, configPath };
 };
 
@@ -78,9 +87,31 @@ const ensureHooksRoot = (cfg) => {
 
 const getMappingHookName = (mapping) =>
   String(mapping?.match?.path || "").trim();
-const getMappingIdFromPath = (mapping) => {
-  const hookPath = getMappingHookName(mapping).replace(/^\/+|\/+$/g, "");
-  return kNamePattern.test(hookPath) ? hookPath : "";
+const normalizeMappingIdPart = (value) =>
+  String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+const getMappingIdBase = (mapping, index) => {
+  const hookPath = normalizeMappingIdPart(getMappingHookName(mapping));
+  if (hookPath) return hookPath;
+  const name = normalizeMappingIdPart(mapping?.name);
+  if (name) return name;
+  const source = normalizeMappingIdPart(mapping?.match?.source);
+  if (source) return `source-${source}`;
+  return `mapping-${index + 1}`;
+};
+const reserveUniqueMappingId = (baseId, usedIds) => {
+  let candidate = baseId;
+  let suffix = 2;
+  while (usedIds.has(candidate)) {
+    candidate = `${baseId}-${suffix}`;
+    suffix += 1;
+  }
+  usedIds.add(candidate);
+  return candidate;
 };
 const isWebhookMapping = (mapping) => !!getMappingHookName(mapping);
 const findMappingIndexByName = (mappings, name) =>
@@ -151,11 +182,21 @@ const ensureWebhookMappingIds = ({ fs, constants }) => {
   const mappings = Array.isArray(cfg?.hooks?.mappings)
     ? cfg.hooks.mappings
     : [];
+  const usedIds = new Set(
+    mappings
+      .map((mapping) => String(mapping?.id || "").trim())
+      .filter(Boolean),
+  );
   const updatedIds = [];
-  for (const mapping of mappings) {
+  for (const [index, mapping] of mappings.entries()) {
+    if (!mapping || typeof mapping !== "object" || Array.isArray(mapping)) {
+      continue;
+    }
     if (String(mapping?.id || "").trim()) continue;
-    const id = getMappingIdFromPath(mapping);
-    if (!id) continue;
+    const id = reserveUniqueMappingId(
+      getMappingIdBase(mapping, index),
+      usedIds,
+    );
     mapping.id = id;
     updatedIds.push(id);
   }

--- a/tests/server/routes-webhooks.test.js
+++ b/tests/server/routes-webhooks.test.js
@@ -104,6 +104,13 @@ describe("server/routes/webhooks", () => {
     expect(response.body?.webhook?.oauthCallbackUrl).toBe(
       "https://alphaclaw.example.com/oauth/0123456789abcdef0123456789abcdef",
     );
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(config.hooks.mappings).toEqual([
+      expect.objectContaining({
+        id: "schwab-oauth",
+        match: { path: "schwab-oauth" },
+      }),
+    ]);
     const transformPath = path.join(
       openclawDir,
       getTransformRelativePath("schwab-oauth"),

--- a/tests/server/startup.test.js
+++ b/tests/server/startup.test.js
@@ -9,6 +9,10 @@ describe("server/startup", () => {
     const ensureUsageTrackerPluginConfig = vi.fn(() =>
       callOrder.push("ensureUsageTrackerPluginConfig"),
     );
+    const ensureWebhookMappingIds = vi.fn(() => {
+      callOrder.push("ensureWebhookMappingIds");
+      return { changed: false, updatedIds: [] };
+    });
     const doSyncPromptFiles = vi.fn(() => callOrder.push("doSyncPromptFiles"));
     const reloadEnv = vi.fn(() => callOrder.push("reloadEnv"));
     const readEnvFile = vi.fn(() => {
@@ -32,6 +36,7 @@ describe("server/startup", () => {
     runOnboardedBootSequence({
       ensureManagedExecDefaults,
       ensureUsageTrackerPluginConfig,
+      ensureWebhookMappingIds,
       doSyncPromptFiles,
       reloadEnv,
       syncChannelConfig,
@@ -47,6 +52,7 @@ describe("server/startup", () => {
     expect(callOrder).toEqual([
       "ensureManagedExecDefaults",
       "ensureUsageTrackerPluginConfig",
+      "ensureWebhookMappingIds",
       "doSyncPromptFiles",
       "reloadEnv",
       "readEnvFile",

--- a/tests/server/webhooks.test.js
+++ b/tests/server/webhooks.test.js
@@ -2,6 +2,7 @@ const path = require("path");
 
 const {
   createWebhook,
+  ensureWebhookMappingIds,
   getTransformRelativePath,
   updateWebhookDestination,
 } = require("../../lib/server/webhooks");
@@ -80,6 +81,7 @@ describe("server/webhooks", () => {
     );
     expect(mapping).toEqual(
       expect.objectContaining({
+        id: "gmail-alerts",
         deliver: true,
         channel: "telegram",
         to: "-1003709908795:4011",
@@ -97,6 +99,45 @@ describe("server/webhooks", () => {
         agentId: "main",
       }),
     );
+  });
+
+  it("backfills stable IDs on existing webhook mappings", () => {
+    const openclawDir = "/tmp/openclaw";
+    const configPath = path.join(openclawDir, "openclaw.json");
+    const fs = createMemoryFs({
+      [configPath]: JSON.stringify({
+        hooks: {
+          mappings: [
+            { match: { path: "schwab" }, action: "agent" },
+            { id: "", match: { path: "/gmail/" }, action: "agent" },
+            { id: "fathom", match: { path: "fathom" }, action: "agent" },
+            { match: { path: "nested/unsupported" }, action: "agent" },
+          ],
+        },
+      }),
+    });
+
+    expect(
+      ensureWebhookMappingIds({
+        fs,
+        constants: { OPENCLAW_DIR: openclawDir },
+      }),
+    ).toEqual({ changed: true, updatedIds: ["schwab", "gmail"] });
+
+    const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(config.hooks.mappings).toEqual([
+      expect.objectContaining({ id: "schwab" }),
+      expect.objectContaining({ id: "gmail" }),
+      expect.objectContaining({ id: "fathom" }),
+      expect.objectContaining({ match: { path: "nested/unsupported" } }),
+    ]);
+    expect(config.hooks.mappings[3]).not.toHaveProperty("id");
+    expect(
+      ensureWebhookMappingIds({
+        fs,
+        constants: { OPENCLAW_DIR: openclawDir },
+      }),
+    ).toEqual({ changed: false, updatedIds: [] });
   });
 
   it("defaults mapping delivery channel to last and falls back to default agent", () => {

--- a/tests/server/webhooks.test.js
+++ b/tests/server/webhooks.test.js
@@ -112,6 +112,10 @@ describe("server/webhooks", () => {
             { id: "", match: { path: "/gmail/" }, action: "agent" },
             { id: "fathom", match: { path: "fathom" }, action: "agent" },
             { match: { path: "nested/unsupported" }, action: "agent" },
+            { match: { path: "schwab" }, action: "agent" },
+            { name: "Nightly Sync", action: "agent" },
+            { match: { source: "Salesforce" }, action: "agent" },
+            { action: "agent" },
           ],
         },
       }),
@@ -122,16 +126,30 @@ describe("server/webhooks", () => {
         fs,
         constants: { OPENCLAW_DIR: openclawDir },
       }),
-    ).toEqual({ changed: true, updatedIds: ["schwab", "gmail"] });
+    ).toEqual({
+      changed: true,
+      updatedIds: [
+        "schwab",
+        "gmail",
+        "nested-unsupported",
+        "schwab-2",
+        "nightly-sync",
+        "source-salesforce",
+        "mapping-8",
+      ],
+    });
 
     const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
     expect(config.hooks.mappings).toEqual([
       expect.objectContaining({ id: "schwab" }),
       expect.objectContaining({ id: "gmail" }),
       expect.objectContaining({ id: "fathom" }),
-      expect.objectContaining({ match: { path: "nested/unsupported" } }),
+      expect.objectContaining({ id: "nested-unsupported" }),
+      expect.objectContaining({ id: "schwab-2" }),
+      expect.objectContaining({ id: "nightly-sync" }),
+      expect.objectContaining({ id: "source-salesforce" }),
+      expect.objectContaining({ id: "mapping-8" }),
     ]);
-    expect(config.hooks.mappings[3]).not.toHaveProperty("id");
     expect(
       ensureWebhookMappingIds({
         fs,


### PR DESCRIPTION
## Summary

- write a stable `id` on every webhook mapping created or updated by AlphaClaw
- backfill every missing mapping ID during onboarded startup, before the gateway launches
- derive readable IDs from path, name, or source, with deterministic `mapping-N` fallback IDs
- avoid collisions with existing and newly generated IDs while preserving all existing IDs
- cover Gmail-style legacy mappings and OAuth-enabled webhook creation

OpenClaw treats mapping IDs as optional and synthesizes positional IDs when absent. This migration makes those identities explicit and stable across reordering, improving diagnostics, auditing, and compatibility for existing user configurations. It is idempotent and requires no manual config edits.

## Verification

- Node.js 22.22.3 full suite on the initial implementation: 102 files, 719 tests passed
- targeted webhook, OAuth callback, and startup tests pass with collision and fallback coverage
- `git diff --check`
- localhost gateway restarted healthy on OpenClaw 2026.7.1