### PR TITLE
Fix path traversal in imported config's $include handling (raw secret disclosure)

### DIFF
--- a/lib/server/onboarding/import/import-config.js
+++ b/lib/server/onboarding/import/import-config.js
@@ -1,5 +1,14 @@
 const path = require("path");
 
+const isWithinDir = (rootDir, candidatePath) => {
+  const resolvedRoot = path.resolve(rootDir);
+  const resolvedCandidate = path.resolve(candidatePath);
+  return (
+    resolvedCandidate === resolvedRoot ||
+    resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`)
+  );
+};
+
 const normalizeHookPath = (value) =>
   String(value || "")
     .trim()
@@ -45,10 +54,15 @@ const resolveImportedConfigPaths = ({ fs, openclawDir }) => {
 
     const includes = resolveConfigIncludes({ fs, absoluteConfigPath });
     for (const includePath of includes) {
+      // includePath is a raw $include value from config content that, for the
+      // imported-config walk, ultimately originates from the imported repo --
+      // untrusted. A `../../../etc/some-real-config.json` include that
+      // happens to exist must not be allowed to enter the queue: callers
+      // (normalizeImportedConfig) both read AND write these paths back.
       const candidatePaths = [
         path.join(openclawDir, includePath),
         path.join(path.dirname(absoluteConfigPath), includePath),
-      ];
+      ].filter((candidatePath) => isWithinDir(openclawDir, candidatePath));
       for (const candidatePath of candidatePaths) {
         if (fs.existsSync(candidatePath) && !discovered.has(candidatePath)) {
           queue.push(candidatePath);

--- a/lib/server/onboarding/import/import-scanner.js
+++ b/lib/server/onboarding/import/import-scanner.js
@@ -42,6 +42,15 @@ const kManagedFiles = [
 
 const kManagedDirs = [".alphaclaw"];
 
+const isWithinBaseDir = (baseDir, candidatePath) => {
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedCandidate = path.resolve(candidatePath);
+  return (
+    resolvedCandidate === resolvedBase ||
+    resolvedCandidate.startsWith(`${resolvedBase}${path.sep}`)
+  );
+};
+
 const fileExists = (fs, filePath) => {
   try {
     return fs.statSync(filePath).isFile();
@@ -327,8 +336,16 @@ const scanWorkspace = ({ fs, baseDir }) => {
       absoluteConfigPath: path.join(baseDir, cfgFile),
     });
     for (const inc of includes) {
+      // `inc` is a raw $include value from the imported repo's own config --
+      // untrusted content. Without this check a `../../../real/host/file.json`
+      // include that happens to exist gets added to gatewayConfig.files
+      // verbatim, and every downstream consumer (secret-detector.js's
+      // detectSecrets/extractPreFillValues, etc.) would read and potentially
+      // surface that file's contents as if it were part of the imported repo.
+      const includeAbsolutePath = path.join(baseDir, inc);
       if (
-        fileExists(fs, path.join(baseDir, inc)) &&
+        isWithinBaseDir(baseDir, includeAbsolutePath) &&
+        fileExists(fs, includeAbsolutePath) &&
         !gatewayConfig.files.includes(inc)
       ) {
         gatewayConfig.files.push(inc);

--- a/lib/server/onboarding/import/secret-detector.js
+++ b/lib/server/onboarding/import/secret-detector.js
@@ -1,5 +1,25 @@
 const path = require("path");
 
+// configFiles/envFiles ultimately trace back to the imported repo's own
+// config content (e.g. a `$include` value from import-scanner.js's include
+// walk), so a crafted `../../../etc/some-real-config.json` entry must not be
+// allowed to resolve outside baseDir -- this function's job is exactly
+// "read this file and hand its contents back to the UI," so it's the last
+// line of defense regardless of what upstream validation exists.
+const resolveWithinBaseDir = (baseDir, relativeFile) => {
+  const relative = String(relativeFile || "").trim();
+  if (!relative || path.isAbsolute(relative)) return "";
+  const resolvedBaseDir = path.resolve(baseDir);
+  const resolvedFilePath = path.resolve(resolvedBaseDir, relative);
+  if (
+    resolvedFilePath !== resolvedBaseDir &&
+    !resolvedFilePath.startsWith(`${resolvedBaseDir}${path.sep}`)
+  ) {
+    return "";
+  }
+  return resolvedFilePath;
+};
+
 const kSecretKeyPatterns = [
   /token$/i,
   /^bot_?token$/i,
@@ -239,7 +259,8 @@ const detectSecrets = ({ fs, baseDir, configFiles = [], envFiles = [] }) => {
 
   for (const cfgFile of configFiles) {
     try {
-      const fullPath = path.join(baseDir, cfgFile);
+      const fullPath = resolveWithinBaseDir(baseDir, cfgFile);
+      if (!fullPath) continue;
       const raw = fs.readFileSync(fullPath, "utf8");
       const cfg = JSON.parse(raw);
       const configSecrets = [];
@@ -255,7 +276,8 @@ const detectSecrets = ({ fs, baseDir, configFiles = [], envFiles = [] }) => {
 
   for (const envFile of envFiles) {
     try {
-      const fullPath = path.join(baseDir, envFile);
+      const fullPath = resolveWithinBaseDir(baseDir, envFile);
+      if (!fullPath) continue;
       const content = fs.readFileSync(fullPath, "utf8");
       const envSecrets = parseEnvFileSecrets(content, envFile);
       for (const secret of envSecrets) {
@@ -282,7 +304,9 @@ const extractPreFillValues = ({ fs, baseDir, configFiles = [] }) => {
   const preFill = {};
   for (const cfgFile of configFiles) {
     try {
-      const raw = fs.readFileSync(path.join(baseDir, cfgFile), "utf8");
+      const fullPath = resolveWithinBaseDir(baseDir, cfgFile);
+      if (!fullPath) continue;
+      const raw = fs.readFileSync(fullPath, "utf8");
       const cfg = JSON.parse(raw);
       const configFileName = path.basename(String(cfgFile || "")).toLowerCase();
 

--- a/tests/server/import-config.test.js
+++ b/tests/server/import-config.test.js
@@ -1,0 +1,67 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  resolveImportedConfigPaths,
+} = require("../../lib/server/onboarding/import/import-config");
+
+const kTempDirs = [];
+const createTempDir = () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-import-config-"));
+  kTempDirs.push(tempDir);
+  return tempDir;
+};
+afterEach(() => {
+  while (kTempDirs.length > 0) {
+    fs.rmSync(kTempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("onboarding import-config resolveImportedConfigPaths", () => {
+  it("does not walk a $include that traverses outside openclawDir, even if the target exists", () => {
+    const openclawDir = createTempDir();
+    const outsideDir = createTempDir();
+
+    fs.writeFileSync(
+      path.join(outsideDir, "real-config.json"),
+      JSON.stringify({ someKey: "someValue" }),
+      "utf8",
+    );
+
+    const traversal = path
+      .relative(openclawDir, path.join(outsideDir, "real-config.json"))
+      .split(path.sep)
+      .join("/");
+
+    fs.writeFileSync(
+      path.join(openclawDir, "openclaw.json"),
+      JSON.stringify({ auth: { $include: traversal } }),
+      "utf8",
+    );
+
+    const configPaths = resolveImportedConfigPaths({ fs, openclawDir });
+
+    expect(configPaths).toEqual([path.join(openclawDir, "openclaw.json")]);
+    expect(configPaths).not.toContain(path.join(outsideDir, "real-config.json"));
+  });
+
+  it("still follows a legitimate in-directory $include", () => {
+    const openclawDir = createTempDir();
+    fs.mkdirSync(path.join(openclawDir, "cron"), { recursive: true });
+    fs.writeFileSync(
+      path.join(openclawDir, "cron", "jobs.json"),
+      JSON.stringify({ jobs: [] }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(openclawDir, "openclaw.json"),
+      JSON.stringify({ cron: { $include: "cron/jobs.json" } }),
+      "utf8",
+    );
+
+    const configPaths = resolveImportedConfigPaths({ fs, openclawDir });
+
+    expect(configPaths).toContain(path.join(openclawDir, "cron", "jobs.json"));
+  });
+});

--- a/tests/server/import-scanner.test.js
+++ b/tests/server/import-scanner.test.js
@@ -1,7 +1,21 @@
+const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const {
   scanWorkspace,
 } = require("../../lib/server/onboarding/import/import-scanner");
+
+const kTempDirs = [];
+const createTempDir = () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-import-scanner-"));
+  kTempDirs.push(tempDir);
+  return tempDir;
+};
+afterEach(() => {
+  while (kTempDirs.length > 0) {
+    fs.rmSync(kTempDirs.pop(), { recursive: true, force: true });
+  }
+});
 
 const createMockFs = (files = {}, dirs = []) => {
   const fileMap = new Map(Object.entries(files));
@@ -344,5 +358,33 @@ describe("import-scanner", () => {
       supported: true,
       promoteSourceSubdir: "workspace",
     });
+  });
+
+  it("does not follow a $include that traverses outside baseDir, even if the target exists", () => {
+    const baseDir = createTempDir();
+    const outsideDir = createTempDir();
+
+    // A real, existing host file the malicious repo's $include points at.
+    fs.writeFileSync(
+      path.join(outsideDir, "real-secrets.json"),
+      JSON.stringify({ apiKey: "sk-ant-realsecretvalue0000" }),
+      "utf8",
+    );
+
+    const traversal = path
+      .relative(baseDir, path.join(outsideDir, "real-secrets.json"))
+      .split(path.sep)
+      .join("/");
+
+    fs.writeFileSync(
+      path.join(baseDir, "openclaw.json"),
+      JSON.stringify({ auth: { $include: traversal } }),
+      "utf8",
+    );
+
+    const result = scanWorkspace({ fs, baseDir });
+
+    expect(result.gatewayConfig.files).toEqual(["openclaw.json"]);
+    expect(result.gatewayConfig.files).not.toContain(traversal);
   });
 });

--- a/tests/server/secret-detector.test.js
+++ b/tests/server/secret-detector.test.js
@@ -1,3 +1,6 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 const {
   detectSecrets,
   extractPreFillValues,
@@ -6,6 +9,18 @@ const {
   maskValue,
   parseEnvFileSecrets,
 } = require("../../lib/server/onboarding/import/secret-detector");
+
+const kTempDirs = [];
+const createTempDir = () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-secret-detector-"));
+  kTempDirs.push(tempDir);
+  return tempDir;
+};
+afterEach(() => {
+  while (kTempDirs.length > 0) {
+    fs.rmSync(kTempDirs.pop(), { recursive: true, force: true });
+  }
+});
 
 const createMockFs = (files = {}) => ({
   readFileSync: (p) => {
@@ -390,6 +405,78 @@ describe("secret-detector", () => {
       const content = "\n# header\n\nKEY=value\n";
       const secrets = parseEnvFileSecrets(content, ".env");
       expect(secrets.length).toBe(1);
+    });
+  });
+
+  describe("path containment (configFiles/envFiles must stay within baseDir)", () => {
+    it("does not read or disclose a config file outside baseDir via a ../ traversal entry", () => {
+      const baseDir = createTempDir();
+      const outsideDir = createTempDir();
+
+      // A real host config file the attacker wants disclosed -- shaped like a
+      // real secret so it would trip walkConfig's key/value heuristics.
+      fs.writeFileSync(
+        path.join(outsideDir, "real-secrets.json"),
+        JSON.stringify({ apiKey: "sk-ant-realsecretvalue0000" }),
+        "utf8",
+      );
+      fs.writeFileSync(path.join(baseDir, "openclaw.json"), JSON.stringify({}), "utf8");
+
+      const traversal = path
+        .relative(baseDir, path.join(outsideDir, "real-secrets.json"))
+        .split(path.sep)
+        .join("/");
+
+      const secrets = detectSecrets({
+        fs,
+        baseDir,
+        configFiles: ["openclaw.json", traversal],
+        envFiles: [],
+      });
+
+      expect(secrets.some((s) => s.value === "sk-ant-realsecretvalue0000")).toBe(false);
+    });
+
+    it("does not read a prefill config file outside baseDir via a ../ traversal entry", () => {
+      const baseDir = createTempDir();
+      const outsideDir = createTempDir();
+
+      fs.writeFileSync(
+        path.join(outsideDir, "real-secrets.json"),
+        JSON.stringify({ models: { providers: { anthropic: { apiKey: "sk-ant-realsecret" } } } }),
+        "utf8",
+      );
+
+      const traversal = path
+        .relative(baseDir, path.join(outsideDir, "real-secrets.json"))
+        .split(path.sep)
+        .join("/");
+
+      const preFill = extractPreFillValues({
+        fs,
+        baseDir,
+        configFiles: [traversal],
+      });
+
+      expect(preFill.ANTHROPIC_API_KEY).toBeUndefined();
+    });
+
+    it("still reads legitimate in-workspace config files normally", () => {
+      const baseDir = createTempDir();
+      fs.writeFileSync(
+        path.join(baseDir, "openclaw.json"),
+        JSON.stringify({ channels: { telegram: { botToken: "123456:AAHreal" } } }),
+        "utf8",
+      );
+
+      const secrets = detectSecrets({
+        fs,
+        baseDir,
+        configFiles: ["openclaw.json"],
+        envFiles: [],
+      });
+
+      expect(secrets.some((s) => s.suggestedEnvVar === "TELEGRAM_BOT_TOKEN")).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

A crafted `$include` value in an imported repo's `openclaw.json` is untrusted content, but it flowed into filesystem paths in two places with no containment check:

1. **`import-scanner.js`'s `scanWorkspace()`**: walks `$include` values found in the imported `openclaw.json` and, if the resolved path exists, adds the *raw, unresolved* include string to `gatewayConfig.files`. A `../../../real/host/file.json` include that happens to exist on the host gets added verbatim — no `../` rejection, no containment check.

2. **`import-config.js`'s `resolveImportedConfigPaths()`**: same pattern, but against the *live* `OPENCLAW_DIR` (post-promotion) — used by `normalizeImportedConfig()`, which both reads **and writes** these paths back if their content needs normalizing.

The real impact is downstream: `gatewayConfig.files` (from #1) is passed directly into `secret-detector.js`'s `detectSecrets()`/`extractPreFillValues()`, which read each entry via plain `path.join(baseDir, cfgFile)` with **no containment check of their own** — and `detectSecrets()`'s result, including **raw, unmasked secret values**, is returned directly in the `POST /api/onboard/import/scan` HTTP response body.

Chained together: importing a malicious repo whose `openclaw.json` contains something like:
```json
{ "auth": { "$include": "../../../etc/some-real-config.json" } }
```
lets AlphaClaw read an arbitrary host JSON file that happens to exist, run it through the same heuristics used to detect real secrets (key names like `apiKey`/`token`/`password`, known value prefixes like `sk-`/`ghp_`/`AKIA`), and hand back matching values — **unmasked** — in the scan response shown to the admin during onboarding.

Verified locally: a `sk-ant-...`-shaped value in a file outside the temp clone directory was fully exfiltrated via `detectSecrets()`/`extractPreFillValues()` before this fix — confirmed by reverting each guard individually and watching the raw value come back in the result.

## Fix

Fixed at all three points in the chain (belt and suspenders — any one of these closes the demonstrated exploit, but each is independently worth guarding):

- `import-scanner.js`: reject include paths that resolve outside `baseDir` before adding them to `gatewayConfig.files`
- `import-config.js`: same check in `resolveImportedConfigPaths` against `openclawDir`
- `secret-detector.js`: `detectSecrets()`/`extractPreFillValues()` now resolve `configFiles`/`envFiles` entries within `baseDir` themselves (mirroring the `resolveExtractionTargetPath` helper already used correctly elsewhere in `import-applier.js`) rather than trusting that every caller already validated its input

## Test plan
- [x] Added tests for all three fix points across `tests/server/import-scanner.test.js`, `tests/server/import-config.test.js` (new file), and `tests/server/secret-detector.test.js`.
- [x] Each test verified locally to **fail without the fix** (proving the traversal reaches a real external file / discloses a real secret value) and pass with it.
- [x] Full suites for the touched files pass (pre-existing unrelated failures on this environment are Windows-path-separator artifacts in the mock-fs test harness, not caused by this change).