### PR TITLE
fix: expose OpenClaw CLI to gateway-spawned agent shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["alphaclaw", "start"]
 ```
 
+At startup, AlphaClaw also exposes the bundled OpenClaw CLI at
+`/usr/local/bin/openclaw`. This keeps the command available to gateway-spawned
+agent shells whose minimal `PATH` may not include `/app/node_modules/.bin`.
+
 ## Setup UI
 
 | Tab           | What it manages                                                                                                          |

--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -19,6 +19,9 @@ const {
   ensureMainUpstream,
   restoreMissingOpenclawConfigFromRemote,
 } = require("../lib/cli/openclaw-config-restore");
+const {
+  ensureOpenclawCliShim,
+} = require("../lib/cli/openclaw-runtime");
 const { buildSecretReplacements } = require("../lib/server/helpers");
 const {
   migrateLegacyTelegramStreamingConfig,
@@ -933,7 +936,24 @@ if (fs.existsSync(configPath)) {
 }
 
 // ---------------------------------------------------------------------------
-// 12. Install systemctl shim if in Docker (no real systemd)
+// 12. Expose the bundled OpenClaw CLI to gateway-spawned agent shells
+// ---------------------------------------------------------------------------
+
+try {
+  const result = ensureOpenclawCliShim();
+  const version = execFileSync(result.shimPath, ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  console.log(
+    `[alphaclaw] OpenClaw CLI ${result.action} at ${result.shimPath} (${version})`,
+  );
+} catch (e) {
+  console.warn(`[alphaclaw] OpenClaw CLI shim unavailable: ${e.message}`);
+}
+
+// ---------------------------------------------------------------------------
+// 13. Install systemctl shim if in Docker (no real systemd)
 // ---------------------------------------------------------------------------
 
 try {
@@ -951,7 +971,7 @@ try {
 }
 
 // ---------------------------------------------------------------------------
-// 13. Install git auth shim
+// 14. Install git auth shim
 // ---------------------------------------------------------------------------
 
 try {
@@ -991,7 +1011,7 @@ try {
 }
 
 // ---------------------------------------------------------------------------
-// 14. Start Express server
+// 15. Start Express server
 // ---------------------------------------------------------------------------
 
 console.log("[alphaclaw] Setup complete -- starting server");

--- a/lib/cli/openclaw-runtime.js
+++ b/lib/cli/openclaw-runtime.js
@@ -1,0 +1,81 @@
+const fs = require("fs");
+const path = require("path");
+
+const kDefaultOpenclawShimPath = "/usr/local/bin/openclaw";
+
+const resolveOpenclawEntrypoint = ({
+  resolveModule = require.resolve,
+  fsModule = fs,
+} = {}) => {
+  const exportedEntrypointPath = resolveModule("openclaw");
+  const exportedEntrypointDir = path.dirname(exportedEntrypointPath);
+  const packageRoot =
+    path.basename(exportedEntrypointDir) === "dist"
+      ? path.dirname(exportedEntrypointDir)
+      : exportedEntrypointDir;
+  const entrypointPath = path.join(packageRoot, "openclaw.mjs");
+  fsModule.accessSync(entrypointPath, fsModule.constants.X_OK);
+  return entrypointPath;
+};
+
+const ensureOpenclawCliShim = ({
+  fsModule = fs,
+  shimPath = kDefaultOpenclawShimPath,
+  entrypointPath = resolveOpenclawEntrypoint({ fsModule }),
+  processId = process.pid,
+  now = Date.now,
+} = {}) => {
+  const resolvedShimPath = path.resolve(shimPath);
+  const resolvedEntrypointPath = path.resolve(entrypointPath);
+
+  try {
+    const stat = fsModule.lstatSync(resolvedShimPath);
+    if (!stat.isSymbolicLink()) {
+      return {
+        action: "preserved",
+        entrypointPath: resolvedEntrypointPath,
+        shimPath: resolvedShimPath,
+      };
+    }
+
+    const currentTarget = fsModule.readlinkSync(resolvedShimPath);
+    const resolvedCurrentTarget = path.resolve(
+      path.dirname(resolvedShimPath),
+      currentTarget,
+    );
+    if (resolvedCurrentTarget === resolvedEntrypointPath) {
+      return {
+        action: "unchanged",
+        entrypointPath: resolvedEntrypointPath,
+        shimPath: resolvedShimPath,
+      };
+    }
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+
+  fsModule.mkdirSync(path.dirname(resolvedShimPath), { recursive: true });
+  const temporaryShimPath = `${resolvedShimPath}.alphaclaw-${processId}-${now()}`;
+  try {
+    fsModule.symlinkSync(resolvedEntrypointPath, temporaryShimPath);
+    fsModule.renameSync(temporaryShimPath, resolvedShimPath);
+  } finally {
+    try {
+      fsModule.unlinkSync(temporaryShimPath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+
+  return {
+    action: "installed",
+    entrypointPath: resolvedEntrypointPath,
+    shimPath: resolvedShimPath,
+  };
+};
+
+module.exports = {
+  kDefaultOpenclawShimPath,
+  resolveOpenclawEntrypoint,
+  ensureOpenclawCliShim,
+};

--- a/tests/server/openclaw-cli-runtime.test.js
+++ b/tests/server/openclaw-cli-runtime.test.js
@@ -1,0 +1,118 @@
+const path = require("path");
+const {
+  resolveOpenclawEntrypoint,
+  ensureOpenclawCliShim,
+} = require("../../lib/cli/openclaw-runtime");
+
+const createFsMock = ({
+  existingShim = null,
+  existingTarget = "",
+} = {}) => {
+  const entries = new Map();
+  if (existingShim) entries.set(existingShim, { type: "symlink", target: existingTarget });
+
+  return {
+    constants: { X_OK: 1 },
+    accessSync: vi.fn(),
+    mkdirSync: vi.fn(),
+    lstatSync(targetPath) {
+      const entry = entries.get(targetPath);
+      if (!entry) throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      return { isSymbolicLink: () => entry.type === "symlink" };
+    },
+    readlinkSync(targetPath) {
+      return entries.get(targetPath).target;
+    },
+    symlinkSync(target, shimPath) {
+      entries.set(shimPath, { type: "symlink", target });
+    },
+    renameSync(fromPath, toPath) {
+      entries.set(toPath, entries.get(fromPath));
+      entries.delete(fromPath);
+    },
+    unlinkSync(targetPath) {
+      if (!entries.delete(targetPath)) {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      }
+    },
+  };
+};
+
+describe("cli/openclaw runtime", () => {
+  it("resolves the executable entrypoint next to the OpenClaw package manifest", () => {
+    const fsModule = createFsMock();
+    const entrypointPath = resolveOpenclawEntrypoint({
+      fsModule,
+      resolveModule: () => "/app/node_modules/openclaw/dist/index.js",
+    });
+
+    expect(entrypointPath).toBe("/app/node_modules/openclaw/openclaw.mjs");
+    expect(fsModule.accessSync).toHaveBeenCalledWith(entrypointPath, 1);
+  });
+
+  it("installs a launcher atomically when it is missing", () => {
+    const fsModule = createFsMock();
+    const result = ensureOpenclawCliShim({
+      fsModule,
+      shimPath: "/usr/local/bin/openclaw",
+      entrypointPath: "/app/node_modules/openclaw/openclaw.mjs",
+      processId: 42,
+      now: () => 1000,
+    });
+
+    expect(result.action).toBe("installed");
+    expect(fsModule.mkdirSync).toHaveBeenCalledWith("/usr/local/bin", {
+      recursive: true,
+    });
+    expect(fsModule.readlinkSync(result.shimPath)).toBe(result.entrypointPath);
+  });
+
+  it("keeps a correct existing launcher unchanged", () => {
+    const shimPath = "/usr/local/bin/openclaw";
+    const entrypointPath = "/app/node_modules/openclaw/openclaw.mjs";
+    const fsModule = createFsMock({
+      existingShim: shimPath,
+      existingTarget: entrypointPath,
+    });
+
+    const result = ensureOpenclawCliShim({ fsModule, shimPath, entrypointPath });
+
+    expect(result.action).toBe("unchanged");
+    expect(fsModule.mkdirSync).not.toHaveBeenCalled();
+  });
+
+  it("replaces a stale launcher after an OpenClaw update", () => {
+    const shimPath = "/usr/local/bin/openclaw";
+    const fsModule = createFsMock({
+      existingShim: shimPath,
+      existingTarget: "/app/node_modules/.openclaw-old/openclaw.mjs",
+    });
+
+    const result = ensureOpenclawCliShim({
+      fsModule,
+      shimPath,
+      entrypointPath: "/app/node_modules/openclaw/openclaw.mjs",
+      processId: 42,
+      now: () => 1000,
+    });
+
+    expect(result.action).toBe("installed");
+    expect(fsModule.readlinkSync(shimPath)).toBe(
+      "/app/node_modules/openclaw/openclaw.mjs",
+    );
+  });
+
+  it("does not overwrite an unmanaged regular launcher", () => {
+    const fsModule = createFsMock();
+    fsModule.lstatSync = () => ({ isSymbolicLink: () => false });
+
+    const result = ensureOpenclawCliShim({
+      fsModule,
+      shimPath: "/usr/local/bin/openclaw",
+      entrypointPath: "/app/node_modules/openclaw/openclaw.mjs",
+    });
+
+    expect(result.action).toBe("preserved");
+    expect(fsModule.mkdirSync).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

AlphaClaw starts with `/app/node_modules/.bin` on PATH, but gateway-spawned agent shells can receive a minimal PATH without that directory. `openclaw` then fails with exit 127 even though the bundled package and Gateway are healthy. Agents may fall back to stale paths such as `/app/openclaw.mjs`, producing `MODULE_NOT_FOUND`.

## Fix

- Resolve the installed OpenClaw package entrypoint without assuming npm hoisting layout.
- Atomically install or refresh `/usr/local/bin/openclaw` during AlphaClaw startup.
- Preserve an unmanaged regular launcher.
- Verify the launcher with `openclaw --version` and emit a clear warning if setup fails.
- Document the launcher behavior.

## Validation

- `npm test`: 732 passed; one unrelated existing failure in `openclaw-codex-migration.test.js` (SQLite verification does not find imported profile).
- Focused startup/Gateway suite: 54 passed.
- New runtime helper suite: 5 passed.
- Real deployment reproduction: isolated OpenClaw cron executed `openclaw --version` with exit 0 after the launcher was present.

The startup operation is idempotent and refreshes stale symlinks after package updates.