### PR TITLE
feat: add named OrcaRouter provider for onboarding and model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ CMD ["alphaclaw", "start"]
 | **Cron**      | Cron job management, interactive rolling calendar, run-history drilldowns, trend analytics, and per-run usage breakdowns |
 | **Nodes**     | Guided local-node setup for VPS deployments, per-node browser attach, reconnect commands, and routing/pairing controls   |
 | **Watchdog**  | Health monitoring, crash-loop status, auto-repair toggle, notifications, event log, live log tail, interactive terminal  |
-| **Providers** | AI provider credentials (Anthropic, OpenAI, Gemini, Mistral, Voyage, Groq, Deepgram) and model selection                 |
+| **Providers** | AI provider credentials (Anthropic, OpenAI, Gemini, OrcaRouter, Mistral, Voyage, Groq, Deepgram) and model selection      |
 | **Envars**    | Environment variables — view, edit, add — with gateway restart prompts                                                   |
 | **Webhooks**  | Webhook endpoints, transform modules, request history, payload inspection, OAuth callbacks, Gmail watch delivery flows   |
 

--- a/lib/public/js/lib/model-config.js
+++ b/lib/public/js/lib/model-config.js
@@ -37,6 +37,10 @@ export const kFeaturedModelDefs = [
     label: "Gemini 3.1 Pro",
     preferredKeys: ["google/gemini-3.1-pro-preview"],
   },
