### PR TITLE
Fix OAuth login CSRF in Google account linking flow

### DIFF
--- a/lib/server/constants.js
+++ b/lib/server/constants.js
@@ -36,6 +36,7 @@ const CODEX_OAUTH_REDIRECT_URI = "http://localhost:1455/auth/callback";
 const CODEX_OAUTH_SCOPE = "openid profile email offline_access";
 const CODEX_JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const kCodexOauthStateTtlMs = 10 * 60 * 1000;
+const kGoogleOauthStateTtlMs = 10 * 60 * 1000;
 
 const kTrustProxyHops = parsePositiveInt(process.env.TRUST_PROXY_HOPS, 1);
 const kLoginWindowMs = parsePositiveInt(
@@ -518,6 +519,7 @@ module.exports = {
   CODEX_OAUTH_SCOPE,
   CODEX_JWT_CLAIM_PATH,
   kCodexOauthStateTtlMs,
+  kGoogleOauthStateTtlMs,
   kTrustProxyHops,
   kLoginWindowMs,
   kLoginMaxAttempts,

--- a/lib/server/routes/google.js
+++ b/lib/server/routes/google.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const {
   kDefaultGoogleClient,
   kDefaultGoogleScopes,
@@ -14,6 +15,22 @@ const { syncBootstrapPromptFiles } = require("../onboarding/workspace");
 const { installGogCliSkill } = require("../gog-skill");
 const { parseJsonSafe } = require("../utils/json");
 const { quoteShellArg } = require("../utils/shell");
+const { kGoogleOauthStateTtlMs } = require("../constants");
+
+const createGoogleOauthState = () => {
+  const kGoogleOauthStates = new Map();
+
+  const cleanupGoogleOauthStates = () => {
+    const now = Date.now();
+    for (const [state, value] of kGoogleOauthStates.entries()) {
+      if (!value || now - value.createdAt > kGoogleOauthStateTtlMs) {
+        kGoogleOauthStates.delete(state);
+      }
+    }
+  };
+
+  return { kGoogleOauthStates, cleanupGoogleOauthStates };
+};
 
 const uniqueServiceLabels = (scopes) =>
   Array.from(
@@ -47,6 +64,7 @@ const registerGoogleRoutes = ({
 
   const readState = () => readGoogleState({ fs, statePath: GOG_STATE_PATH });
   const saveState = (state) => writeGoogleState({ fs, statePath: GOG_STATE_PATH, state });
+  const { kGoogleOauthStates, cleanupGoogleOauthStates } = createGoogleOauthState();
   const syncBootstrapTools = (req) => {
     try {
       syncBootstrapPromptFiles({
@@ -455,14 +473,15 @@ const registerGoogleRoutes = ({
         ...services.map((scope) => SCOPE_MAP[scope]).filter(Boolean),
       ].join(" ");
       const redirectUri = `${getBaseUrl(req)}/auth/google/callback`;
-      const encodedState = Buffer.from(
-        JSON.stringify({
-          accountId: account?.id || requestedAccountId || "",
-          client,
-          email,
-          services,
-        }),
-      ).toString("base64url");
+      cleanupGoogleOauthStates();
+      const oauthStateToken = crypto.randomBytes(16).toString("hex");
+      kGoogleOauthStates.set(oauthStateToken, {
+        accountId: account?.id || requestedAccountId || "",
+        client,
+        email,
+        services,
+        createdAt: Date.now(),
+      });
       const authUrl = new URL("https://accounts.google.com/o/oauth2/auth");
       authUrl.searchParams.set("client_id", clientId);
       authUrl.searchParams.set("redirect_uri", redirectUri);
@@ -470,7 +489,7 @@ const registerGoogleRoutes = ({
       authUrl.searchParams.set("scope", scopes);
       authUrl.searchParams.set("access_type", "offline");
       authUrl.searchParams.set("prompt", "consent");
-      authUrl.searchParams.set("state", encodedState);
+      authUrl.searchParams.set("state", oauthStateToken);
       if (email) authUrl.searchParams.set("login_hint", email);
       res.redirect(authUrl.toString());
     } catch (err) {
@@ -484,11 +503,14 @@ const registerGoogleRoutes = ({
     if (error) return res.redirect(`/setup?google=error&message=${encodeURIComponent(error)}`);
     if (!code) return res.redirect("/setup?google=error&message=no_code");
 
+    cleanupGoogleOauthStates();
+    const decodedState = kGoogleOauthStates.get(String(state || "")) || null;
+    kGoogleOauthStates.delete(String(state || ""));
+    if (!decodedState) {
+      return res.redirect("/setup?google=error&message=state_mismatch_or_expired");
+    }
+
     try {
-      const decodedState = parseJsonSafe(
-        Buffer.from(String(state || ""), "base64url").toString(),
-        {},
-      );
       const accountId = String(decodedState.accountId || "").trim();
       const requestedClient = String(decodedState.client || "").trim();
       const stateData = readState();

--- a/tests/server/routes-google.test.js
+++ b/tests/server/routes-google.test.js
@@ -1,0 +1,125 @@
+const express = require("express");
+const request = require("supertest");
+
+const { registerGoogleRoutes } = require("../../lib/server/routes/google");
+
+const createFsMock = () => {
+  const files = new Map();
+  return {
+    existsSync: vi.fn((p) => files.has(p)),
+    readFileSync: vi.fn((p) => {
+      if (!files.has(p)) {
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      }
+      return files.get(p);
+    }),
+    writeFileSync: vi.fn((p, content) => {
+      files.set(p, content);
+    }),
+    unlinkSync: vi.fn((p) => {
+      files.delete(p);
+    }),
+  };
+};
+
+const createApp = (overrides = {}) => {
+  const app = express();
+  app.use(express.json());
+  const deps = {
+    app,
+    fs: createFsMock(),
+    isGatewayRunning: vi.fn(async () => true),
+    gogCmd: vi.fn(async () => ({ ok: true, stdout: "", stderr: "" })),
+    getBaseUrl: () => "https://alphaclaw.example",
+    readGoogleCredentials: vi.fn(() => ({
+      clientId: "client-id",
+      clientSecret: "client-secret",
+    })),
+    getApiEnableUrl: vi.fn(() => ""),
+    constants: {
+      GOG_CONFIG_DIR: "/tmp/gog",
+      GOG_STATE_PATH: "/tmp/gog/state.json",
+      API_TEST_COMMANDS: {},
+      BASE_SCOPES: ["openid", "email"],
+      SCOPE_MAP: { "gmail:read": "gmail.readonly" },
+      REVERSE_SCOPE_MAP: { "gmail.readonly": "gmail:read" },
+      kMaxGoogleAccounts: 5,
+      gogClientCredentialsPath: () => "/tmp/gog/creds.json",
+      WORKSPACE_DIR: "/tmp/workspace",
+    },
+    ...overrides,
+  };
+  registerGoogleRoutes(deps);
+  return { app, deps };
+};
+
+describe("server/routes/google oauth state (CSRF)", () => {
+  it("mints an opaque, unguessable state token on start rather than trusting client-supplied data", async () => {
+    const { app } = createApp();
+    const res = await request(app).get("/auth/google/start");
+
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.location);
+    const state = location.searchParams.get("state");
+    expect(state).toBeTruthy();
+    // Must not be a base64url-encoded JSON blob an attacker could forge with
+    // their own accountId/email/client -- just an opaque random token.
+    expect(() => JSON.parse(Buffer.from(state, "base64url").toString())).toThrow();
+    expect(state).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("rejects a callback whose state was never issued by this server", async () => {
+    const { app } = createApp();
+    const fetchSpy = vi.spyOn(global, "fetch");
+
+    const res = await request(app)
+      .get("/auth/google/callback")
+      .query({ code: "attacker-code", state: "forged-state-attacker-controls" });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toContain("google=error");
+    expect(res.headers.location).toContain("state_mismatch_or_expired");
+    // Must never exchange the code for tokens without a verified state.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("accepts a callback using the exact state issued by /auth/google/start, and consumes it once", async () => {
+    const { app } = createApp();
+
+    const startRes = await request(app)
+      .get("/auth/google/start")
+      .query({ email: "owner@example.com" });
+    const state = new URL(startRes.headers.location).searchParams.get("state");
+
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (url) => {
+      if (String(url).includes("oauth2.googleapis.com/token")) {
+        return {
+          ok: true,
+          json: async () => ({
+            access_token: "at",
+            refresh_token: "rt",
+            scope: "gmail.readonly",
+          }),
+        };
+      }
+      return { ok: true, json: async () => ({ email: "owner@example.com" }) };
+    });
+
+    const firstAttempt = await request(app)
+      .get("/auth/google/callback")
+      .query({ code: "real-code", state });
+    expect(firstAttempt.status).toBe(200);
+    expect(firstAttempt.text).toContain("google");
+
+    // Replaying the same state (e.g. an attacker who intercepted the callback
+    // URL) must not be able to trigger a second token exchange.
+    const secondAttempt = await request(app)
+      .get("/auth/google/callback")
+      .query({ code: "replayed-code", state });
+    expect(secondAttempt.status).toBe(302);
+    expect(secondAttempt.headers.location).toContain("state_mismatch_or_expired");
+
+    fetchSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

`/auth/google/callback` trusted the `state` query param as-is: it was a base64url-encoded JSON blob (`accountId`, `client`, `email`, `services`) built entirely from client-supplied input on `/auth/google/start`, with nothing tying a given callback back to the browser session that actually initiated it.

Since `/auth/google/callback` is necessarily exempt from the app's normal session-cookie auth (it has to be reachable when Google redirects the browser back), this meant anyone could craft their own `state` — including one naming an existing account's `accountId` — and get an admin to open:

```
/auth/google/callback?code=<attacker's own authorization code>&state=<forged>
```

via a plain link (no JS needed, just a GET navigation). The server would exchange the attacker's authorization code for the attacker's own Google tokens and store them under the *target* account's id — silently swapping in Google credentials the admin doesn't control, without ever needing the admin's password or session token.

## Fix

This codebase already has the correct pattern for exactly this problem in `/auth/codex/callback` (`lib/server/routes/codex.js`): mint a random, unguessable state token server-side when the flow starts, hold the actual account-linking data in an in-memory map keyed by that token (never round-tripped through the client), and require the callback's `state` to match a live, single-use entry before doing anything.

Applied the same pattern to `/auth/google/start` / `/auth/google/callback`:
- `state` sent to Google is now a random 16-byte hex token, not JSON.
- The real `accountId`/`client`/`email`/`services` are stored server-side in a map keyed by that token, with a TTL (`kGoogleOauthStateTtlMs`, matching the existing Codex TTL).
- The callback looks up and deletes the entry before proceeding; unknown, forged, or already-consumed state values are rejected before any token exchange happens.

## Test plan
- [x] Added `tests/server/routes-google.test.js`:
  - the minted state is opaque (not attacker-decodable JSON)
  - a forged/unknown state is rejected and `fetch` (the token exchange) is never called
  - a valid state works once, and replaying it is rejected