### PR TITLE
fix(models): reuse MiniMax key for CN selections and add MiniMax-M3 to cold-start catalog

### DIFF
--- a/lib/public/js/lib/model-config.js
+++ b/lib/public/js/lib/model-config.js
@@ -5,6 +5,7 @@ export const getAuthProviderFromModelProvider = (provider) => {
   if (normalized === "openai-codex") return "openai";
   if (normalized === "volcengine-plan") return "volcengine";
   if (normalized === "byteplus-plan") return "byteplus";
+  if (normalized === "minimax-cn") return "minimax";
   return normalized;
 };
 

--- a/lib/server/model-catalog-bootstrap.json
+++ b/lib/server/model-catalog-bootstrap.json
@@ -1550,6 +1550,11 @@
       "label": "MiniMax-M2.7-highspeed"
     },
     {
+      "key": "minimax/MiniMax-M3",
+      "provider": "minimax",
+      "label": "MiniMax-M3"
+    },
+    {
       "key": "minimax-cn/MiniMax-M2.7",
       "provider": "minimax-cn",
       "label": "MiniMax-M2.7"
@@ -1558,6 +1563,11 @@
       "key": "minimax-cn/MiniMax-M2.7-highspeed",
       "provider": "minimax-cn",
       "label": "MiniMax-M2.7-highspeed"
+    },
+    {
+      "key": "minimax-cn/MiniMax-M3",
+      "provider": "minimax-cn",
+      "label": "MiniMax-M3"
     },
     {
       "key": "mistral/codestral-latest",

--- a/tests/frontend/model-config.test.js
+++ b/tests/frontend/model-config.test.js
@@ -11,7 +11,16 @@ describe("frontend/model-config", () => {
     expect(modelConfig.getAuthProviderFromModelProvider("byteplus-plan")).toBe(
       "byteplus",
     );
+    expect(modelConfig.getAuthProviderFromModelProvider("minimax-cn")).toBe(
+      "minimax",
+    );
     expect(modelConfig.getAuthProviderFromModelProvider("google")).toBe("google");
+  });
+
+  it("lets CN model selections reuse the MiniMax API key", async () => {
+    const modelConfig = await loadModelConfig();
+    const keys = modelConfig.getVisibleAiFieldKeys("minimax-cn");
+    expect(keys.has("MINIMAX_API_KEY")).toBe(true);
   });
 
   it("returns visible AI field keys for provider", async () => {


### PR DESCRIPTION
Reason: CN model selections could not reuse the MiniMax API key, and the cold-start catalog was missing MiniMax-M3.

## Changes

- **CN auth normalization** (`lib/public/js/lib/model-config.js`): `getAuthProviderFromModelProvider` now maps the `minimax-cn` model provider to the `minimax` auth provider, alongside the existing `openai-codex`, `volcengine-plan`, and `byteplus-plan` mappings. Previously `minimax-cn` was returned unchanged, so credential fields defined only under `minimax` were never surfaced for CN selections and `MINIMAX_API_KEY` could not be reused.
- **Cold-start catalog** (`lib/server/model-catalog-bootstrap.json`): added `MiniMax-M3` entries for both the `minimax` and `minimax-cn` providers, matching the existing regional pattern used for `MiniMax-M2.7`. The bundled catalog previously exposed the CN provider but omitted `MiniMax-M3` on cold start.
- **Tests** (`tests/frontend/model-config.test.js`): assert that `minimax-cn` normalizes to `minimax` and that the visible AI field keys for `minimax-cn` include `MINIMAX_API_KEY`.

## Checks

- `npx vitest run tests/frontend/model-config.test.js tests/server/model-catalog-cache.test.js` — 16 passed.
