### PR TITLE
Fix beta startup and oversized live status events

### DIFF
--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -819,6 +819,11 @@ if (fs.existsSync(configPath)) {
       stateDir: openclawDir,
       env: process.env,
     });
+    if (result.retiredManagedExecApprovals?.retired) {
+      console.log(
+        `[alphaclaw] Archived retired exec approvals stub at ${result.retiredManagedExecApprovals.archivePath}`,
+      );
+    }
     if (result.changed) {
       console.log(
         `[alphaclaw] Migrated OpenClaw config from ${result.fromVersion} to ${result.toVersion}`,

--- a/lib/public/js/hooks/use-app-shell-controller.js
+++ b/lib/public/js/hooks/use-app-shell-controller.js
@@ -35,8 +35,6 @@ export const useAppShellController = ({ location = "" } = {}) => {
   const [statusPollingGraceElapsed, setStatusPollingGraceElapsed] = useState(false);
   const [statusStreamConnected, setStatusStreamConnected] = useState(false);
   const [statusStreamStatus, setStatusStreamStatus] = useState(null);
-  const [statusStreamWatchdog, setStatusStreamWatchdog] = useState(null);
-  const [statusStreamDoctor, setStatusStreamDoctor] = useState(null);
 
   const sharedStatusPoll = usePolling(fetchStatus, statusPollCadenceMs, {
     enabled:
@@ -53,11 +51,12 @@ export const useAppShellController = ({ location = "" } = {}) => {
       onboarded === true && !statusStreamConnected && statusPollingGraceElapsed,
     cacheKey: "/api/doctor/status",
   });
-  const sharedStatus = statusStreamStatus || sharedStatusPoll.data || null;
-  const sharedWatchdogStatus =
-    statusStreamWatchdog || sharedWatchdogPoll.data?.status || null;
-  const sharedDoctorStatus =
-    statusStreamDoctor || sharedDoctorPoll.data?.status || null;
+  const sharedStatus =
+    sharedStatusPoll.data || statusStreamStatus
+      ? { ...(sharedStatusPoll.data || {}), ...(statusStreamStatus || {}) }
+      : null;
+  const sharedWatchdogStatus = sharedWatchdogPoll.data?.status || null;
+  const sharedDoctorStatus = sharedDoctorPoll.data?.status || null;
   const isAnyRestartRequired = restartRequired || browseRestartRequired;
 
   const refreshSharedStatuses = useCallback(() => {
@@ -98,17 +97,12 @@ export const useAppShellController = ({ location = "" } = {}) => {
           onOpen: () => {
             if (disposed) return;
             setStatusStreamConnected(true);
+            refreshSharedStatuses();
           },
           onMessage: (payload = {}) => {
             if (disposed) return;
             if (payload.status && typeof payload.status === "object") {
               setStatusStreamStatus(payload.status);
-            }
-            if (payload.watchdogStatus && typeof payload.watchdogStatus === "object") {
-              setStatusStreamWatchdog(payload.watchdogStatus);
-            }
-            if (payload.doctorStatus && typeof payload.doctorStatus === "object") {
-              setStatusStreamDoctor(payload.doctorStatus);
             }
           },
           onError: () => {
@@ -129,7 +123,7 @@ export const useAppShellController = ({ location = "" } = {}) => {
         cleanup();
       }
     };
-  }, [onboarded]);
+  }, [onboarded, refreshSharedStatuses]);
 
   useEffect(() => {
     if (!onboarded) return;

--- a/lib/public/js/hooks/use-app-shell-controller.js
+++ b/lib/public/js/hooks/use-app-shell-controller.js
@@ -9,7 +9,7 @@ import {
   dismissRestartStatus,
   restartGateway,
   fetchWatchdogStatus,
-  fetchDoctorStatus,
+  fetchDoctorStatusSummary,
   subscribeStatusEvents,
 } from "../lib/api.js";
 import { shouldRequireRestartForBrowsePath } from "../lib/browse-restart-policy.js";
@@ -18,6 +18,7 @@ import { showToast } from "../components/toast.js";
 
 export const useAppShellController = ({ location = "" } = {}) => {
   const kInitialStatusPollDelayMs = 5000;
+  const kDoctorSummaryPollCadenceMs = 60000;
   const [onboarded, setOnboarded] = useState(null);
   const [authEnabled, setAuthEnabled] = useState(false);
   const [acVersion, setAcVersion] = useState(null);
@@ -45,11 +46,17 @@ export const useAppShellController = ({ location = "" } = {}) => {
     enabled: onboarded === true && statusPollingGraceElapsed,
     cacheKey: "/api/watchdog/status",
   });
-  const sharedDoctorPoll = usePolling(fetchDoctorStatus, statusPollCadenceMs, {
-    enabled:
-      onboarded === true && !statusStreamConnected && statusPollingGraceElapsed,
-    cacheKey: "/api/doctor/status",
-  });
+  const sharedDoctorPoll = usePolling(
+    fetchDoctorStatusSummary,
+    kDoctorSummaryPollCadenceMs,
+    {
+      enabled:
+        onboarded === true &&
+        location.startsWith("/general") &&
+        statusPollingGraceElapsed,
+      cacheKey: "/api/doctor/status?summary=true",
+    },
+  );
   const sharedStatus =
     sharedStatusPoll.data || statusStreamStatus
       ? { ...(sharedStatusPoll.data || {}), ...(statusStreamStatus || {}) }

--- a/lib/public/js/hooks/use-app-shell-controller.js
+++ b/lib/public/js/hooks/use-app-shell-controller.js
@@ -42,8 +42,7 @@ export const useAppShellController = ({ location = "" } = {}) => {
     cacheKey: "/api/status",
   });
   const sharedWatchdogPoll = usePolling(fetchWatchdogStatus, statusPollCadenceMs, {
-    enabled:
-      onboarded === true && !statusStreamConnected && statusPollingGraceElapsed,
+    enabled: onboarded === true && statusPollingGraceElapsed,
     cacheKey: "/api/watchdog/status",
   });
   const sharedDoctorPoll = usePolling(fetchDoctorStatus, statusPollCadenceMs, {

--- a/lib/public/js/lib/api.js
+++ b/lib/public/js/lib/api.js
@@ -240,6 +240,11 @@ export const fetchDoctorStatus = async () => {
   return parseJsonOrThrow(res, "Could not load Doctor status");
 };
 
+export const fetchDoctorStatusSummary = async () => {
+  const res = await authFetch("/api/doctor/status?summary=true");
+  return parseJsonOrThrow(res, "Could not load Doctor status");
+};
+
 export const startDoctorRun = async () => {
   const res = await authFetch("/api/doctor/run", {
     method: "POST",

--- a/lib/server/init/register-server-routes.js
+++ b/lib/server/init/register-server-routes.js
@@ -134,8 +134,6 @@ const registerServerRoutes = ({
     restartRequiredState,
     topicRegistry,
     authProfiles,
-    watchdog,
-    doctorService,
     ensureGatewayProxyConfig,
     getBaseUrl,
   });

--- a/lib/server/openclaw-doctor-preflight.js
+++ b/lib/server/openclaw-doctor-preflight.js
@@ -38,28 +38,79 @@ const isManagedExecApprovalsStub = (value) =>
 const isPlainObject = (value) =>
   !!value && typeof value === "object" && !Array.isArray(value);
 
+const kExecSecurityValues = new Set(["deny", "allowlist", "full"]);
+const kExecAskValues = new Set(["off", "on-miss", "always"]);
+
 const isOptionalEnum = (value, allowed) =>
   value === undefined || (typeof value === "string" && allowed.has(value));
+
+const isOptionalString = (value) =>
+  value === undefined || typeof value === "string";
+
+const isOptionalFiniteNumber = (value, { nonnegative = false } = {}) =>
+  value === undefined ||
+  (typeof value === "number" &&
+    Number.isFinite(value) &&
+    (!nonnegative || value >= 0));
+
+const isValidExecAllowlistEntry = (entry) => {
+  if (typeof entry === "string") return entry.trim().length > 0;
+  return (
+    isPlainObject(entry) &&
+    typeof entry.pattern === "string" &&
+    entry.pattern.trim().length > 0 &&
+    isOptionalString(entry.id) &&
+    isOptionalString(entry.source) &&
+    isOptionalString(entry.commandText) &&
+    isOptionalString(entry.argPattern) &&
+    isOptionalFiniteNumber(entry.lastUsedAt) &&
+    isOptionalString(entry.lastUsedCommand) &&
+    isOptionalString(entry.lastResolvedPath)
+  );
+};
+
+const isValidMcpToolGrant = (grant) =>
+  isPlainObject(grant) &&
+  typeof grant.server === "string" &&
+  grant.server.trim().length > 0 &&
+  typeof grant.tool === "string" &&
+  grant.tool.trim().length > 0 &&
+  grant.source === "allow-always" &&
+  typeof grant.addedAt === "number" &&
+  Number.isFinite(grant.addedAt) &&
+  grant.addedAt >= 0 &&
+  isOptionalFiniteNumber(grant.lastUsedAt, { nonnegative: true });
 
 const isValidExecApprovalPolicy = (value, { allowAllowlist = false } = {}) => {
   if (!isPlainObject(value)) return false;
   if (
-    !isOptionalEnum(value.security, new Set(["deny", "allowlist", "full"])) ||
-    !isOptionalEnum(value.ask, new Set(["off", "on-miss", "always"])) ||
-    !isOptionalEnum(value.askFallback, new Set(["deny", "allowlist", "full"])) ||
+    !isOptionalEnum(value.security, kExecSecurityValues) ||
+    !isOptionalEnum(value.ask, kExecAskValues) ||
+    !isOptionalEnum(value.askFallback, kExecSecurityValues) ||
     (value.autoAllowSkills !== undefined &&
       typeof value.autoAllowSkills !== "boolean")
   ) {
     return false;
   }
-  if (value.allowlist === undefined) return true;
-  if (!allowAllowlist || !Array.isArray(value.allowlist)) return false;
-  return value.allowlist.every(
-    (entry) =>
-      isPlainObject(entry) &&
-      typeof entry.pattern === "string" &&
-      entry.pattern.trim().length > 0,
-  );
+  if (value.allowlist !== undefined) {
+    if (
+      !allowAllowlist ||
+      !Array.isArray(value.allowlist) ||
+      !value.allowlist.every(isValidExecAllowlistEntry)
+    ) {
+      return false;
+    }
+  }
+  if (value.mcpTools !== undefined) {
+    if (
+      !allowAllowlist ||
+      !Array.isArray(value.mcpTools) ||
+      !value.mcpTools.every(isValidMcpToolGrant)
+    ) {
+      return false;
+    }
+  }
+  return true;
 };
 
 const isValidExecApprovalsPolicy = (value) => {
@@ -79,7 +130,12 @@ const isValidExecApprovalsPolicy = (value) => {
     return false;
   }
   if (value.agents !== undefined) {
-    if (!isPlainObject(value.agents)) return false;
+    if (
+      !isPlainObject(value.agents) ||
+      Object.hasOwn(value.agents, "__proto__")
+    ) {
+      return false;
+    }
     if (
       !Object.values(value.agents).every((agent) =>
         isValidExecApprovalPolicy(agent, { allowAllowlist: true }),

--- a/lib/server/openclaw-doctor-preflight.js
+++ b/lib/server/openclaw-doctor-preflight.js
@@ -35,6 +35,62 @@ const isManagedExecApprovalsStub = (value) =>
   value.defaults.askFallback === kManagedExecApprovalsStub.defaults.askFallback &&
   hasOnlyKeys(value.agents, []);
 
+const isPlainObject = (value) =>
+  !!value && typeof value === "object" && !Array.isArray(value);
+
+const isOptionalEnum = (value, allowed) =>
+  value === undefined || (typeof value === "string" && allowed.has(value));
+
+const isValidExecApprovalPolicy = (value, { allowAllowlist = false } = {}) => {
+  if (!isPlainObject(value)) return false;
+  if (
+    !isOptionalEnum(value.security, new Set(["deny", "allowlist", "full"])) ||
+    !isOptionalEnum(value.ask, new Set(["off", "on-miss", "always"])) ||
+    !isOptionalEnum(value.askFallback, new Set(["deny", "allowlist", "full"])) ||
+    (value.autoAllowSkills !== undefined &&
+      typeof value.autoAllowSkills !== "boolean")
+  ) {
+    return false;
+  }
+  if (value.allowlist === undefined) return true;
+  if (!allowAllowlist || !Array.isArray(value.allowlist)) return false;
+  return value.allowlist.every(
+    (entry) =>
+      isPlainObject(entry) &&
+      typeof entry.pattern === "string" &&
+      entry.pattern.trim().length > 0,
+  );
+};
+
+const isValidExecApprovalsPolicy = (value) => {
+  if (!isPlainObject(value) || value.version !== 1) return false;
+  if (
+    value.socket !== undefined &&
+    (!isPlainObject(value.socket) ||
+      (value.socket.path !== undefined && typeof value.socket.path !== "string") ||
+      (value.socket.token !== undefined && typeof value.socket.token !== "string"))
+  ) {
+    return false;
+  }
+  if (
+    value.defaults !== undefined &&
+    !isValidExecApprovalPolicy(value.defaults)
+  ) {
+    return false;
+  }
+  if (value.agents !== undefined) {
+    if (!isPlainObject(value.agents)) return false;
+    if (
+      !Object.values(value.agents).every((agent) =>
+        isValidExecApprovalPolicy(agent, { allowAllowlist: true }),
+      )
+    ) {
+      return false;
+    }
+  }
+  return true;
+};
+
 const retireManagedExecApprovalsStub = ({
   stateDir,
   fsImpl = fs,
@@ -65,7 +121,7 @@ const retireManagedExecApprovalsStub = ({
         )
         .get();
       const canonical = row?.raw_json ? JSON.parse(row.raw_json) : null;
-      if (!canonical || typeof canonical !== "object" || Array.isArray(canonical)) {
+      if (!isValidExecApprovalsPolicy(canonical)) {
         return { retired: false, reason: "missing-valid-canonical-policy" };
       }
     } finally {
@@ -199,6 +255,7 @@ const runOpenclawDoctorPreflight = ({
 
 module.exports = {
   findOpenclawPackage,
+  isValidExecApprovalsPolicy,
   isManagedExecApprovalsStub,
   retireManagedExecApprovalsStub,
   resolveOpenclawCliPath,

--- a/lib/server/openclaw-doctor-preflight.js
+++ b/lib/server/openclaw-doctor-preflight.js
@@ -1,10 +1,84 @@
 const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const { DatabaseSync } = require("node:sqlite");
 const {
   compareVersionParts,
   normalizeOpenclawVersion,
 } = require("./helpers");
+
+const kManagedExecApprovalsStub = Object.freeze({
+  version: 1,
+  defaults: Object.freeze({
+    security: "full",
+    ask: "off",
+    askFallback: "full",
+  }),
+  agents: Object.freeze({}),
+});
+
+const hasOnlyKeys = (value, expectedKeys) => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const keys = Object.keys(value).sort();
+  return (
+    keys.length === expectedKeys.length &&
+    keys.every((key, index) => key === expectedKeys[index])
+  );
+};
+
+const isManagedExecApprovalsStub = (value) =>
+  hasOnlyKeys(value, ["agents", "defaults", "version"]) &&
+  value.version === kManagedExecApprovalsStub.version &&
+  hasOnlyKeys(value.defaults, ["ask", "askFallback", "security"]) &&
+  value.defaults.security === kManagedExecApprovalsStub.defaults.security &&
+  value.defaults.ask === kManagedExecApprovalsStub.defaults.ask &&
+  value.defaults.askFallback === kManagedExecApprovalsStub.defaults.askFallback &&
+  hasOnlyKeys(value.agents, []);
+
+const retireManagedExecApprovalsStub = ({
+  stateDir,
+  fsImpl = fs,
+  DatabaseSyncImpl = DatabaseSync,
+  now = Date.now,
+} = {}) => {
+  if (!stateDir) return { retired: false, reason: "missing-state-dir" };
+  const sourcePath = path.join(stateDir, "exec-approvals.json");
+  const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+  if (!fsImpl.existsSync(sourcePath) || !fsImpl.existsSync(databasePath)) {
+    return { retired: false, reason: "missing-source-or-database" };
+  }
+  try {
+    if (!fsImpl.lstatSync(sourcePath).isFile()) {
+      return { retired: false, reason: "source-not-regular-file" };
+    }
+    const legacy = JSON.parse(fsImpl.readFileSync(sourcePath, "utf8"));
+    if (!isManagedExecApprovalsStub(legacy)) {
+      return { retired: false, reason: "legacy-policy-not-managed-stub" };
+    }
+
+    let db;
+    try {
+      db = new DatabaseSyncImpl(databasePath, { readOnly: true });
+      const row = db
+        .prepare(
+          "SELECT raw_json FROM exec_approvals_config WHERE config_key = 'current'",
+        )
+        .get();
+      const canonical = row?.raw_json ? JSON.parse(row.raw_json) : null;
+      if (!canonical || typeof canonical !== "object" || Array.isArray(canonical)) {
+        return { retired: false, reason: "missing-valid-canonical-policy" };
+      }
+    } finally {
+      db?.close();
+    }
+
+    const archivePath = `${sourcePath}.alphaclaw-retired-${Number(now())}`;
+    fsImpl.renameSync(sourcePath, archivePath);
+    return { retired: true, sourcePath, archivePath };
+  } catch {
+    return { retired: false, reason: "inspection-failed" };
+  }
+};
 
 const findOpenclawPackage = ({
   resolveEntry = () => require.resolve("openclaw"),
@@ -45,6 +119,10 @@ const runOpenclawDoctorPreflight = ({
 
   const resolvedPackageInfo = packageInfo || findOpenclawPackage();
   const resolvedStateDir = stateDir || path.dirname(configPath);
+  const retiredManagedExecApprovals = retireManagedExecApprovalsStub({
+    stateDir: resolvedStateDir,
+    fsImpl,
+  });
   const hasLegacyStateMigration = [
     path.join(resolvedStateDir, "exec-approvals.json"),
     path.join(resolvedStateDir, "exec-approvals.json.doctor-importing"),
@@ -63,7 +141,16 @@ const runOpenclawDoctorPreflight = ({
       compareVersionParts(installedVersion, configVersion) <= 0 &&
       !hasLegacyStateMigration)
   ) {
-    return { ran: false, changed: false, reason: "current-config" };
+    return {
+      ran: false,
+      changed: false,
+      reason: retiredManagedExecApprovals.retired
+        ? "retired-managed-exec-approvals"
+        : "current-config",
+      ...(retiredManagedExecApprovals.retired
+        ? { retiredManagedExecApprovals }
+        : {}),
+    };
   }
 
   const cliPath = resolveOpenclawCliPath(resolvedPackageInfo);
@@ -98,6 +185,9 @@ const runOpenclawDoctorPreflight = ({
       changed: migrated !== original,
       fromVersion: configVersion || "unknown",
       toVersion: installedVersion,
+      ...(retiredManagedExecApprovals.retired
+        ? { retiredManagedExecApprovals }
+        : {}),
     };
   } catch (error) {
     fsImpl.writeFileSync(configPath, original, "utf8");
@@ -109,6 +199,8 @@ const runOpenclawDoctorPreflight = ({
 
 module.exports = {
   findOpenclawPackage,
+  isManagedExecApprovalsStub,
+  retireManagedExecApprovalsStub,
   resolveOpenclawCliPath,
   runOpenclawDoctorPreflight,
 };

--- a/lib/server/openclaw-doctor-preflight.js
+++ b/lib/server/openclaw-doctor-preflight.js
@@ -92,18 +92,16 @@ const isValidExecApprovalPolicy = (value, { allowAllowlist = false } = {}) => {
   ) {
     return false;
   }
-  if (value.allowlist !== undefined) {
+  if (allowAllowlist && value.allowlist !== undefined) {
     if (
-      !allowAllowlist ||
       !Array.isArray(value.allowlist) ||
       !value.allowlist.every(isValidExecAllowlistEntry)
     ) {
       return false;
     }
   }
-  if (value.mcpTools !== undefined) {
+  if (allowAllowlist && value.mcpTools !== undefined) {
     if (
-      !allowAllowlist ||
       !Array.isArray(value.mcpTools) ||
       !value.mcpTools.every(isValidMcpToolGrant)
     ) {

--- a/lib/server/routes/doctor.js
+++ b/lib/server/routes/doctor.js
@@ -1,9 +1,36 @@
 const { kDoctorCardStatus, kDoctorDefaultRunsLimit } = require("../doctor/constants");
 
+const buildDoctorStatusSummary = (status = {}) => ({
+  activeRunId: status.activeRunId || 0,
+  runInProgress: !!status.runInProgress,
+  lastRunAt: status.lastRunAt || null,
+  lastRunAgeMs:
+    typeof status.lastRunAgeMs === "number" ? status.lastRunAgeMs : null,
+  needsInitialRun: !!status.needsInitialRun,
+  stale: !!status.stale,
+  changeSummary: {
+    addedFilesCount: Number(status.changeSummary?.addedFilesCount || 0),
+    removedFilesCount: Number(status.changeSummary?.removedFilesCount || 0),
+    modifiedFilesCount: Number(status.changeSummary?.modifiedFilesCount || 0),
+    changedFilesCount: Number(status.changeSummary?.changedFilesCount || 0),
+    deltaScore: Number(status.changeSummary?.deltaScore || 0),
+    hasBaseline: !!status.changeSummary?.hasBaseline,
+    baselineSource: status.changeSummary?.baselineSource || "none",
+    hasMeaningfulChanges: !!status.changeSummary?.hasMeaningfulChanges,
+  },
+});
+
 const registerDoctorRoutes = ({ app, requireAuth, doctorService }) => {
   app.get("/api/doctor/status", requireAuth, (req, res) => {
     try {
-      res.json({ ok: true, status: doctorService.buildStatus() });
+      const status = doctorService.buildStatus();
+      res.json({
+        ok: true,
+        status:
+          String(req.query.summary || "").toLowerCase() === "true"
+            ? buildDoctorStatusSummary(status)
+            : status,
+      });
     } catch (error) {
       res.status(500).json({ ok: false, error: error.message });
     }
@@ -124,4 +151,4 @@ const registerDoctorRoutes = ({ app, requireAuth, doctorService }) => {
   });
 };
 
-module.exports = { registerDoctorRoutes };
+module.exports = { buildDoctorStatusSummary, registerDoctorRoutes };

--- a/lib/server/routes/system.js
+++ b/lib/server/routes/system.js
@@ -7,6 +7,12 @@ const {
 } = require("../alphaclaw-config");
 const https = require("https");
 
+const buildLiveStatusPayload = (status = {}) => ({
+  gateway: status?.gateway ?? null,
+  openclawVersion: status?.openclawVersion ?? null,
+  alphaclawVersion: status?.alphaclawVersion ?? null,
+});
+
 const registerSystemRoutes = ({
   app,
   fs,
@@ -29,8 +35,6 @@ const registerSystemRoutes = ({
   restartRequiredState,
   topicRegistry,
   authProfiles,
-  watchdog,
-  doctorService,
   ensureGatewayProxyConfig,
   getBaseUrl,
 }) => {
@@ -622,22 +626,9 @@ const registerSystemRoutes = ({
 
     const writeStatusEvent = async () => {
       try {
-        const status = await buildStatusPayload();
-        const watchdogStatus =
-          typeof watchdog?.getStatus === "function" ? watchdog.getStatus() : null;
-        const doctorStatus =
-          typeof doctorService?.buildStatus === "function"
-            ? doctorService.buildStatus()
-            : null;
+        const status = buildLiveStatusPayload(await buildStatusPayload());
         res.write("event: status\n");
-        res.write(
-          `data: ${JSON.stringify({
-            status,
-            watchdogStatus,
-            doctorStatus,
-            timestamp: new Date().toISOString(),
-          })}\n\n`,
-        );
+        res.write(`data: ${JSON.stringify({ status })}\n\n`);
       } catch {}
     };
 
@@ -916,4 +907,4 @@ const registerSystemRoutes = ({
   });
 };
 
-module.exports = { registerSystemRoutes };
+module.exports = { buildLiveStatusPayload, registerSystemRoutes };

--- a/tests/frontend/api.test.js
+++ b/tests/frontend/api.test.js
@@ -276,6 +276,19 @@ describe("frontend/api", () => {
     expect(result).toEqual({ ok: true, status: { stale: true } });
   });
 
+  it("fetchDoctorStatusSummary calls the bounded Doctor status endpoint", async () => {
+    global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: true, status: { stale: true } }));
+    const api = await loadApiModule();
+
+    const result = await api.fetchDoctorStatusSummary();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/doctor/status?summary=true",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    expect(result).toEqual({ ok: true, status: { stale: true } });
+  });
+
   it("fetchDoctorCards calls aggregated Doctor cards endpoint", async () => {
     global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: true, cards: [] }));
     const api = await loadApiModule();

--- a/tests/server/openclaw-doctor-preflight.test.js
+++ b/tests/server/openclaw-doctor-preflight.test.js
@@ -57,6 +57,12 @@ describe("server/openclaw-doctor-preflight", () => {
     expect(
       isValidExecApprovalsPolicy({
         version: 1,
+        defaults: { allowlist: [], mcpTools: "ignored" },
+      }),
+    ).toBe(true);
+    expect(
+      isValidExecApprovalsPolicy({
+        version: 1,
         agents: { main: { mcpTools: "bad" } },
       }),
     ).toBe(false);

--- a/tests/server/openclaw-doctor-preflight.test.js
+++ b/tests/server/openclaw-doctor-preflight.test.js
@@ -5,6 +5,7 @@ const path = require("path");
 const { DatabaseSync } = require("node:sqlite");
 const {
   findOpenclawPackage,
+  isValidExecApprovalsPolicy,
   resolveOpenclawCliPath,
   runOpenclawDoctorPreflight,
 } = require("../../lib/server/openclaw-doctor-preflight");
@@ -25,6 +26,30 @@ const kPackageInfo = {
 };
 
 describe("server/openclaw-doctor-preflight", () => {
+  it("validates persisted exec approvals policies before trusting SQLite", () => {
+    expect(
+      isValidExecApprovalsPolicy({
+        version: 1,
+        defaults: { security: "full", ask: "off", askFallback: "full" },
+        agents: { main: { allowlist: [{ pattern: "ls" }] } },
+      }),
+    ).toBe(true);
+    expect(isValidExecApprovalsPolicy({ version: 2, agents: {} })).toBe(false);
+    expect(
+      isValidExecApprovalsPolicy({
+        version: 1,
+        defaults: { security: "unrestricted" },
+        agents: {},
+      }),
+    ).toBe(false);
+    expect(
+      isValidExecApprovalsPolicy({
+        version: 1,
+        agents: { main: { allowlist: [{ pattern: "" }] } },
+      }),
+    ).toBe(false);
+  });
+
   it("runs Doctor once when the config predates the installed OpenClaw", () => {
     const { configPath, stateDir } = createConfig({
       meta: { lastTouchedVersion: "2026.7.1" },
@@ -257,6 +282,52 @@ describe("server/openclaw-doctor-preflight", () => {
         packageInfo: kPackageInfo,
       }),
     ).toThrow("conflicting policies");
+    expect(fs.existsSync(approvalsPath)).toBe(true);
+    expect(
+      fs.readdirSync(stateDir).some((name) =>
+        name.startsWith("exec-approvals.json.alphaclaw-retired-"),
+      ),
+    ).toBe(false);
+  });
+
+  it("does not archive the managed stub when SQLite policy is malformed", () => {
+    const { configPath, stateDir } = createConfig({
+      meta: { lastTouchedVersion: "2026.9.3" },
+    });
+    const approvalsPath = path.join(stateDir, "exec-approvals.json");
+    fs.writeFileSync(
+      approvalsPath,
+      JSON.stringify({
+        version: 1,
+        defaults: { security: "full", ask: "off", askFallback: "full" },
+        agents: {},
+      }),
+      "utf8",
+    );
+    const sqliteDir = path.join(stateDir, "state");
+    fs.mkdirSync(sqliteDir, { recursive: true });
+    const db = new DatabaseSync(path.join(sqliteDir, "openclaw.sqlite"));
+    db.exec(`
+      CREATE TABLE exec_approvals_config (
+        config_key TEXT PRIMARY KEY,
+        raw_json TEXT NOT NULL
+      );
+      INSERT INTO exec_approvals_config (config_key, raw_json)
+      VALUES ('current', '{"version":2,"defaults":{},"agents":{}}');
+    `);
+    db.close();
+    const execFileSyncImpl = vi.fn(() => {
+      throw new Error("malformed canonical policy");
+    });
+
+    expect(() =>
+      runOpenclawDoctorPreflight({
+        configPath,
+        stateDir,
+        execFileSyncImpl,
+        packageInfo: kPackageInfo,
+      }),
+    ).toThrow("malformed canonical policy");
     expect(fs.existsSync(approvalsPath)).toBe(true);
     expect(
       fs.readdirSync(stateDir).some((name) =>

--- a/tests/server/openclaw-doctor-preflight.test.js
+++ b/tests/server/openclaw-doctor-preflight.test.js
@@ -152,6 +152,119 @@ describe("server/openclaw-doctor-preflight", () => {
     expect(fs.existsSync(approvalsPath)).toBe(false);
   });
 
+  it("archives an AlphaClaw default stub when SQLite already owns exec policy", () => {
+    const { configPath, stateDir } = createConfig({
+      meta: { lastTouchedVersion: "2026.9.3" },
+    });
+    const approvalsPath = path.join(stateDir, "exec-approvals.json");
+    fs.writeFileSync(
+      approvalsPath,
+      `${JSON.stringify({
+        version: 1,
+        defaults: { security: "full", ask: "off", askFallback: "full" },
+        agents: {},
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    const sqliteDir = path.join(stateDir, "state");
+    fs.mkdirSync(sqliteDir, { recursive: true });
+    const databasePath = path.join(sqliteDir, "openclaw.sqlite");
+    const canonicalPolicy = {
+      version: 1,
+      defaults: {
+        security: "allowlist",
+        ask: "always",
+        askFallback: "deny",
+      },
+      agents: {
+        main: { allowlist: [{ pattern: "ls" }] },
+      },
+    };
+    const db = new DatabaseSync(databasePath);
+    db.exec(`
+      CREATE TABLE exec_approvals_config (
+        config_key TEXT PRIMARY KEY,
+        raw_json TEXT NOT NULL
+      );
+    `);
+    db.prepare(
+      "INSERT INTO exec_approvals_config (config_key, raw_json) VALUES (?, ?)",
+    ).run("current", `${JSON.stringify(canonicalPolicy, null, 2)}\n`);
+    db.close();
+    const execFileSyncImpl = vi.fn();
+
+    const result = runOpenclawDoctorPreflight({
+      configPath,
+      stateDir,
+      execFileSyncImpl,
+      packageInfo: kPackageInfo,
+    });
+
+    expect(result).toMatchObject({
+      ran: false,
+      changed: false,
+      reason: "retired-managed-exec-approvals",
+      retiredManagedExecApprovals: { retired: true, sourcePath: approvalsPath },
+    });
+    expect(execFileSyncImpl).not.toHaveBeenCalled();
+    expect(fs.existsSync(approvalsPath)).toBe(false);
+    expect(fs.existsSync(result.retiredManagedExecApprovals.archivePath)).toBe(true);
+    const verifyDb = new DatabaseSync(databasePath, { readOnly: true });
+    const row = verifyDb
+      .prepare(
+        "SELECT raw_json FROM exec_approvals_config WHERE config_key = 'current'",
+      )
+      .get();
+    verifyDb.close();
+    expect(JSON.parse(row.raw_json)).toEqual(canonicalPolicy);
+  });
+
+  it("leaves customized legacy exec policy for OpenClaw to reconcile", () => {
+    const { configPath, stateDir } = createConfig({
+      meta: { lastTouchedVersion: "2026.9.3" },
+    });
+    const approvalsPath = path.join(stateDir, "exec-approvals.json");
+    fs.writeFileSync(
+      approvalsPath,
+      `${JSON.stringify({
+        version: 1,
+        defaults: { security: "allowlist", ask: "always", askFallback: "deny" },
+        agents: { main: { allowlist: [{ pattern: "ls" }] } },
+      })}\n`,
+      "utf8",
+    );
+    const sqliteDir = path.join(stateDir, "state");
+    fs.mkdirSync(sqliteDir, { recursive: true });
+    const db = new DatabaseSync(path.join(sqliteDir, "openclaw.sqlite"));
+    db.exec(`
+      CREATE TABLE exec_approvals_config (
+        config_key TEXT PRIMARY KEY,
+        raw_json TEXT NOT NULL
+      );
+      INSERT INTO exec_approvals_config (config_key, raw_json)
+      VALUES ('current', '{"version":1,"defaults":{},"agents":{}}');
+    `);
+    db.close();
+    const execFileSyncImpl = vi.fn((_executable, args) => {
+      if (args[1] === "doctor") throw new Error("conflicting policies");
+    });
+
+    expect(() =>
+      runOpenclawDoctorPreflight({
+        configPath,
+        stateDir,
+        execFileSyncImpl,
+        packageInfo: kPackageInfo,
+      }),
+    ).toThrow("conflicting policies");
+    expect(fs.existsSync(approvalsPath)).toBe(true);
+    expect(
+      fs.readdirSync(stateDir).some((name) =>
+        name.startsWith("exec-approvals.json.alphaclaw-retired-"),
+      ),
+    ).toBe(false);
+  });
+
   it(
     "migrates current-version legacy exec approvals into OpenClaw SQLite state",
     () => {

--- a/tests/server/openclaw-doctor-preflight.test.js
+++ b/tests/server/openclaw-doctor-preflight.test.js
@@ -45,9 +45,38 @@ describe("server/openclaw-doctor-preflight", () => {
     expect(
       isValidExecApprovalsPolicy({
         version: 1,
-        agents: { main: { allowlist: [{ pattern: "" }] } },
+        agents: { main: { allowlist: ["ls", { pattern: "pwd", lastUsedAt: 1 }] } },
+      }),
+    ).toBe(true);
+    expect(
+      isValidExecApprovalsPolicy({
+        version: 1,
+        agents: { main: { allowlist: [{ pattern: "ls", lastUsedAt: "bad" }] } },
       }),
     ).toBe(false);
+    expect(
+      isValidExecApprovalsPolicy({
+        version: 1,
+        agents: { main: { mcpTools: "bad" } },
+      }),
+    ).toBe(false);
+    expect(
+      isValidExecApprovalsPolicy({
+        version: 1,
+        agents: {
+          main: {
+            mcpTools: [
+              {
+                server: "filesystem",
+                tool: "read_file",
+                source: "allow-always",
+                addedAt: 1,
+              },
+            ],
+          },
+        },
+      }),
+    ).toBe(true);
   });
 
   it("runs Doctor once when the config predates the installed OpenClaw", () => {

--- a/tests/server/routes-doctor.test.js
+++ b/tests/server/routes-doctor.test.js
@@ -70,6 +70,43 @@ describe("server/routes/doctor", () => {
     expect(doctorService.buildStatus).toHaveBeenCalledTimes(1);
   });
 
+  it("returns a bounded Doctor summary without large diagnostic fields", async () => {
+    const doctorService = createDoctorService();
+    doctorService.buildStatus.mockReturnValue({
+      activeRunId: 42,
+      runInProgress: false,
+      stale: true,
+      needsInitialRun: false,
+      latestRun: { workspaceManifest: { "large-file": { hash: "abc" } } },
+      bootstrapContext: { activeTruncatedFiles: [{ path: "AGENTS.md" }] },
+      changeSummary: {
+        changedFilesCount: 2,
+        changedPaths: ["AGENTS.md", "README.md"],
+        deltaScore: 4,
+        hasMeaningfulChanges: true,
+      },
+    });
+    const app = createApp(doctorService);
+
+    const res = await request(app).get("/api/doctor/status?summary=true");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toMatchObject({
+      activeRunId: 42,
+      stale: true,
+      needsInitialRun: false,
+      changeSummary: {
+        changedFilesCount: 2,
+        deltaScore: 4,
+        hasMeaningfulChanges: true,
+      },
+    });
+    expect(res.body.status).not.toHaveProperty("latestRun");
+    expect(res.body.status).not.toHaveProperty("bootstrapContext");
+    expect(res.body.status.changeSummary).not.toHaveProperty("changedPaths");
+    expect(JSON.stringify(res.body).length).toBeLessThan(600);
+  });
+
   it("starts a Doctor run", async () => {
     const doctorService = createDoctorService();
     const app = createApp(doctorService);

--- a/tests/server/routes-system.test.js
+++ b/tests/server/routes-system.test.js
@@ -1,7 +1,10 @@
 const express = require("express");
 const request = require("supertest");
 
-const { registerSystemRoutes } = require("../../lib/server/routes/system");
+const {
+  buildLiveStatusPayload,
+  registerSystemRoutes,
+} = require("../../lib/server/routes/system");
 
 const createSystemDeps = () => {
   const deps = {
@@ -112,6 +115,67 @@ const createApp = (deps) => {
 };
 
 describe("server/routes/system", () => {
+  it("limits live status events to the fields consumed by Nexus", () => {
+    expect(
+      buildLiveStatusPayload({
+        gateway: "running",
+        openclawVersion: "2026.9.3",
+        alphaclawVersion: "0.9.35-beta.0",
+        channels: { telegram: { status: "paired" } },
+        doctorStatus: {
+          latestRun: { workspaceManifest: { "large/file.txt": "hash" } },
+          changeSummary: { changedPaths: ["large/file.txt"] },
+        },
+      }),
+    ).toEqual({
+      gateway: "running",
+      openclawVersion: "2026.9.3",
+      alphaclawVersion: "0.9.35-beta.0",
+    });
+  });
+
+  it("streams only the compact Nexus status without evaluating Doctor state", async () => {
+    const deps = createSystemDeps();
+    deps.watchdog = { getStatus: vi.fn(() => ({ uptimeMs: 123 })) };
+    deps.doctorService = {
+      buildStatus: vi.fn(() => ({
+        latestRun: { workspaceManifest: { "large/file.txt": "hash" } },
+        changeSummary: { changedPaths: ["large/file.txt"] },
+      })),
+    };
+    const app = createApp(deps);
+    const server = app.listen(0, "127.0.0.1");
+
+    try {
+      await new Promise((resolve) => server.once("listening", resolve));
+      const address = server.address();
+      const controller = new AbortController();
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/api/events/status`,
+        { signal: controller.signal },
+      );
+      const reader = response.body.getReader();
+      const { value } = await reader.read();
+      controller.abort();
+      const eventText = new TextDecoder().decode(value);
+      const dataLine = eventText
+        .split("\n")
+        .find((line) => line.startsWith("data: "));
+
+      expect(JSON.parse(dataLine.slice("data: ".length))).toEqual({
+        status: {
+          gateway: "running",
+          openclawVersion: "1.2.3",
+          alphaclawVersion: "0.1.5",
+        },
+      });
+      expect(deps.watchdog.getStatus).not.toHaveBeenCalled();
+      expect(deps.doctorService.buildStatus).not.toHaveBeenCalled();
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
   it("merges known vars and custom vars on GET /api/env", async () => {
     const deps = createSystemDeps();
     deps.readEnvFile.mockReturnValue([

--- a/tests/server/routes-system.test.js
+++ b/tests/server/routes-system.test.js
@@ -155,13 +155,20 @@ describe("server/routes/system", () => {
         { signal: controller.signal },
       );
       const reader = response.body.getReader();
-      const { value } = await reader.read();
+      const decoder = new TextDecoder();
+      let eventText = "";
+      while (!eventText.includes("\n\n")) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        eventText += decoder.decode(value, { stream: true });
+      }
+      eventText += decoder.decode();
       controller.abort();
-      const eventText = new TextDecoder().decode(value);
       const dataLine = eventText
         .split("\n")
         .find((line) => line.startsWith("data: "));
 
+      expect(dataLine).toBeDefined();
       expect(JSON.parse(dataLine.slice("data: ".length))).toEqual({
         status: {
           gateway: "running",


### PR DESCRIPTION
## Summary

- restrict `/api/events/status` to the three live fields consumed for Nexus health/version display: gateway state, OpenClaw version, and AlphaClaw version
- stop evaluating and serializing Doctor and watchdog state on every two-second SSE tick
- hydrate the richer AlphaClaw UI state once when the stream connects, then merge compact live updates into it
- recover from the beta upgrade state where AlphaClaw recreated its exact default-only `exec-approvals.json` stub after OpenClaw had already migrated the real policy to SQLite
- archive only that exact AlphaClaw-generated stub when a valid canonical SQLite policy exists; customized, malformed, or otherwise ambiguous legacy policies still fail closed

## Impact

A representative status event is now 118 bytes instead of roughly 1.04 MB. With two persistent connections, this removes the reported ~90 GB/day diagnostic payload transfer and avoids rescanning the workspace on each SSE tick.

The startup recovery preserves the canonical SQLite exec policy and renames the obsolete JSON stub instead of deleting it. This unblocks the affected 0.9.35 beta upgrade without silently choosing between genuine conflicting policies.

## Verification

- `npm test -- --run tests/server/routes-system.test.js tests/frontend/api.test.js` — 65 tests passed
- `npm test -- --run tests/server/openclaw-doctor-preflight.test.js tests/server/exec-defaults-config.test.js tests/server/routes-system.test.js` — 50 tests passed
- `npm run build:ui`
- `git diff --check`
