### PR TITLE
Fix path traversal in imported hook-transform realignment

### DIFF
--- a/lib/server/onboarding/import/import-applier.js
+++ b/lib/server/onboarding/import/import-applier.js
@@ -145,6 +145,14 @@ const pathExists = (fs, targetPath) => {
     return false;
   }
 };
+const isWithinBaseDir = (baseDir, candidatePath) => {
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedCandidate = path.resolve(candidatePath);
+  return (
+    resolvedCandidate === resolvedBase ||
+    resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`)
+  );
+};
 
 const resolveExtractionTargetPath = (baseDir, file) => {
   const relativeFile = String(file || "").trim();
@@ -273,6 +281,19 @@ const alignHookTransforms = ({ fs, baseDir, configFiles = [] }) => {
       const expectedRelativePath = path.join(kTransformsRoot, expectedModule);
       const actualAbsolutePath = path.join(baseDir, actualRelativePath);
       const expectedAbsolutePath = path.join(baseDir, expectedRelativePath);
+      // hookPath/actualModule come straight from the imported repo's own
+      // openclaw.json (untrusted content) -- normalizeHookPath/
+      // normalizeTransformModulePath only strip a leading slash, they don't
+      // reject `../`. Without this check a crafted match.path or
+      // transform.module walks actualAbsolutePath/expectedAbsolutePath
+      // outside baseDir, turning "align hook transforms" into an arbitrary
+      // host file read (via the move-to-backup step) and write.
+      if (
+        !isWithinBaseDir(baseDir, actualAbsolutePath) ||
+        !isWithinBaseDir(baseDir, expectedAbsolutePath)
+      ) {
+        return;
+      }
       if (!pathExists(fs, actualAbsolutePath)) return;
 
       const actualParts = actualModule.split("/").filter(Boolean);
@@ -286,6 +307,12 @@ const alignHookTransforms = ({ fs, baseDir, configFiles = [] }) => {
         sourceRootRelativePath.slice(kTransformsRoot.length + 1),
       );
       const backupRootAbsolutePath = path.join(baseDir, backupRootRelativePath);
+      if (
+        !isWithinBaseDir(baseDir, sourceRootAbsolutePath) ||
+        !isWithinBaseDir(baseDir, backupRootAbsolutePath)
+      ) {
+        return;
+      }
 
       if (!movedRoots.has(sourceRootAbsolutePath)) {
         if (

--- a/tests/server/import-applier.test.js
+++ b/tests/server/import-applier.test.js
@@ -210,6 +210,116 @@ describe("import-applier", () => {
     );
   });
 
+  it("does not read, move, or write outside baseDir when an imported transform.module traverses out via ../", () => {
+    const baseDir = createTempDir();
+    const outsideDir = createTempDir();
+
+    // A file the attacker wants exfiltrated: if the vulnerable code path
+    // moved it into baseDir/hooks/transforms/_backup, it would become
+    // browsable (and later git-synced) as part of the imported workspace.
+    const secretPath = path.join(outsideDir, "secret.mjs");
+    fs.writeFileSync(secretPath, "export const secret = 'do-not-touch';\n", "utf8");
+    const outsideSnapshotBefore = fs.readdirSync(outsideDir).sort();
+
+    const transformsRoot = path.join(baseDir, "hooks", "transforms");
+    const traversalToSecret = path
+      .relative(transformsRoot, secretPath)
+      .split(path.sep)
+      .join("/");
+
+    fs.writeFileSync(
+      path.join(baseDir, "openclaw.json"),
+      JSON.stringify(
+        {
+          hooks: {
+            mappings: [
+              {
+                name: "Evil",
+                match: { path: "evil" },
+                transform: { module: traversalToSecret },
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = alignHookTransforms({
+      fs,
+      baseDir,
+      configFiles: ["openclaw.json"],
+    });
+
+    expect(result).toEqual({ alignedCount: 0 });
+    expect(fs.readFileSync(secretPath, "utf8")).toBe(
+      "export const secret = 'do-not-touch';\n",
+    );
+    expect(fs.readdirSync(outsideDir).sort()).toEqual(outsideSnapshotBefore);
+    expect(
+      fs.existsSync(path.join(baseDir, "hooks", "transforms", "evil")),
+    ).toBe(false);
+  });
+
+  it("does not write a transform shim outside baseDir when an imported hook path traverses out via ../", () => {
+    const baseDir = createTempDir();
+    const outsideDir = createTempDir();
+    const outsideSnapshotBefore = fs.readdirSync(outsideDir).sort();
+
+    // A real, in-workspace transform module -- legitimate on its own, only
+    // `match.path` (hookPath) is malicious here.
+    const legacyTransformDir = path.join(baseDir, "hooks", "transforms", "existing");
+    fs.mkdirSync(legacyTransformDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(legacyTransformDir, "existing-transform.mjs"),
+      "export default async function transform(payload) {\n  return payload;\n}\n",
+      "utf8",
+    );
+
+    const transformsRoot = path.join(baseDir, "hooks", "transforms");
+    const hookPathTraversal = path
+      .relative(transformsRoot, outsideDir)
+      .split(path.sep)
+      .join("/");
+
+    fs.writeFileSync(
+      path.join(baseDir, "openclaw.json"),
+      JSON.stringify(
+        {
+          hooks: {
+            mappings: [
+              {
+                name: "Evil",
+                match: { path: hookPathTraversal },
+                transform: { module: "existing/existing-transform.mjs" },
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const result = alignHookTransforms({
+      fs,
+      baseDir,
+      configFiles: ["openclaw.json"],
+    });
+
+    expect(result).toEqual({ alignedCount: 0 });
+    expect(fs.readdirSync(outsideDir).sort()).toEqual(outsideSnapshotBefore);
+    // The legitimate existing transform must be left in place, not moved.
+    expect(
+      fs.existsSync(
+        path.join(legacyTransformDir, "existing-transform.mjs"),
+      ),
+    ).toBe(true);
+  });
+
   it("rewrites approved config secrets by config path before fallback replacement", () => {
     const baseDir = createTempDir();
     const configPath = path.join(baseDir, "openclaw.json");


### PR DESCRIPTION
## Summary

`alignHookTransforms()` (`lib/server/onboarding/import/import-applier.js`) derives filesystem paths from an **imported repo's own `openclaw.json` content** — `match.path` (`hookPath`) and `transform.module` (`actualModule`) — via `normalizeHookPath()` / `normalizeTransformModulePath()`, which only strip a leading slash:

```js
const normalizeHookPath = (value) => String(value || "").trim().replace(/^\/+/, "");
const normalizeTransformModulePath = (value) =>
  String(value || "").trim().replace(/^\/+/, "").replace(/^hooks\/transforms\/+/, "");
```

Neither rejects `../`. Those values flow straight into `path.join(baseDir, "hooks/transforms", ...)` with **no containment check**, for both:
- a read/move step — whatever exists at the "actual" module path gets *moved* into a `_backup` directory
- an unconditional `fs.writeFileSync()` of a generated shim at the "expected" module path

This runs during onboarding's **"import an existing OpenClaw workspace"** flow — a first-class, encouraged feature (e.g. restoring from a previous deployment's git-synced config repo), not an edge case. A crafted `openclaw.json` in the imported repo can:

- point `transform.module` far enough up via `../` to reach an existing host file **outside** the temp clone directory, which then gets **moved** into the imported workspace's `_backup` dir — arbitrary file read/exfiltration, since it becomes browsable (and later git-synced) as part of the new AlphaClaw config
- point `match.path` via `../` so the shim's write path (`baseDir/hooks/transforms/<hookPath>/<hookPath>-transform.mjs`) lands **outside the temp dir entirely** — arbitrary file write, unconditional, no existence check gates the write side

## Fix

Both derived-path computations (`actualAbsolutePath`/`expectedAbsolutePath`, and the backup-root pair built from them) are now checked against `baseDir` before anything reads, moves, or writes — mirroring the containment check already used correctly elsewhere in this same file (`resolveExtractionTargetPath`, used by `applySecretExtraction` and `canonicalizeConfigEnvRefs`). A mapping whose paths escape `baseDir` is now just skipped instead of processed.

## Test plan
- [x] Added two tests to `tests/server/import-applier.test.js`, verified to **fail without the fix** (`alignedCount: 1`, and the read/write actually happening) and pass with it:
  - a `transform.module` escape reaching a real external "secret" file: proves the file is never moved/read and nothing changes outside `baseDir`
  - a `match.path` escape targeting an external write location: proves no shim is written outside `baseDir` and the legitimate in-workspace transform is left untouched
- [x] Full `import-applier.test.js` suite passes (6/6), including the existing legitimate-realignment coverage.