+  {
+    label: "OrcaRouter Auto",
+    preferredKeys: ["orcarouter/auto"],
+  },
 ];
 
 const kDeprecatedOnboardingModelKeys = new Set([
@@ -202,6 +206,15 @@ export const kProviderAuthFields = {
       placeholder: "sk-or-...",
     },
   ],
+  orcarouter: [
+    {
+      key: "ORCAROUTER_API_KEY",
+      label: "OrcaRouter API Key",
+      url: "https://www.orcarouter.ai",
+      linkText: "Get key",
+      placeholder: "sk-orca-...",
+    },
+  ],
   zai: [
     {
       key: "ZAI_API_KEY",
@@ -330,6 +343,7 @@ export const kProviderLabels = {
   google: "Gemini",
   opencode: "OpenCode Zen",
   openrouter: "OpenRouter",
+  orcarouter: "OrcaRouter",
   zai: "Z.AI",
   "vercel-ai-gateway": "Vercel AI Gateway",
   kilocode: "Kilo Gateway",
@@ -355,6 +369,7 @@ export const kProviderOrder = [
   "zai",
   "xai",
   "openrouter",
+  "orcarouter",
   "opencode",
   "kilocode",
   "vercel-ai-gateway",
@@ -372,7 +387,13 @@ export const kProviderOrder = [
   "vllm",
 ];
 
-export const kCoreProviders = new Set(["anthropic", "openai", "google", "openrouter"]);
+export const kCoreProviders = new Set([
+  "anthropic",
+  "openai",
+  "google",
+  "openrouter",
+  "orcarouter",
+]);
 
 export const kProviderFeatures = {
   anthropic: ["Agent Model"],
@@ -380,6 +401,7 @@ export const kProviderFeatures = {
   google: ["Agent Model", "Embeddings", "Audio"],
   opencode: ["Agent Model"],
   openrouter: ["Agent Model"],
+  orcarouter: ["Agent Model"],
   zai: ["Agent Model"],
   "vercel-ai-gateway": ["Agent Model"],
   kilocode: ["Agent Model"],

--- a/lib/server/auth-profiles.js
+++ b/lib/server/auth-profiles.js
@@ -27,6 +27,7 @@ const kApiKeyEnvVarByProvider = {
   groq: "GROQ_API_KEY",
   deepgram: "DEEPGRAM_API_KEY",
   vllm: "VLLM_API_KEY",
+  orcarouter: "ORCAROUTER_API_KEY",
 };
 
 const normalizeSecret = (raw) =>

--- a/lib/server/constants.js
+++ b/lib/server/constants.js
@@ -145,6 +145,7 @@ const kOnboardingModelProviders = new Set([
   "voyage",
   "groq",
   "vllm",
+  "orcarouter",
 ]);
 const kMinimalFallbackOnboardingModels = [
   {
@@ -309,6 +310,13 @@ const kKnownVars = [
     group: "ai",
     hint: "From elevenlabs.io (XI_API_KEY also works)",
     features: ["TTS"],
+  },
+  {
+    key: "ORCAROUTER_API_KEY",
+    label: "OrcaRouter API Key",
+    group: "ai",
+    hint: "From orcarouter.ai",
+    features: ["Models"],
   },
   {
     key: "GITHUB_TOKEN",

--- a/lib/server/onboarding/import/secret-detector.js
+++ b/lib/server/onboarding/import/secret-detector.js
@@ -76,6 +76,7 @@ const kConfigPathToEnvVar = {
   "models.providers.minimax.apiKey": "MINIMAX_API_KEY",
   "models.providers.voyage.apiKey": "VOYAGE_API_KEY",
   "models.providers.vllm.apiKey": "VLLM_API_KEY",
+  "models.providers.orcarouter.apiKey": "ORCAROUTER_API_KEY",
   "tools.web.search.apiKey": "BRAVE_API_KEY",
   "audio.apiKey": "ELEVENLABS_API_KEY",
   "talk.apiKey": "ELEVENLABS_API_KEY",

--- a/lib/server/onboarding/index.js
+++ b/lib/server/onboarding/index.js
@@ -12,6 +12,7 @@ const {
 } = require("./github");
 const {
   buildOnboardArgs,
+  ensureOrcaRouterProviderEntry,
   writeManagedImportOpenclawConfig,
   writeSanitizedOpenclawConfig,
 } = require("./openclaw");
@@ -181,6 +182,7 @@ const syncApiKeyAuthProfilesFromEnvVars = (authProfiles, envVars = []) => {
     "groq",
     "deepgram",
     "vllm",
+    "orcarouter",
   ];
   const envMap = new Map(
     (envVars || []).map((entry) => [
@@ -511,6 +513,36 @@ const createOnboardingService = ({
       );
     }
 
+    // Register the named OrcaRouter provider before `models set` so a model
+    // key like `orcarouter/auto` resolves to a known inline provider.
+    const orcaRouterKeyValue = String(
+      varMap.ORCAROUTER_API_KEY || "",
+    ).trim();
+    if (orcaRouterKeyValue) {
+      try {
+        const preConfigPath = `${OPENCLAW_DIR}/openclaw.json`;
+        if (fs.existsSync(preConfigPath)) {
+          const preConfig = JSON.parse(
+            fs.readFileSync(preConfigPath, "utf8"),
+          );
+          ensureOrcaRouterProviderEntry({
+            cfg: preConfig,
+            hasOrcaRouterKey: true,
+          });
+          fs.writeFileSync(
+            preConfigPath,
+            JSON.stringify(preConfig, null, 2),
+          );
+          console.log("[onboard] OrcaRouter provider registered");
+        }
+      } catch (err) {
+        console.error(
+          "[onboard] Failed to register OrcaRouter provider:",
+          err.message,
+        );
+      }
+    }
+
     await shellCmd(`openclaw models set "${modelKey}"`, {
       env: gatewayEnv(),
       timeout: 30000,
@@ -520,7 +552,6 @@ const createOnboardingService = ({
         `Onboarding completed but failed to set model "${modelKey}"`,
       );
     });
-
     try {
       fs.rmSync(`${WORKSPACE_DIR}/.git`, { recursive: true, force: true });
     } catch {}

--- a/lib/server/onboarding/openclaw.js
+++ b/lib/server/onboarding/openclaw.js
@@ -232,6 +232,29 @@ const applyFreshOnboardingChannels = ({
   ensureUsageTrackerPluginEntry(cfg);
 };
 
+const kOrcaRouterBaseUrl = "https://api.orcarouter.ai/v1";
+const kOrcaRouterModels = [
+  { id: "orcarouter/auto", name: "OrcaRouter Auto" },
+  { id: "orcarouter/fusion", name: "OrcaRouter Fusion" },
+  { id: "orcarouter/fusion-flash", name: "OrcaRouter Fusion Flash" },
+  { id: "orcarouter/fusion-mini", name: "OrcaRouter Fusion Mini" },
+];
+
+const ensureOrcaRouterProviderEntry = ({ cfg, hasOrcaRouterKey }) => {
+  if (!hasOrcaRouterKey) return cfg;
+  if (!cfg.models) cfg.models = {};
+  if (!cfg.models.providers) cfg.models.providers = {};
+  if (!cfg.models.providers.orcarouter) {
+    cfg.models.providers.orcarouter = {
+      baseUrl: kOrcaRouterBaseUrl,
+      api: "openai-completions",
+      apiKey: "${ORCAROUTER_API_KEY}",
+      models: kOrcaRouterModels,
+    };
+  }
+  return cfg;
+};
+
 const writeSanitizedOpenclawConfig = ({
   fs,
   openclawDir,
@@ -248,6 +271,10 @@ const writeSanitizedOpenclawConfig = ({
   applyFreshOnboardingChannels({
     cfg,
     varMap,
+  });
+  ensureOrcaRouterProviderEntry({
+    cfg,
+    hasOrcaRouterKey: !!String(varMap.ORCAROUTER_API_KEY || "").trim(),
   });
   ensureCodexRuntimePlugin(cfg);
 
@@ -359,6 +386,11 @@ const writeManagedImportOpenclawConfig = ({
     ensurePluginAllowed({ cfg, pluginKey: "whatsapp" });
   }
 
+  ensureOrcaRouterProviderEntry({
+    cfg,
+    hasOrcaRouterKey: !!String(varMap.ORCAROUTER_API_KEY || "").trim(),
+  });
+
   ensureCodexRuntimePlugin(cfg);
 
   fs.writeFileSync(configPath, JSON.stringify(cfg, null, 2));
@@ -368,4 +400,5 @@ module.exports = {
   buildOnboardArgs,
   writeManagedImportOpenclawConfig,
   writeSanitizedOpenclawConfig,
+  ensureOrcaRouterProviderEntry,
 };

--- a/tests/frontend/model-config.test.js
+++ b/tests/frontend/model-config.test.js
@@ -25,6 +25,16 @@ describe("frontend/model-config", () => {
     expect(volcengineKeys.has("VOLCANO_ENGINE_API_KEY")).toBe(true);
   });
 
+  it("registers the named OrcaRouter provider with its auth key", async () => {
+    const modelConfig = await loadModelConfig();
+    const orcaKeys = modelConfig.getVisibleAiFieldKeys("orcarouter");
+    expect(orcaKeys.has("ORCAROUTER_API_KEY")).toBe(true);
+    expect(modelConfig.kProviderLabels.orcarouter).toBe("OrcaRouter");
+    expect(modelConfig.kProviderOrder).toContain("orcarouter");
+    expect(modelConfig.kCoreProviders.has("orcarouter")).toBe(true);
+    expect(modelConfig.kProviderFeatures.orcarouter).toEqual(["Agent Model"]);
+  });
+
   it("picks featured models in defined preference order", async () => {
     const modelConfig = await loadModelConfig();
     const featured = modelConfig.getFeaturedModels([

--- a/tests/server/auth-profiles.test.js
+++ b/tests/server/auth-profiles.test.js
@@ -448,4 +448,12 @@ describe("server/auth-profiles", () => {
     expect(config.auth?.profiles || {}).toEqual({});
     expect(config.gateway.port).toBe(18789);
   });
+
+  it("maps the named OrcaRouter provider to ORCAROUTER_API_KEY", () => {
+    const { getEnvVarForApiKeyProvider } = require("../../lib/server/auth-profiles");
+    expect(getEnvVarForApiKeyProvider("orcarouter")).toBe(
+      "ORCAROUTER_API_KEY",
+    );
+    expect(ap.listApiKeyProviders()).toContain("orcarouter");
+  });
 });

--- a/tests/server/helpers.test.js
+++ b/tests/server/helpers.test.js
@@ -72,6 +72,7 @@ describe("server/helpers", () => {
       { key: "anthropic/claude-opus-4-6", name: "Opus 4.6" },
       { key: "zai/glm-5", name: "GLM 5" },
       { key: "minimax/MiniMax-M2.5", name: "MiniMax M2.5" },
+      { key: "orcarouter/auto", name: "OrcaRouter Auto" },
       { key: "openai/gpt-5.1-codex", name: "Duplicate" },
       { key: "google/gemini-3.1-pro-preview" },
       { bad: "shape" },
@@ -103,6 +104,11 @@ describe("server/helpers", () => {
         provider: "openai",
         label: "GPT-5.4-Mini",
         agentRuntime: { id: "codex" },
+      },
+      {
+        key: "orcarouter/auto",
+        provider: "orcarouter",
+        label: "OrcaRouter Auto",
       },
       {
         key: "zai/glm-5",

--- a/tests/server/onboarding-openclaw.test.js
+++ b/tests/server/onboarding-openclaw.test.js
@@ -4,6 +4,7 @@ const path = require("path");
 
 const {
   buildOnboardArgs,
+  ensureOrcaRouterProviderEntry,
   writeManagedImportOpenclawConfig,
   writeSanitizedOpenclawConfig,
 } = require("../../lib/server/onboarding/openclaw");
@@ -212,5 +213,75 @@ describe("server/onboarding/openclaw", () => {
     expect(next.channels.discord.enabled).toBe(true);
     expect(next.channels.discord.dmPolicy).toBe("pairing");
     expect(next.channels.discord.token).toBe("${DISCORD_BOT_TOKEN}");
+  });
+
+  it("writes the named OrcaRouter provider when ORCAROUTER_API_KEY is present", () => {
+    const openclawDir = createTempOpenclawDir();
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ plugins: { entries: {} }, channels: {} }, null, 2),
+      "utf8",
+    );
+
+    writeSanitizedOpenclawConfig({
+      fs,
+      openclawDir,
+      varMap: { ORCAROUTER_API_KEY: "sk-orca-test" },
+    });
+
+    const next = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(next.models.providers.orcarouter).toEqual({
+      baseUrl: "https://api.orcarouter.ai/v1",
+      api: "openai-completions",
+      apiKey: "${ORCAROUTER_API_KEY}",
+      models: [
+        { id: "orcarouter/auto", name: "OrcaRouter Auto" },
+        { id: "orcarouter/fusion", name: "OrcaRouter Fusion" },
+        { id: "orcarouter/fusion-flash", name: "OrcaRouter Fusion Flash" },
+        { id: "orcarouter/fusion-mini", name: "OrcaRouter Fusion Mini" },
+      ],
+    });
+  });
+
+  it("does not write the OrcaRouter provider when the key is absent", () => {
+    const openclawDir = createTempOpenclawDir();
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ plugins: { entries: {} }, channels: {} }, null, 2),
+      "utf8",
+    );
+
+    writeSanitizedOpenclawConfig({
+      fs,
+      openclawDir,
+      varMap: {},
+    });
+
+    const next = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(next.models).toBeUndefined();
+  });
+
+  it("ensureOrcaRouterProviderEntry preserves an existing orcarouter provider entry", () => {
+    const cfg = {
+      models: {
+        providers: {
+          orcarouter: {
+            baseUrl: "https://custom.example/v1",
+            api: "openai-completions",
+            apiKey: "${ORCAROUTER_API_KEY}",
+            models: [{ id: "orcarouter/auto", name: "Custom" }],
+          },
+        },
+      },
+    };
+    const next = ensureOrcaRouterProviderEntry({ cfg, hasOrcaRouterKey: true });
+    expect(next.models.providers.orcarouter.baseUrl).toBe(
+      "https://custom.example/v1",
+    );
+    expect(next.models.providers.orcarouter.models[0].id).toBe(
+      "orcarouter/auto",
+    );
   });
 });

--- a/tests/server/onboarding-validation.test.js
+++ b/tests/server/onboarding-validation.test.js
@@ -40,6 +40,27 @@ describe("onboarding/validation", () => {
     expect(res.error).toBe('Missing credentials for selected provider "openrouter"');
   });
 
+  it("accepts ORCAROUTER_API_KEY when the selected model uses the orcarouter provider", () => {
+    const res = validateOnboardingInput({
+      vars: [...kBaseVars(), { key: "ORCAROUTER_API_KEY", value: "sk-orca-test" }],
+      modelKey: "orcarouter/auto",
+      resolveModelProvider: kResolveProvider,
+      hasCodexOauthProfile: () => false,
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects orcarouter model when only unrelated API keys are present", () => {
+    const res = validateOnboardingInput({
+      vars: [...kBaseVars(), { key: "OPENAI_API_KEY", value: "sk-test" }],
+      modelKey: "orcarouter/auto",
+      resolveModelProvider: kResolveProvider,
+      hasCodexOauthProfile: () => false,
+    });
+    expect(res.ok).toBe(false);
+    expect(res.error).toBe('Missing credentials for selected provider "orcarouter"');
+  });
+
   it("accepts whatsapp owner number as the required channel credential", () => {
     const res = validateOnboardingInput({
       vars: [

--- a/tests/server/secret-detector.test.js
+++ b/tests/server/secret-detector.test.js
@@ -119,6 +119,7 @@ describe("secret-detector", () => {
             "kimi-coding": { apiKey: "kimi-secret-value-12345" },
             "vercel-ai-gateway": { apiKey: "gateway-secret-value-12345" },
             volcengine: { apiKey: "volcengine-secret-value-12345" },
+            orcarouter: { apiKey: "orcarouter-secret-value-12345" },
           },
         },
       };
@@ -162,6 +163,11 @@ describe("secret-detector", () => {
           (s) => s.configPath === "models.providers.volcengine.apiKey",
         )?.suggestedEnvVar,
       ).toBe("VOLCANO_ENGINE_API_KEY");
+      expect(
+        secrets.find(
+          (s) => s.configPath === "models.providers.orcarouter.apiKey",
+        )?.suggestedEnvVar,
+      ).toBe("ORCAROUTER_API_KEY");
     });
 
     it("falls back to provider-scoped env names for unmapped model providers", () => {


### PR DESCRIPTION
## Summary

Adds **OrcaRouter** as a first-class, named model provider so AlphaClaw users can route their OpenClaw agent through [OrcaRouter](https://www.orcarouter.ai) with a single `ORCAROUTER_API_KEY`.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### What changed

- **Onboarding** (`lib/server/onboarding/openclaw.js`, `lib/server/onboarding/index.js`): when `ORCAROUTER_API_KEY` is present, write a named `models.providers.orcarouter` block into `openclaw.json` — `baseUrl: https://api.orcarouter.ai/v1`, `openai-completions` transport, `apiKey: ${ORCAROUTER_API_KEY}`, and the OrcaRouter model set (`orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini`). The block is written before `openclaw models set` so `orcarouter/*` model keys resolve to a known provider.
- **Model UI** (`lib/public/js/lib/model-config.js`): register the `orcarouter` provider (auth field, label, display order, features, and a featured `orcarouter/auto` model).
- **Server wiring** (`lib/server/constants.js`, `lib/server/auth-profiles.js`): allow `orcarouter` in onboarding model providers, surface `ORCAROUTER_API_KEY` in the Envars tab, and map it to an api-key auth profile.
- **Import scanner** (`lib/server/onboarding/import/secret-detector.js`): map `models.providers.orcarouter.apiKey` to `ORCAROUTER_API_KEY`.
- **README**: list OrcaRouter among supported AI providers.

### Why a named provider

A named OrcaRouter entry is preferable to a generic OpenAI-compatible passthrough: users see and explicitly select OrcaRouter, and the provider base URL, auth, and model set are pre-configured correctly.

### How it was tested

- `npm test` — 735/735 passing (new tests cover onboarding config writing, validation, auth-profile mapping, env-var hint, and model-catalog filtering).
- `npm run build:ui` — succeeds.
- Live end-to-end: configured `models.providers.orcarouter` in an OpenClaw instance with a real key, ran `openclaw models set orcarouter/auto` and `openclaw models list` — all four OrcaRouter models appear `available: true`, and an `openclaw agent --local` turn resolved `winnerProvider: orcarouter` / `winnerModel: orcarouter/auto` with a successful reply for each model.

Disclosure: I'm an engineer on the OrcaRouter team.
