### PR TITLE
fix(test): clean up leaked temp dirs and raise testTimeout for macOS ARM64

### DIFF
--- a/tests/server/routes-browse.test.js
+++ b/tests/server/routes-browse.test.js
@@ -7,8 +7,12 @@ const request = require("supertest");
 
 const { registerBrowseRoutes } = require("../../lib/server/routes/browse");
 
-const createTestRoot = () =>
-  fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-browse-test-"));
+const createdTestRoots = [];
+const createTestRoot = () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-browse-test-"));
+  createdTestRoots.push(dir);
+  return dir;
+};
 
 const createApp = (kRootDir) => {
   const app = express();
@@ -26,6 +30,12 @@ const runGit = (cwd, args) =>
     .trim();
 
 describe("server/routes/browse", () => {
+  afterEach(() => {
+    for (const dir of createdTestRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns browse tree rooted at configured directory", async () => {
     const rootDir = createTestRoot();
     fs.mkdirSync(path.join(rootDir, "devices"), { recursive: true });

--- a/tests/server/routes-models.test.js
+++ b/tests/server/routes-models.test.js
@@ -52,12 +52,15 @@ const createModelDeps = () => {
   return deps;
 };
 
+const createdTempRoots = [];
+
 const createApp = (deps) => {
   const app = express();
   app.use(express.json());
   const tempRoot = fs.mkdtempSync(
     path.join(os.tmpdir(), "alphaclaw-routes-models-"),
   );
+  createdTempRoots.push(tempRoot);
   const modelCatalogCache = createModelCatalogCache({
     cachePath: path.join(tempRoot, "cache", "model-catalog.json"),
     shellCmd: deps.shellCmd,
@@ -76,6 +79,12 @@ const createApp = (deps) => {
 };
 
 describe("server/routes/models", () => {
+  afterEach(() => {
+    for (const dir of createdTempRoots.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("bootstraps with the bundled catalog, then returns normalized models from openclaw output", async () => {
     const deps = createModelDeps();
     deps.shellCmd.mockResolvedValue("noise");

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
     include: ["tests/**/*.test.js"],
     restoreMocks: true,
     clearMocks: true,
+    testTimeout: 10000,
   },
 });


### PR DESCRIPTION
## Summary

Two of the server route test suites (`routes-browse.test.js`,
`routes-models.test.js`) create a fresh `mkdtempSync()` temp directory
per test case but never clean it up. Over a full local run this leaves
dozens of leaked directories under macOS's memory-mapped `/var/folders/.../T`.

Under vitest's parallel workers on macOS ARM64, that accumulated memory
pressure slows down **all** workers -- including pure-mock tests with no
filesystem I/O of their own -- past the default 5s test timeout,
producing intermittent, hard-to-reproduce failures that look unrelated
to the actual cause.

## Fix

- `tests/server/routes-browse.test.js`: track each created temp dir in
  `createdTestRoots[]`; `afterEach` splices and `rmSync({recursive,
  force: true})` every entry.
- `tests/server/routes-models.test.js`: same pattern (`createdTempRoots`)
  for the temp roots created in `createApp()`.
- `vitest.config.js`: `testTimeout` 5000ms -> 10000ms as a safety margin
  while workers finish draining any pre-existing temp-dir backlog from a
  run before this fix.

This is a fix-only PR -- no behavior, API, or test-assertion changes,
just leaked-resource cleanup and a timeout safety margin.

## Test plan

- [x] `npx vitest run tests/server/routes-browse.test.js
      tests/server/routes-models.test.js` -- 37/37 pass
- [x] Confirmed 0 leaked temp dirs under `/var/folders/*/T/alphaclaw-*`
      after a full run (previously non-zero, growing with every run)
- [x] Full suite run before/after: identical pre-existing pass/fail
      counts elsewhere in the suite -- this change touches only the two
      files above, no regressions introduced